### PR TITLE
add basic auth using oauth as the auth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ to catch the exams and log something about them.
 ```bash
 docker run -d -p :8080:8080 --name exam-service --link rabbitmq:rabbitmq fwsbac/rdw-exam-service --spring.rabbitmq.host=rabbitmq
 docker run -d -p :8090:8080 --name exam-log --link rabbitmq:rabbitmq springcloudstream/log-sink-rabbit --spring.rabbitmq.host=rabbitmq \
-  --spring.cloud.stream.bindings.input.destination=exams \
+  --spring.cloud.stream.bindings.input.destination=exam \
   --log.expression="headers['id'].toString().concat(': ').concat(payload.substring(0, 10))"
 docker logs -f exam-log
 ```
@@ -59,6 +59,14 @@ You can use a REST client to hit end-points, e.g.
 ```text
 POST /exams/imports  with an XML payload should return an import request payload
 GET /exams/imports/:id   should return a mock import request payload (unless id starts with 'a')
+```
+
+The log sink should be replaced with the exam-processor but we're still working out some kinks so this will
+result in processing exceptions being logged (stop exam-log first if you started it):
+```bash
+docker stop exam-log
+docker run -d -p :8081:8080 --name exam-processor --link rabbitmq:rabbitmq fwsbac/rdw-exam-processor --spring.rabbitmq.host=rabbitmq
+docker logs -f exam-processor
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,14 @@
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
-        mavenCentral()
+        jcenter()
+        maven { url 'http://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath("com.bmuschko:gradle-docker-plugin:3.0.5")
         classpath("io.spring.gradle:dependency-management-plugin:1.0.0.RELEASE")
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.1.RELEASE")
+        classpath('org.springframework.build.gradle:propdeps-plugin:0.0.7')
     }
 }
 
@@ -25,6 +26,9 @@ allprojects {
     version = '0.0.1-SNAPSHOT'
 
     apply plugin: 'idea'
+    apply plugin: 'propdeps'
+    apply plugin: 'propdeps-maven'
+    apply plugin: 'propdeps-idea'
 }
 
 subprojects {
@@ -57,6 +61,9 @@ subprojects {
     }
 
     dependencies {
+        // handy for creating metadata with @ConfigurationProperties
+        optional "org.springframework.boot:spring-boot-configuration-processor"
+
         // every app is a microservice with actuator end-points
         compile('org.springframework.boot:spring-boot-starter-actuator')
 
@@ -70,6 +77,9 @@ subprojects {
 
         testCompile('org.springframework.boot:spring-boot-starter-test')
     }
+
+    // this is for creating metadata
+    compileJava.dependsOn(processResources)
 
     // generate coverage report automatically (./build/reports/jacoco/test/html/index.html)
     test.finalizedBy(jacocoTestReport)

--- a/exam-service/build.gradle
+++ b/exam-service/build.gradle
@@ -3,6 +3,10 @@ dependencies {
     compile 'org.rdw.common:messaging'
     compile 'org.rdw.common:model'
     compile 'org.springframework.boot:spring-boot-starter-web'
-//compile('org.springframework.cloud:spring-cloud-starter-oauth2')
+    compile 'org.springframework.boot:spring-boot-starter-security'
+    compile('org.springframework.cloud:spring-cloud-starter-oauth2')
+//compile('org.springframework.boot:spring-security-oauth2')
 //compile('org.springframework.boot:spring-boot-starter-hateoas')
+
+    testCompile('org.springframework.security:spring-security-test')
 }

--- a/exam-service/src/main/java/org/rdw/ingest/web/OAuth2AuthenticationProvider.java
+++ b/exam-service/src/main/java/org/rdw/ingest/web/OAuth2AuthenticationProvider.java
@@ -1,0 +1,125 @@
+package org.rdw.ingest.web;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.rdw.ingest.web.SecurityConfig.DataLoadRole;
+
+/**
+ * This auth provider acts as an adapter between basic auth from the clients of our RESTful API and the
+ * credentials stored in our IDP which are accessed via oauth2. If things change so our clients are aware
+ * of oauth2 and use it fully, this can go away and we can use magick Spring wiring (i think).
+ */
+@Component
+@EnableConfigurationProperties({OAuth2Properties.class})
+@EnableOAuth2Client
+public class OAuth2AuthenticationProvider implements AuthenticationProvider {
+    private static final Logger logger = LoggerFactory.getLogger(OAuth2AuthenticationProvider.class);
+
+    private Cache<String, UserDetails> userCache;
+    private OAuth2Properties oauth2Properties;
+
+    @Autowired
+    void setProperties(final OAuth2Properties oauth2Properties) {
+        this.oauth2Properties = oauth2Properties;
+        this.userCache = CacheBuilder.newBuilder()
+                .maximumSize(oauth2Properties.getCache().getSize())
+                .expireAfterWrite(oauth2Properties.getCache().getExpire(), TimeUnit.MINUTES)
+                .build();
+    }
+
+    @Override
+    public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
+        if (!supports(authentication.getClass())) return authentication;
+
+        final UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
+
+        UserDetails user = userCache.getIfPresent(auth.getName());
+        if (user == null) {
+            final OAuth2RestTemplate template = template(auth);
+            try {
+                final OAuth2AccessToken token = template.getAccessToken();
+                if (token.isExpired()) {
+                    throw new RuntimeException("token is expired");
+                }
+                final Map tokenInfo = template.getForObject(oauth2Properties.getTokenInfoUri(), Map.class,
+                        Collections.singletonMap("access_token", token.getValue()));
+                final String tenancyChain = (String) tokenInfo.get("sbacTenancyChain");
+                if (StringUtils.isEmpty(tenancyChain)) {
+                    throw new RuntimeException("user doesn't have a SBAC tenancy chain");
+                }
+
+                // TODO - make this more robust parsing of tenancy chain to get all roles (by tenant)
+                // TODO   for now, all we care about is the data load role
+                // TODO - it would be nice to preserve the tenancy chain somewhere in user/auth?
+                final List<GrantedAuthority> authorities = new ArrayList<>();
+                if (tenancyChain.contains(DataLoadRole)) {
+                    authorities.add(new SimpleGrantedAuthority(DataLoadRole));
+                }
+
+                user = new User(auth.getName(), (String) auth.getCredentials(), authorities);
+                userCache.put(user.getUsername(), user);
+
+                logger.info(auth.getName() + " authenticated");
+
+            } catch (final Exception ignored) {
+                logger.info(auth.getName() + " not authenticated", ignored.getMessage());
+                throw new BadCredentialsException(auth.getName());
+            }
+        }
+
+        // need to copy cached user that we created, since framework will mess with auth token principal
+        final UsernamePasswordAuthenticationToken result = new UsernamePasswordAuthenticationToken(
+                new User(user.getUsername(), user.getPassword(), user.getAuthorities()), user.getPassword(), user.getAuthorities());
+        result.setDetails(auth.getDetails());
+
+        return result;
+    }
+
+    @Override
+    public boolean supports(final Class<?> aClass) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(aClass);
+    }
+
+    private OAuth2RestTemplate template(final UsernamePasswordAuthenticationToken auth) {
+        final ResourceOwnerPasswordResourceDetails resource = new ResourceOwnerPasswordResourceDetails();
+        resource.setId(oauth2Properties.getId());
+        resource.setTokenName(oauth2Properties.getTokenName());
+        resource.setGrantType(oauth2Properties.getGrantType());
+        resource.setClientId(oauth2Properties.getClientId());
+        resource.setClientSecret(oauth2Properties.getClientSecret());
+        resource.setAuthenticationScheme(oauth2Properties.getAuthenticationScheme());
+        resource.setAccessTokenUri(oauth2Properties.getAccessTokenUri());
+        resource.setClientAuthenticationScheme(oauth2Properties.getClientAuthenticationScheme());
+        resource.setScope(oauth2Properties.getScope());
+        resource.setUsername(auth.getName());
+        resource.setPassword((String) auth.getCredentials());
+        return new OAuth2RestTemplate(resource, new DefaultOAuth2ClientContext());
+    }
+}

--- a/exam-service/src/main/java/org/rdw/ingest/web/OAuth2Properties.java
+++ b/exam-service/src/main/java/org/rdw/ingest/web/OAuth2Properties.java
@@ -1,0 +1,68 @@
+package org.rdw.ingest.web;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+
+@ConfigurationProperties("oauth2")
+public class OAuth2Properties extends BaseOAuth2ProtectedResourceDetails {
+
+    /**
+     * URI for oauth token info end-point
+     */
+    private String tokenInfoUri;
+
+    /**
+     * Cache of user credentials
+     */
+    @NestedConfigurationProperty
+    private CacheProperties cache = new CacheProperties();
+
+    public OAuth2Properties() {
+        setGrantType("password");
+    }
+
+    public String getTokenInfoUri() {
+        return tokenInfoUri;
+    }
+
+    public void setTokenInfoUri(String tokenInfoUri) {
+        this.tokenInfoUri = tokenInfoUri;
+    }
+
+    public CacheProperties getCache() {
+        return cache;
+    }
+
+    public void setCache(final CacheProperties cache) {
+        this.cache = cache;
+    }
+
+    public static class CacheProperties {
+        /**
+         * Size of cache, i.e. number of user credentials to keep
+         */
+        private int size = 10;
+
+        /**
+         * Expire time for cache entries, in minutes
+         */
+        private int expire = 15;
+
+        public int getSize() {
+            return size;
+        }
+
+        public void setSize(final int size) {
+            this.size = size;
+        }
+
+        public int getExpire() {
+            return expire;
+        }
+
+        public void setExpire(final int expire) {
+            this.expire = expire;
+        }
+    }
+}

--- a/exam-service/src/main/java/org/rdw/ingest/web/SecurityConfig.java
+++ b/exam-service/src/main/java/org/rdw/ingest/web/SecurityConfig.java
@@ -1,0 +1,49 @@
+package org.rdw.ingest.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+/**
+ * Security configuration
+ */
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    final static String DataLoadRole = "ASMTDATALOAD";
+
+    private AuthenticationProvider authenticationProvider;
+
+    @Autowired
+    void setAuthenticationProvider(final AuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    @Override
+    protected void configure(final AuthenticationManagerBuilder auth) throws Exception {
+        auth.authenticationProvider(authenticationProvider);
+    }
+
+    @Override
+    public void configure(final WebSecurity web) throws Exception {
+        web.ignoring().antMatchers(HttpMethod.OPTIONS, "/**");
+    }
+
+    @Override
+    protected void configure(final HttpSecurity http) throws Exception {
+        http.csrf()
+                .disable()
+            .authorizeRequests()
+                // TODO - worry about actuator end-points
+                .anyRequest()
+                .hasAuthority("ASMTDATALOAD")
+            .and().httpBasic()
+            .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        // TODO - realm?
+    }
+}

--- a/exam-service/src/main/resources/application.yml
+++ b/exam-service/src/main/resources/application.yml
@@ -1,8 +1,16 @@
+oauth2:
+  access-token-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/access_token?realm=/sbac
+  client-id: sbacdw
+  client-secret: sbacdw123
+  token-info-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/tokeninfo
+  cache:
+    size: 10
+    expire: 15
 
 spring:
   cloud:
     stream:
       bindings:
         output:
-          destination: exams
+          destination: exam
 

--- a/exam-service/src/test/java/org/rdw/ingest/web/ExamControllerTests.java
+++ b/exam-service/src/test/java/org/rdw/ingest/web/ExamControllerTests.java
@@ -8,9 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import rdw.model.TDSReport;
 
 import java.util.Optional;
 
@@ -23,6 +25,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ExamController.class)
+@ContextConfiguration(classes = TestAppConfig.class)
+@WebAppConfiguration
+@WithMockUser(username = "alice", authorities = {"ASMTDATALOAD"})
 public class ExamControllerTests {
 
     @Autowired

--- a/exam-service/src/test/java/org/rdw/ingest/web/OAuth2PropertiesTest.java
+++ b/exam-service/src/test/java/org/rdw/ingest/web/OAuth2PropertiesTest.java
@@ -1,0 +1,42 @@
+package org.rdw.ingest.web;
+
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OAuth2PropertiesTest {
+
+    @Configuration
+    @EnableConfigurationProperties(OAuth2Properties.class)
+    static class Conf {
+    }
+
+    @Test
+    public void defaultValues() {
+        final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(Conf.class);
+        context.refresh();
+        final OAuth2Properties properties = context.getBean(OAuth2Properties.class);
+        assertThat(properties.getTokenInfoUri()).isNull();
+        assertThat(properties.getCache().getSize()).isEqualTo(10);
+        assertThat(properties.getCache().getExpire()).isEqualTo(15);
+    }
+
+    @Test
+    public void valuesCanBeCustomized() {
+        final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(context, "oauth2.token-info-uri=https://localhost/auth/oauth2/tokeninfo");
+        EnvironmentTestUtils.addEnvironment(context, "oauth2.cache.size=100");
+        EnvironmentTestUtils.addEnvironment(context, "oauth2.cache.expire=5");
+        context.register(Conf.class);
+        context.refresh();
+        final OAuth2Properties properties = context.getBean(OAuth2Properties.class);
+        assertThat(properties.getTokenInfoUri()).isEqualTo("https://localhost/auth/oauth2/tokeninfo");
+        assertThat(properties.getCache().getSize()).isEqualTo(100);
+        assertThat(properties.getCache().getExpire()).isEqualTo(5);
+    }
+}

--- a/exam-service/src/test/java/org/rdw/ingest/web/TestAppConfig.java
+++ b/exam-service/src/test/java/org/rdw/ingest/web/TestAppConfig.java
@@ -1,0 +1,19 @@
+package org.rdw.ingest.web;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+/**
+ * Pretty sure i'm cheating with this. This is from the instructions for getting @WithMockUser working in tests.
+ * But the example wasn't using the same annotations we are (older vs. newer spring boot stuff). However,
+ * dropping this puppy into the test folder makes the annotations do what they should. If you can get rid of
+ * this config class and still have the @withMockUser annotation work ... please do!
+ */
+@Configuration
+@ComponentScan("org.rdw.ingest.web")
+@EnableWebMvc
+@Import({SecurityConfig.class})
+class TestAppConfig {
+}


### PR DESCRIPTION
To clarify this: our client (ETS) will use basic auth while we use OpenAM IDP as the authority for user credentials. This is a rudimentary implementation just to make sure it works as expected. 

After a chat with ETS we will decide whether to continue down this route or switch to full oauth2 (where they'd have to know about our OpenAM IDP and get a token).