### PR TITLE
auth tweaks to preserve tenancy chain and content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ You will need valid credentials and connectivity to our SSO OAuth2 server.
 #### Running Standalone
 It is not the recommended approach but the artifacts are Spring Boot executable jars so you can just run them, e.g.:
 ```bash
-java -jar exam-service/build/libs/exam-service-0.0.1-SNAPSHOT.jar
+java -jar exam-service/build/libs/exam-service-0.0.1-SNAPSHOT.jar --server.port=8080
+java -jar exam-processor/build/libs/exam-processor-0.0.1-SNAPSHOT.jar --server.port=8081
 ```
 
 All the ingest apps work with a message broker, currently RabbitMQ. So RabbitMQ must be running; you can use the

--- a/exam-processor/src/main/java/org/rdw/ingest/processor/ExamProcessorConfiguration.java
+++ b/exam-processor/src/main/java/org/rdw/ingest/processor/ExamProcessorConfiguration.java
@@ -17,6 +17,7 @@ public class ExamProcessorConfiguration {
     public void process(final Message<?> message) {
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
         final String payload = (String) message.getPayload();
-        logger.info(accessor.getContent() + ": " + (payload.length() > 80 ? payload.substring(0, 80) + "..." : payload));
+        logger.info("received " + accessor.getContent() + " from " + accessor.getUserLogin());
+        logger.info(accessor.getContentType() + ": " + (payload.length() > 80 ? payload.substring(0, 80) + "..." : payload));
     }
 }

--- a/exam-service/src/main/java/org/rdw/ingest/auth/OAuth2AuthenticationProvider.java
+++ b/exam-service/src/main/java/org/rdw/ingest/auth/OAuth2AuthenticationProvider.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.rdw.ingest.auth.SecurityConfig.DataLoadRole;
+
 /**
  * This auth provider acts as an adapter between basic auth from the clients of our RESTful API and the
  * credentials stored in our IDP which are accessed via oauth2. If things change so our clients are aware
@@ -76,8 +78,8 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider {
                 // extract roles from tenancy chain
                 // TODO - should this be client-specific? i.e. chain.hasRoleForClient(DataLoadRole)
                 final List<GrantedAuthority> authorities = new ArrayList<>();
-                if (chain.hasRole(SecurityConfig.DataLoadRole)) {
-                    authorities.add(new SimpleGrantedAuthority(SecurityConfig.DataLoadRole));
+                if (chain.hasRole(DataLoadRole)) {
+                    authorities.add(new SimpleGrantedAuthority(DataLoadRole));
                 }
 
                 user = new RdwUser(username, password, authorities, chain);

--- a/exam-service/src/main/java/org/rdw/ingest/auth/OAuth2Properties.java
+++ b/exam-service/src/main/java/org/rdw/ingest/auth/OAuth2Properties.java
@@ -1,4 +1,4 @@
-package org.rdw.ingest.web;
+package org.rdw.ingest.auth;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;

--- a/exam-service/src/main/java/org/rdw/ingest/auth/RdwUser.java
+++ b/exam-service/src/main/java/org/rdw/ingest/auth/RdwUser.java
@@ -1,0 +1,31 @@
+package org.rdw.ingest.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import rdw.utils.TenancyChain;
+
+import java.util.Collection;
+
+/**
+ * Extend user to store tenancy chain.
+ */
+public class RdwUser extends User {
+
+    private final TenancyChain tenancyChain;
+
+    public static RdwUser copy(final RdwUser user) {
+        return new RdwUser(user.getUsername(), user.getPassword(), user.getAuthorities(), user.getTenancyChain());
+    }
+
+    public RdwUser(final String username,
+                   final String password,
+                   final Collection<? extends GrantedAuthority> authorities,
+                   final TenancyChain tenancyChain) {
+        super(username, password, authorities);
+        this.tenancyChain = tenancyChain;
+    }
+
+    public TenancyChain getTenancyChain() {
+        return tenancyChain;
+    }
+}

--- a/exam-service/src/main/java/org/rdw/ingest/auth/SecurityConfig.java
+++ b/exam-service/src/main/java/org/rdw/ingest/auth/SecurityConfig.java
@@ -1,4 +1,4 @@
-package org.rdw.ingest.web;
+package org.rdw.ingest.auth;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
@@ -39,11 +39,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.csrf()
                 .disable()
             .authorizeRequests()
-                // TODO - worry about actuator end-points
                 .antMatchers("/exams/**").hasAuthority("ASMTDATALOAD")
                 .antMatchers("/testresults/**").hasAuthority("ASMTDATALOAD")
             .and().httpBasic()
             .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        // TODO - realm?
     }
 }

--- a/exam-service/src/main/java/org/rdw/ingest/service/DefaultExamService.java
+++ b/exam-service/src/main/java/org/rdw/ingest/service/DefaultExamService.java
@@ -1,5 +1,6 @@
 package org.rdw.ingest.service;
 
+import org.rdw.ingest.auth.RdwUser;
 import org.rdw.ingest.model.ImportStatus;
 import org.rdw.ingest.model.RdwImport;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,17 +25,14 @@ class DefaultExamService implements ExamService {
     }
 
     @Override
-    public RdwImport importExam(final String xml, final String batchId) {
-        // TODO - do we pass in user or steal credentials from thread local?
-        // TODO - do we need/want to set contentType of payload as part of import record?
+    public RdwImport importExam(final RdwUser user, final String payload, final String contentType, final String batchId) {
         final RdwImport rdwImport = RdwImport.builder()
                 .batchId(batchId)
                 .content("exam")
                 .status(ImportStatus.ACCEPTED)
                 .build();
 
-        // TODO - what do we really want to inject into workflow pipeline?
-        source.submitExam(xml);
+        source.submitExam(user, payload, contentType);
 
         return rdwImport;
     }

--- a/exam-service/src/main/java/org/rdw/ingest/service/DefaultExamSource.java
+++ b/exam-service/src/main/java/org/rdw/ingest/service/DefaultExamSource.java
@@ -1,9 +1,9 @@
 package org.rdw.ingest.service;
 
+import org.rdw.ingest.auth.RdwUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
@@ -34,14 +34,13 @@ public class DefaultExamSource implements ExamSource {
     }
 
     @Override
-    public void submitExam(final String body) {
-        final RdwMessageHeaderAccessor accessor = wrap(null);
-        // TODO - default message headers (id, timestamp)
-        // TODO - rdw-specific headers (user login, tenancy chain)
-        // TODO - get media type from http request
-        accessor.setContentType(MediaType.APPLICATION_XML);
-        accessor.setContent("exams");
-
+    public void submitExam(final RdwUser user, final String body, final String contentType) {
+        final RdwMessageHeaderAccessor accessor = wrap(null)
+                .setReceivedNow()
+                .setContent("exams")
+                .setUserLogin(user.getUsername())
+                .setUserTenancyChain(user.getTenancyChain().toString())
+                .setContentType(contentType);
         output.send(MessageBuilder.createMessage(body, accessor.getMessageHeaders()));
     }
 }

--- a/exam-service/src/main/java/org/rdw/ingest/service/ExamService.java
+++ b/exam-service/src/main/java/org/rdw/ingest/service/ExamService.java
@@ -1,7 +1,7 @@
 package org.rdw.ingest.service;
 
+import org.rdw.ingest.auth.RdwUser;
 import org.rdw.ingest.model.RdwImport;
-import rdw.model.TDSReport;
 
 import java.util.Optional;
 
@@ -10,7 +10,7 @@ import java.util.Optional;
  */
 public interface ExamService {
 
-    RdwImport importExam(String xml, String batchId);
+    RdwImport importExam(RdwUser user, String payload, String contentType, String batchId);
 
     Optional<RdwImport> getImport(String id);
 }

--- a/exam-service/src/main/java/org/rdw/ingest/service/ExamService.java
+++ b/exam-service/src/main/java/org/rdw/ingest/service/ExamService.java
@@ -10,7 +10,20 @@ import java.util.Optional;
  */
 public interface ExamService {
 
+    /**
+     * Accept the payload for import processing
+     *
+     * @param user user credentials
+     * @param payload payload to process
+     * @param contentType content type, e.g. application/xml
+     * @param batchId optional batch id
+     * @return newly created import resource
+     */
     RdwImport importExam(RdwUser user, String payload, String contentType, String batchId);
 
+    /**
+     * @param id import resource id
+     * @return the import resource, may be absent if id not found
+     */
     Optional<RdwImport> getImport(String id);
 }

--- a/exam-service/src/main/java/org/rdw/ingest/service/ExamSource.java
+++ b/exam-service/src/main/java/org/rdw/ingest/service/ExamSource.java
@@ -1,5 +1,7 @@
 package org.rdw.ingest.service;
 
+import org.rdw.ingest.auth.RdwUser;
+
 /**
  * Abstraction for injecting an exam payload into the message queue.
  */
@@ -8,7 +10,9 @@ interface ExamSource {
     /**
      * Submit the given text to the "exam" queue
      *
+     * @param user user credentials
      * @param body text representing exam / test results
+     * @param contentType content-type of body
      */
-    void submitExam(String body);
+    void submitExam(RdwUser user, String body, String contentType);
 }

--- a/exam-service/src/main/java/org/rdw/ingest/web/ExamController.java
+++ b/exam-service/src/main/java/org/rdw/ingest/web/ExamController.java
@@ -1,12 +1,14 @@
 package org.rdw.ingest.web;
 
+import org.rdw.ingest.auth.RdwUser;
 import org.rdw.ingest.model.RdwImport;
 import org.rdw.ingest.service.ExamService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.constraints.NotNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
 /**
  * Controller for exam / testresults end-points
@@ -32,9 +35,11 @@ class ExamController {
 
     @RequestMapping(value = "/imports",
                     method = RequestMethod.POST)
-    public ResponseEntity<RdwImport> postImport(@RequestBody String body,
+    public ResponseEntity<RdwImport> postImport(Authentication authentication,
+                                                @RequestHeader(value = CONTENT_TYPE, required = false) String contentType,
+                                                @RequestBody String body,
                                                 @RequestParam(required = false) String batchId) {
-        return ResponseEntity.ok(service.importExam(body, batchId));
+        return ResponseEntity.ok(service.importExam((RdwUser) authentication.getPrincipal(), body, contentType, batchId));
     }
 
     @RequestMapping(value = "/imports/{id}", method = RequestMethod.GET)

--- a/exam-service/src/test/java/org/rdw/ingest/auth/OAuth2PropertiesTests.java
+++ b/exam-service/src/test/java/org/rdw/ingest/auth/OAuth2PropertiesTests.java
@@ -1,4 +1,4 @@
-package org.rdw.ingest.web;
+package org.rdw.ingest.auth;
 
 import org.junit.Test;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OAuth2PropertiesTest {
+public class OAuth2PropertiesTests {
 
     @Configuration
     @EnableConfigurationProperties(OAuth2Properties.class)

--- a/exam-service/src/test/java/org/rdw/ingest/auth/RdwUserTests.java
+++ b/exam-service/src/test/java/org/rdw/ingest/auth/RdwUserTests.java
@@ -1,0 +1,25 @@
+package org.rdw.ingest.auth;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import rdw.utils.TenancyChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RdwUserTests {
+
+    // returns a test user with the same defaults as WithMockRdwUser
+    public static RdwUser testUser() {
+        return new RdwUser("test@example.com", "password",
+                Lists.newArrayList(new SimpleGrantedAuthority("ASMTDATALOAD")),
+                TenancyChain.fromString("||ASMTDATALOAD|||SBAC|||||||||||||"));
+    }
+
+    @Test
+    public void itShouldPreserveConstructorValues() {
+        final RdwUser user = testUser();
+        assertThat(user.getUsername()).isEqualTo("test@example.com");
+        assertThat(user.getTenancyChain().toString()).isEqualTo("||ASMTDATALOAD|||SBAC|||||||||||||");
+    }
+}

--- a/exam-service/src/test/java/org/rdw/ingest/auth/WithMockRdwUser.java
+++ b/exam-service/src/test/java/org/rdw/ingest/auth/WithMockRdwUser.java
@@ -1,0 +1,19 @@
+package org.rdw.ingest.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation to support mocking an RdwUser
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockRdwUserSecurityContextFactory.class)
+public @interface WithMockRdwUser {
+    String username() default "test@example.com";
+    String[] authorities() default { "ASMTDATALOAD" };
+    String password() default "password";
+    String tenancyChain() default "||ASMTDATALOAD|||SBAC|||||||||||||";
+}

--- a/exam-service/src/test/java/org/rdw/ingest/auth/WithMockRdwUserSecurityContextFactory.java
+++ b/exam-service/src/test/java/org/rdw/ingest/auth/WithMockRdwUserSecurityContextFactory.java
@@ -1,0 +1,24 @@
+package org.rdw.ingest.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import rdw.utils.TenancyChain;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class WithMockRdwUserSecurityContextFactory implements WithSecurityContextFactory<WithMockRdwUser> {
+    @Override
+    public SecurityContext createSecurityContext(final WithMockRdwUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        final RdwUser user = new RdwUser(annotation.username(), annotation.password(),
+                Stream.of(annotation.authorities()).map(SimpleGrantedAuthority::new).collect(Collectors.toList()),
+                TenancyChain.fromString(annotation.tenancyChain()));
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities()));
+        return context;
+    }
+}

--- a/exam-service/src/test/java/org/rdw/ingest/service/DefaultExamServiceTests.java
+++ b/exam-service/src/test/java/org/rdw/ingest/service/DefaultExamServiceTests.java
@@ -3,6 +3,11 @@ package org.rdw.ingest.service;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.rdw.ingest.auth.RdwUser;
+import org.rdw.ingest.auth.RdwUserTests;
+import rdw.utils.TenancyChain;
+
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -25,10 +30,12 @@ public class DefaultExamServiceTests {
 
     @Test
     public void importExamReturnsImport() {
+        final RdwUser user = RdwUserTests.testUser();
         final String body = "<TDSReport/>";
+        final String contentType = "application/xml";
         final String batchId = "123";
-        assertThat(service.importExam(body, batchId).getBatchId()).isEqualTo(batchId);
-        verify(examSource).submitExam(body);
+        assertThat(service.importExam(user, body, contentType, batchId).getBatchId()).isEqualTo(batchId);
+        verify(examSource).submitExam(user, body, contentType);
     }
 
     @Test

--- a/exam-service/src/test/java/org/rdw/ingest/service/DefaultExamSourceTests.java
+++ b/exam-service/src/test/java/org/rdw/ingest/service/DefaultExamSourceTests.java
@@ -2,18 +2,20 @@ package org.rdw.ingest.service;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.rdw.ingest.service.DefaultExamSource;
-import org.rdw.ingest.service.ExamSource;
+import org.rdw.ingest.auth.RdwUser;
+import org.rdw.ingest.auth.RdwUserTests;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.context.junit4.SpringRunner;
+import rdw.messaging.RdwMessageHeaderAccessor;
+import rdw.utils.TenancyChain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static rdw.messaging.RdwMessageHeaderAccessor.wrap;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -35,12 +37,16 @@ public class DefaultExamSourceTests {
 
     @Test
     public void submitExamShouldSetHeadersAndSendMessage() {
+        final RdwUser user = RdwUserTests.testUser();
         final String body = "<TDSReport/>";
 
-        examSource.submitExam(body);
+        examSource.submitExam(user, body, "application/xml");
 
         final Message message = messageCollector.forChannel(((DefaultExamSource)examSource).getOutput()).poll();
+        final RdwMessageHeaderAccessor accessor = wrap(message);
         assertThat(message.getPayload()).isEqualTo(body);
-        assertThat(message.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_XML);
+        assertThat(accessor.getContentType()).isEqualTo(MediaType.APPLICATION_XML);
+        assertThat(accessor.getUserLogin()).isEqualTo(user.getUsername());
+        assertThat(accessor.getUserTenancyChain()).isEqualTo(user.getTenancyChain().toString());
     }
 }

--- a/exam-service/src/test/java/org/rdw/ingest/web/ExamControllerTests.java
+++ b/exam-service/src/test/java/org/rdw/ingest/web/ExamControllerTests.java
@@ -2,13 +2,13 @@ package org.rdw.ingest.web;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.rdw.ingest.auth.WithMockRdwUser;
 import org.rdw.ingest.model.RdwImport;
 import org.rdw.ingest.service.ExamService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -27,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ExamController.class)
 @ContextConfiguration(classes = TestAppConfig.class)
 @WebAppConfiguration
-@WithMockUser(username = "alice", authorities = {"ASMTDATALOAD"})
+@WithMockRdwUser()
 public class ExamControllerTests {
 
     @Autowired
@@ -44,7 +46,7 @@ public class ExamControllerTests {
     @Test
     public void itShouldUseServiceToImportExam() throws Exception {
         final String body = "<TDSReport/>";
-        given(examService.importExam(body, null)).willReturn(testImport("123"));
+        given(examService.importExam(any(), eq(body), eq(MediaType.APPLICATION_XML_VALUE), any())).willReturn(testImport("123"));
         mvc.perform(post("/exams/imports").contentType(MediaType.APPLICATION_XML).content(body))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("123")));
@@ -53,7 +55,7 @@ public class ExamControllerTests {
     @Test
     public void itShouldReturn4xxForUnsupportedOperation() throws Exception {
         final String body = "<TDSReport/>";
-        given(examService.importExam(body, null)).willThrow(UnsupportedOperationException.class);
+        given(examService.importExam(any(), eq(body), eq(MediaType.APPLICATION_XML_VALUE), any())).willThrow(UnsupportedOperationException.class);
         mvc.perform(post("/exams/imports").contentType(MediaType.APPLICATION_XML).content(body))
                 .andExpect(status().is4xxClientError());
     }

--- a/exam-service/src/test/java/org/rdw/ingest/web/TestAppConfig.java
+++ b/exam-service/src/test/java/org/rdw/ingest/web/TestAppConfig.java
@@ -1,5 +1,6 @@
 package org.rdw.ingest.web;
 
+import org.rdw.ingest.auth.SecurityConfig;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -12,7 +13,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
  * this config class and still have the @withMockUser annotation work ... please do!
  */
 @Configuration
-@ComponentScan("org.rdw.ingest.web")
+@ComponentScan({"org.rdw.ingest.web", "org.rdw.ingest.auth"})
 @EnableWebMvc
 @Import({SecurityConfig.class})
 class TestAppConfig {


### PR DESCRIPTION
This catches the content type and authenticated user so additional message headers can be set for exam-payload