### PR TITLE
add message to import

### DIFF
--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/model/ImportStatus.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/model/ImportStatus.java
@@ -4,9 +4,13 @@ package org.opentestsystem.rdw.ingest.model;
  * Status for imports
  */
 public enum ImportStatus {
+    UNAUTHORIZED(-4),
+    BAD_DATA(-3),
+    BAD_FORMAT(-2),
     INVALID(-1),
     ACCEPTED(0),
-    PROCESSED(1);
+    PROCESSED(1),
+    PUBLISHED(2);
 
     private final int value;
 

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/model/RdwImport.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/model/RdwImport.java
@@ -91,6 +91,10 @@ public class RdwImport {
         private String message;
 
         public RdwImport build() {
+            if (created == null) {
+                created = now();
+            }
+
             final RdwImport rdwImport = new RdwImport();
             rdwImport.id = id;
             rdwImport.content = content;
@@ -99,7 +103,7 @@ public class RdwImport {
             rdwImport.status = status;
             rdwImport.batch = batch;
             rdwImport.creator = creator;
-            rdwImport.created = now();
+            rdwImport.created = created;
             rdwImport.message = message;
             return rdwImport;
         }

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/model/RdwImport.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/model/RdwImport.java
@@ -16,6 +16,7 @@ public class RdwImport {
     private String batch;
     private String creator;
     private Instant created;
+    private String message;
 
     /**
      * @return system id of import
@@ -70,6 +71,10 @@ public class RdwImport {
         return created;
     }
 
+    public String getMessage() {
+        return message;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -83,6 +88,7 @@ public class RdwImport {
         private String batch;
         private String creator;
         private Instant created;
+        private String message;
 
         public RdwImport build() {
             final RdwImport rdwImport = new RdwImport();
@@ -94,6 +100,7 @@ public class RdwImport {
             rdwImport.batch = batch;
             rdwImport.creator = creator;
             rdwImport.created = now();
+            rdwImport.message = message;
             return rdwImport;
         }
 
@@ -134,6 +141,11 @@ public class RdwImport {
 
         public Builder created(final Instant created) {
             this.created = created;
+            return this;
+        }
+
+        public Builder message(final String message) {
+            this.message = message;
             return this;
         }
     }

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryImpl.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryImpl.java
@@ -62,7 +62,9 @@ class RdwImportRepositoryImpl implements RdwImportRepository {
                 .addValue("digest", rdwImport.getDigest())
                 .addValue("batch", rdwImport.getBatch())
                 .addValue("creator", rdwImport.getCreator())
-                .addValue("created", Timestamp.from(rdwImport.getCreated()));
+                .addValue("created", Timestamp.from(rdwImport.getCreated()))
+                .addValue("message", rdwImport.getMessage())
+                ;
 
         jdbcTemplate.update(sqlImportCreate, parameterSource, keyHolder);
 
@@ -123,6 +125,7 @@ class RdwImportRepositoryImpl implements RdwImportRepository {
                     .batch(rs.getString("batch"))
                     .creator(rs.getString("creator"))
                     .created(rs.getTimestamp("created").toInstant())
+                    .message(rs.getString("message"))
                     .build();
         }
     }

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultExamService.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultExamService.java
@@ -98,7 +98,7 @@ class DefaultExamService implements ExamService {
                 logger.warn(ex.toString());
                 for (int i=0, cnt=ex.getRecordCount(); i<cnt; i++) {
                     final String text = ex.getRecordContext(i).getRecordText();
-                    imports.add(importInvalid(user, text, contentType, batch));
+                    imports.add(importInvalid(user, text, contentType, batch, ex.toString()));
                 }
             });
 
@@ -121,7 +121,7 @@ class DefaultExamService implements ExamService {
         return imports;
     }
 
-    private RdwImport importInvalid(final RdwUser user, final String payload, final String contentType, final String batch) {
+    private RdwImport importInvalid(final RdwUser user, final String payload, final String contentType, final String batch, final String message) {
         final String digest = DigestUtils.md5Hex(payload).toUpperCase();
 
         final RdwImport rdwImport = repository.findOneByDigest(digest);
@@ -137,6 +137,7 @@ class DefaultExamService implements ExamService {
                 .status(ImportStatus.INVALID)
                 .creator(user.getUsername())
                 .batch(batch)
+                .message(message)
                 .build());
     }
 

--- a/exam-service/src/main/resources/application.sql.yml
+++ b/exam-service/src/main/resources/application.sql.yml
@@ -4,8 +4,8 @@ sql:
       SELECT count(*) from import
 
     create: >-
-      INSERT INTO import (status, content, contentType, digest, batch, creator, created)
-        VALUES (:status, :content, :contentType, :digest, :batch, :creator, :created)
+      INSERT INTO import (status, content, contentType, digest, batch, creator, created, message)
+        VALUES (:status, :content, :contentType, :digest, :batch, :creator, :created, :message)
 
     exists: >-
       SELECT (CASE WHEN EXISTS (SELECT 1 FROM import WHERE id=:id) THEN true ELSE false END) exist

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/model/RdwImportTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/model/RdwImportTest.java
@@ -15,6 +15,7 @@ public class RdwImportTest {
                 .content(ImportContent.EXAM)
                 .contentType(MediaType.APPLICATION_XML_VALUE)
                 .creator("alice")
+                .message("message")
                 .build();
         assertThat(rdwImport.getId()).isNull();
         assertThat(rdwImport.getBatch()).isEqualTo("batch");
@@ -22,5 +23,6 @@ public class RdwImportTest {
         assertThat(rdwImport.getContent()).isEqualTo(ImportContent.EXAM);
         assertThat(rdwImport.getContentType()).isEqualTo(MediaType.APPLICATION_XML_VALUE);
         assertThat(rdwImport.getCreator()).isEqualTo("alice");
+        assertThat(rdwImport.getMessage()).isEqualTo("message");
     }
 }

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/model/RdwImportTest.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/model/RdwImportTest.java
@@ -25,4 +25,9 @@ public class RdwImportTest {
         assertThat(rdwImport.getCreator()).isEqualTo("alice");
         assertThat(rdwImport.getMessage()).isEqualTo("message");
     }
+
+    @Test
+    public void itShouldDefaultACreatedValue() {
+        assertThat(RdwImport.builder().build().getCreated()).isNotNull();
+    }
 }

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -29,7 +29,11 @@ public class RdwImportRepositoryIT {
 
         final Map<String, Long> map = createTestData();
 
-        assertThat(repository.findOne(map.get("alice")).getCreator()).isEqualTo("alice");
+        final RdwImport alice = repository.findOne(map.get("alice"));
+        assertThat(alice.getCreator()).isEqualTo("alice");
+        assertThat(alice.getDigest()).isEqualTo("alice");
+        assertThat(alice.getMessage()).isEqualTo("Hi alice");
+
         assertThat(repository.findOneByDigest("bob").getCreator()).isEqualTo("bob");
 
         assertThat(repository.findByBatch("abc")).hasSize(3);
@@ -49,7 +53,11 @@ public class RdwImportRepositoryIT {
 
         final Map<String, Long> result = newHashMap();
         for (final String creator : new String[]{"alice","bob","charlie"}) {
-            final RdwImport saved = repository.create(builder.creator(creator).digest(creator).build());
+            final RdwImport saved = repository.create(builder
+                    .creator(creator)
+                    .digest(creator)
+                    .message("Hi " + creator)
+                    .build());
             result.put(creator, saved.getId());
         }
         return result;


### PR DESCRIPTION
minor tweak to start fleshing out import records, produces import objects like:
`{
    "id": 43,
    "content": "EXAM",
    "contentType": "text/csv",
    "digest": "6CECD8358506280DD938608E314F6501",
    "status": "INVALID",
    "batch": "3C70D4EC0194DCB626E8FAE8C16BF3E3",
    "creator": "dwtest@example.com",
    "created": {
      "nano": 643000000,
      "epochSecond": 1488472962
    },
    "message": "org.beanio.InvalidRecordException: Invalid 'tdsReport' record at line 8\n ==> Invalid 'academicYear':  Type conversion error: Invalid Long value 'NotAYear'"
  }`