### PR TITLE
add local-auth option

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - spring.profiles.active=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
-      - CONFIG_SERVICE_LABEL=rdwauth,master
     extra_hosts:
       - "dwhost:$DATAWAREHOUSE_HOST"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - spring.profiles.active=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
+      - CONFIG_SERVICE_LABEL=rdwauth,master
     extra_hosts:
       - "dwhost:$DATAWAREHOUSE_HOST"
 

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthConfig.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthConfig.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * Configuration for auth provider
+ */
+@Configuration
+@EnableConfigurationProperties({OAuth2Properties.class})
+@EnableWebSecurity
+public class AuthConfig {
+
+    @Autowired
+    private OAuth2Properties oauth2Properties;
+
+    @Bean
+    @AuthProviderType("oauth2")
+    public AuthenticationProvider oauth2AuthenticationProvider() {
+        return new OAuth2AuthenticationProvider(oauth2Properties);
+    }
+
+    @Bean
+    @AuthProviderType("local")
+    public AuthenticationProvider localProvider() {
+        return new LocalAuthenticationProvider();
+    }
+
+    @Bean
+    public WebSecurityConfigurerAdapter securityConfigurer() {
+        return new SecurityConfigurer();
+    }
+}

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthProviderType.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthProviderType.java
@@ -1,0 +1,19 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for conditionally selecting auth provider
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(AuthProviderTypeCondition.class)
+public @interface AuthProviderType {
+
+    String value();
+}

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthProviderTypeCondition.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthProviderTypeCondition.java
@@ -1,0 +1,31 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.util.Map;
+
+/**
+ * Condition for matching auth provider beans based on the environment.
+ * NOTE: we probably want to make instantiating the "local" auth provider more restrictive.
+ */
+public class AuthProviderTypeCondition implements Condition {
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+        final Map<String, Object> attributes = metadata.getAnnotationAttributes(AuthProviderType.class.getName());
+        final String type = (String) attributes.get("value");
+
+        final Environment env = context.getEnvironment();
+
+        if ("oauth2".equalsIgnoreCase(type)) {
+            return env.getProperty("oauth2.token-info-uri") != null;
+        } else if ("local".equalsIgnoreCase(type)) {
+            return env.getProperty("oauth2.token-info-uri") == null;
+        } else {
+            return false;
+        }
+    }
+}

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/LocalAuthenticationProvider.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/LocalAuthenticationProvider.java
@@ -1,0 +1,82 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.opentestsystem.rdw.utils.TenancyChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.util.ResourceUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * This auth provider reads user credentials from a user-info file.
+ * NOTE: we need to ensure this doesn't get out in the wild.
+ */
+public class LocalAuthenticationProvider implements AuthenticationProvider, InitializingBean {
+    private static final Logger logger = LoggerFactory.getLogger(LocalAuthenticationProvider.class);
+
+    @Value("${auth.user-info-uri:classpath:user-info}")
+    private String userInfoUri;
+
+    private List<RdwUser> userInfo = newArrayList();
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        try {
+            // format of file lines is expected to be:
+            // username, password, tenancyChain
+            final File userInfoFile = ResourceUtils.getFile(userInfoUri);
+            try (final BufferedReader reader = new BufferedReader(new FileReader(userInfoFile))) {
+                userInfo = reader.lines()
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .filter(s -> !s.startsWith("#"))
+                        .map(s -> {
+                            final String[] fields = s.split(",");
+                            return RdwUser.from(fields[0].trim(), fields[1].trim(), TenancyChain.fromString(fields[2]));
+                        })
+                        .collect(Collectors.toList());
+            }
+        } catch (final FileNotFoundException e) {
+            logger.warn("Invalid user-info-uri " + userInfoUri);
+        }
+    }
+
+    @Override
+    public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
+        if (!supports(authentication.getClass())) return authentication;
+
+        final UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
+
+        final String username = auth.getName();
+        final String password = (String) auth.getCredentials();
+        for (final RdwUser user : userInfo) {
+            if (user.getUsername().equalsIgnoreCase(username) && user.getPassword().equals(password)) {
+                final UsernamePasswordAuthenticationToken result = new UsernamePasswordAuthenticationToken(
+                        RdwUser.copy(user), user.getPassword(), user.getAuthorities());
+                result.setDetails(auth.getDetails());
+                return result;
+            }
+        }
+        logger.info(username + " not authenticated");
+        throw new BadCredentialsException(auth.getName());
+    }
+
+    @Override
+    public boolean supports(final Class<?> aClass) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(aClass);
+    }
+}

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/OAuth2AuthenticationProvider.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/OAuth2AuthenticationProvider.java
@@ -5,37 +5,26 @@ import com.google.common.cache.CacheBuilder;
 import org.opentestsystem.rdw.utils.TenancyChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
-import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import static org.opentestsystem.rdw.ingest.auth.SecurityConfig.DataLoadRole;
 
 /**
  * This auth provider acts as an adapter between basic auth from the clients of our RESTful API and the
  * credentials stored in our IDP which are accessed via oauth2. If things change so our clients are aware
  * of oauth2 and use it fully, this can go away and we can use magick Spring wiring (i think).
  */
-@Component
-@EnableConfigurationProperties({OAuth2Properties.class})
 @EnableOAuth2Client
 public class OAuth2AuthenticationProvider implements AuthenticationProvider {
     private static final Logger logger = LoggerFactory.getLogger(OAuth2AuthenticationProvider.class);
@@ -43,8 +32,7 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider {
     private Cache<String, RdwUser> userCache;
     private OAuth2Properties oauth2Properties;
 
-    @Autowired
-    void setProperties(final OAuth2Properties oauth2Properties) {
+    OAuth2AuthenticationProvider(final OAuth2Properties oauth2Properties) {
         this.oauth2Properties = oauth2Properties;
         this.userCache = CacheBuilder.newBuilder()
                 .maximumSize(oauth2Properties.getCache().getSize())
@@ -71,17 +59,8 @@ public class OAuth2AuthenticationProvider implements AuthenticationProvider {
                 final Map tokenInfo = template.getForObject(oauth2Properties.getTokenInfoUri(), Map.class,
                         Collections.singletonMap("access_token", token.getValue()));
                 final TenancyChain chain = TenancyChain.fromString((String) tokenInfo.get("sbacTenancyChain"));
-                if (chain.isEmpty()) {
-                    throw new RuntimeException("user doesn't have a SBAC tenancy chain");
-                }
 
-                // extract roles from tenancy chain
-                final List<GrantedAuthority> authorities = new ArrayList<>();
-                if (chain.hasRole(DataLoadRole)) {
-                    authorities.add(new SimpleGrantedAuthority(DataLoadRole));
-                }
-
-                user = new RdwUser(username, password, authorities, chain);
+                user = RdwUser.from(username, password, chain);
                 userCache.put(username+password, user);
 
                 logger.info(auth.getName() + " authenticated");

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/RdwUser.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/RdwUser.java
@@ -2,9 +2,14 @@ package org.opentestsystem.rdw.ingest.auth;
 
 import org.opentestsystem.rdw.utils.TenancyChain;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+
+import static org.opentestsystem.rdw.ingest.auth.SecurityConfigurer.DataLoadAuthority;
 
 /**
  * Extend user to store tenancy chain.
@@ -13,8 +18,22 @@ public class RdwUser extends User {
 
     private final TenancyChain tenancyChain;
 
-    public static RdwUser copy(final RdwUser user) {
+    static RdwUser copy(final RdwUser user) {
         return new RdwUser(user.getUsername(), user.getPassword(), user.getAuthorities(), user.getTenancyChain());
+    }
+
+    static RdwUser from(final String username, final String password, final TenancyChain chain) {
+        if (chain.isEmpty()) {
+            throw new IllegalArgumentException("empty SBAC tenancy chain");
+        }
+
+        // extract roles from tenancy chain
+        final List<GrantedAuthority> authorities = new ArrayList<>();
+        if (chain.hasRole(DataLoadAuthority)) {
+            authorities.add(new SimpleGrantedAuthority(DataLoadAuthority));
+        }
+
+        return new RdwUser(username, password, authorities, chain);
     }
 
     public RdwUser(final String username,

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
@@ -13,9 +13,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 /**
  * Security configuration
  */
-@EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
-    final static String DataLoadRole = "ASMTDATALOAD";
+public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
+    final static String DataLoadAuthority = "ASMTDATALOAD";
 
     private AuthenticationProvider authenticationProvider;
 
@@ -39,8 +38,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.csrf()
                 .disable()
             .authorizeRequests()
-                .antMatchers("/exams/**").hasAuthority("ASMTDATALOAD")
-                .antMatchers("/testresults/**").hasAuthority("ASMTDATALOAD")
+                .antMatchers("/exams/**").hasAuthority(DataLoadAuthority)
+                .antMatchers("/testresults/**").hasAuthority(DataLoadAuthority)
             .and().httpBasic()
             .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
     }

--- a/exam-service/src/main/resources/application.yml
+++ b/exam-service/src/main/resources/application.yml
@@ -5,15 +5,6 @@ management:
   security:
     enabled: false
 
-oauth2:
-  access-token-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/access_token?realm=/sbac
-  client-id: sbacdw
-  client-secret:
-  token-info-uri: https://sso-deployment.sbtds.org:443/auth/oauth2/tokeninfo
-  cache:
-    size: 10
-    expire: 15
-
 spring:
   cloud:
     stream:

--- a/exam-service/src/main/resources/user-info
+++ b/exam-service/src/main/resources/user-info
@@ -1,0 +1,2 @@
+# username, password, tenancyChain
+aptest, aptest, ||ASMTDATALOAD|STATE||SBAC|AP|ARMED FORCES PACIFIC|||||||||||

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/web/TestAppConfig.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/web/TestAppConfig.java
@@ -1,20 +1,11 @@
 package org.opentestsystem.rdw.ingest.web;
 
-import org.opentestsystem.rdw.ingest.auth.SecurityConfig;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-/**
- * Pretty sure i'm cheating with this. This is from the instructions for getting @WithMockUser working in tests.
- * But the example wasn't using the same annotations we are (older vs. newer spring boot stuff). However,
- * dropping this puppy into the test folder makes the annotations do what they should. If you can get rid of
- * this config class and still have the @withMockUser annotation work ... please do!
- */
 @Configuration
 @ComponentScan({"org.opentestsystem.rdw.ingest.web", "org.opentestsystem.rdw.ingest.auth"})
 @EnableWebMvc
-@Import({SecurityConfig.class})
 class TestAppConfig {
 }


### PR DESCRIPTION
I'm not 100% sure of this change and would like thoughts.

What it does is introduce a local auth provider that is instantiated if no other auth provider is configured. This auth provider reads a file to get user credentials. This will allow us to more easily test with arbitrary tenancy chains without having to create users in ART. The obvious downside is that, should this escape into the wild, it would allow somebody to configure a user without having to use ART. We can easily protect against that but it is still a possible security concern ...