### PR TITLE
make test class naming consistent

### DIFF
--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/ExamServiceApplicationTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/ExamServiceApplicationTest.java
@@ -7,7 +7,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class ExamServiceApplicationTests {
+public class ExamServiceApplicationTest {
 
 	@Test
 	public void contextLoads() {

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/auth/OAuth2PropertiesTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/auth/OAuth2PropertiesTest.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OAuth2PropertiesTests {
+public class OAuth2PropertiesTest {
 
     @Configuration
     @EnableConfigurationProperties(OAuth2Properties.class)

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/auth/RdwUserTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/auth/RdwUserTest.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RdwUserTests {
+public class RdwUserTest {
 
     // returns a test user with the same defaults as WithMockRdwUser
     public static RdwUser testUser() {

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/model/RdwImportTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/model/RdwImportTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RdwImportTests {
+public class RdwImportTest {
 
     @Test
     public void itShouldRetainBuilderValues() {

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-public class RdwImportRepositoryTests {
+public class RdwImportRepositoryIT {
 
     @Autowired
     private RdwImportRepository repository;

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultExamServiceTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultExamServiceTest.java
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.opentestsystem.rdw.ingest.auth.RdwUser;
-import org.opentestsystem.rdw.ingest.auth.RdwUserTests;
+import org.opentestsystem.rdw.ingest.auth.RdwUserTest;
 import org.opentestsystem.rdw.ingest.model.RdwImport;
 import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
 
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DefaultExamServiceTests {
+public class DefaultExamServiceTest {
 
     private RdwImportRepository repository;
     private DefaultExamService service;
@@ -35,7 +35,7 @@ public class DefaultExamServiceTests {
 
     @Test
     public void importExamReturnsImport() {
-        final RdwUser user = RdwUserTests.testUser();
+        final RdwUser user = RdwUserTest.testUser();
         final String body = "<TDSReport/>";
         final String contentType = "application/xml";
         final String batch = "batch123";
@@ -49,7 +49,7 @@ public class DefaultExamServiceTests {
 
     @Test
     public void importShouldReturnExistingDigest() {
-        final RdwUser user = RdwUserTests.testUser();
+        final RdwUser user = RdwUserTest.testUser();
         final String body = "<TDSReport/>";
         final String contentType = "application/xml";
 

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultExamSourceTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultExamSourceTest.java
@@ -3,7 +3,7 @@ package org.opentestsystem.rdw.ingest.service;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.auth.RdwUser;
-import org.opentestsystem.rdw.ingest.auth.RdwUserTests;
+import org.opentestsystem.rdw.ingest.auth.RdwUserTest;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class DefaultExamSourceTests {
+public class DefaultExamSourceTest {
 
     @Autowired
     private ExamSource examSource;
@@ -35,7 +35,7 @@ public class DefaultExamSourceTests {
 
     @Test
     public void submitExamShouldSetHeadersAndSendMessage() {
-        final RdwUser user = RdwUserTests.testUser();
+        final RdwUser user = RdwUserTest.testUser();
         final String body = "<TDSReport/>";
 
         examSource.submitExam(user, body, "application/xml");

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = TestAppConfig.class)
 @WebAppConfiguration
 @WithMockRdwUser()
-public class ExamControllerTests {
+public class ExamControllerTest {
 
     @Autowired
     private MockMvc mvc;


### PR DESCRIPTION
Clearly our instincts are to name test suite classes with single `*Test`, so i've renamed the `*Tests`.
Followed Alla's lead to name any test suite `*IT` if it requires other processes to be running.

NOTE: running integration tests separate from unit tests is not, in my opinion, handled well by the gradle community so, for now, `*Test` and `*IT` suites are all run as part of the `test` phase. When we get to the point of having lots of slow integration tests, we can separate out their execution.