### PR TITLE
inject url into status

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,12 +2,8 @@
 // (and i can't figure out how else to get it in here)
 // But it also defines silly boot tasks which we don't want here.
 apply plugin: 'org.springframework.boot'
-bootRepackage {
-    enabled = false
-}
-bootRun {
-    enabled = false
-}
+bootRepackage.enabled = false
+bootRun.enabled = false
 
 dependencies {
     compile 'com.google.guava:guava'
@@ -20,6 +16,5 @@ dependencies {
 
     // For StatusMvcEndpoint
     compile 'org.springframework.boot:spring-boot-starter-actuator'
-    compile 'org.springframework:spring-web'
-    compile 'org.springframework:spring-webmvc'
+    compile 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/LocalSystemStatusIndicator.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/LocalSystemStatusIndicator.java
@@ -10,8 +10,10 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * {@link StatusIndicator} for level 1 local system diagnostics.
@@ -48,7 +50,11 @@ public class LocalSystemStatusIndicator extends AbstractStatusIndicator {
     }
 
     private void addApplicationInfoDetails(final Status.Builder builder) {
-        builder.detail("applicationInfo", ImmutableMap.of("version", buildVersion));
+        // this map needs to be mutable because the MVC wrapper will inject the uri
+        // yeah, this is a hack
+        final Map<String, Object> info = newHashMap();
+        info.put("version", buildVersion);
+        builder.detail("applicationInfo", info);
     }
 
     private void addMemoryDetails(final Status.Builder builder) {

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusMvcEndpoint.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusMvcEndpoint.java
@@ -3,15 +3,18 @@ package org.opentestsystem.rdw.ingest.status;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
 
 /**
  * MVC Endpoint wrapper for {@link StatusEndpoint} for serving up web diagnostics.
- * <p>
- * TODO - localSystem is supposed to have applicationInfo including url which would come from here
- * </p>
  *
  * @see StatusEndpoint
  * @see StatusConfiguration
@@ -27,7 +30,41 @@ public class StatusMvcEndpoint extends EndpointMvcAdapter {
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE, params = {"level"})
     @ResponseBody
-    public ResponseEntity<?> invoke(@RequestParam(defaultValue = "0") int level) {
-        return ResponseEntity.ok(delegate.invoke(level));
+    public ResponseEntity<?> invoke(@RequestParam(defaultValue = "0") int level,
+                                    final HttpServletRequest request) {
+
+        return ResponseEntity.ok(injectUrl(delegate.invoke(level), request));
+    }
+
+    /**
+     * If the status has the localSystem applicationInfo details this will inject an
+     * additional entry for 'url'. Yes, this is hacktacular.
+     *
+     * @param status status to modify
+     * @param request request from which to extract url
+     * @return status, perhaps with additional info in it
+     */
+    private SystemStatus injectUrl(final SystemStatus status, final HttpServletRequest request) {
+        final Status localSystem = status.getSubs().get("localSystem");
+        if (localSystem == null) return status;
+
+        final Map<String, Object> applicationInfo = (Map<String, Object>) localSystem.getDetails().get("applicationInfo");
+        if (applicationInfo == null) return status;
+
+        final UriComponents uriComponents = UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request)).build();
+        String scheme = uriComponents.getScheme();
+        String host = uriComponents.getHost();
+        int port = uriComponents.getPort();
+        final StringBuilder sb = new StringBuilder();
+        if (scheme != null) {
+            sb.append(scheme).append("://");
+        }
+        sb.append(host == null ? "host" : host);
+        if (port != -1) {
+            sb.append(":").append(port);
+        }
+        applicationInfo.put("url", sb.toString());
+
+        return status;
     }
 }


### PR DESCRIPTION
I'm not at all thrilled with this hack but we need to get the `url` value in the status, but only if the status is being served up from the MVC endpoint. I really don't want to spend a lot of time on this ... thus the hack.

@rcordeau i was in the build file so i made your recommended change. I'm not sure the `bootRun.enabled=false` actually does anything but i left it in.