### PR TITLE
caching test helper

### DIFF
--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/CachingTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/CachingTest.java
@@ -1,0 +1,23 @@
+package org.opentestsystem.rdw.ingest.processor;
+
+import org.springframework.boot.autoconfigure.cache.CacheType;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.context.TestExecutionListeners;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Composed annotation for tests of implementations that use spring caches.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@EnableCaching
+@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@TestExecutionListeners(
+        mergeMode=TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS, listeners={CachingTestExecutionListener.class})
+public @interface CachingTest {
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/CachingTestExecutionListener.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/CachingTestExecutionListener.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.processor;
 
+import org.opentestsystem.rdw.ingest.processor.repository.impl.CachingTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -7,7 +8,13 @@ import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
 /**
- * This will clear caches before any test in a test suite that has {@link EnableCaching}.
+ * This will clear caches (from the context CacheManager) before any test in a test suite that has {@link EnableCaching}.
+ * To use, annotate the test suite with:<pre>
+ * {@literal @}TestExecutionListeners(mergeMode=TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+ *                          listeners={CachingTestExecutionListener.class})
+ * </pre>
+ *
+ * @see CachingTest
  */
 public class CachingTestExecutionListener extends AbstractTestExecutionListener {
 

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/CachingTestExecutionListener.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/CachingTestExecutionListener.java
@@ -1,0 +1,31 @@
+package org.opentestsystem.rdw.ingest.processor;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+/**
+ * This will clear caches before any test in a test suite that has {@link EnableCaching}.
+ */
+public class CachingTestExecutionListener extends AbstractTestExecutionListener {
+
+    private static final String EnabledAttribute = "CachingTestExecutionListener.mode";
+
+    @Override
+    public void beforeTestClass(final TestContext testContext) throws Exception {
+        final boolean enabled = null != AnnotatedElementUtils.findMergedAnnotation(testContext.getTestClass(), EnableCaching.class);
+        testContext.setAttribute(EnabledAttribute, enabled);
+    }
+
+    @Override
+    public void beforeTestMethod(final TestContext testContext) throws Exception {
+        if (!(Boolean)testContext.getAttribute(EnabledAttribute)) return;
+
+        final CacheManager cacheManager = testContext.getApplicationContext().getAutowireCapableBeanFactory().getBean(CacheManager.class);
+        for (final String name : cacheManager.getCacheNames()) {
+            cacheManager.getCache(name).clear();
+        }
+    }
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AdminConditionRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AdminConditionRepositoryIT.java
@@ -4,12 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.processor.repository.AdminConditionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO administration_condition (id, name) VALUES (99, 'test1');",
         "INSERT INTO administration_condition (id, name) VALUES (88, 'test2');",

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentTypeRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentTypeRepositoryIT.java
@@ -4,12 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.processor.repository.AssessmentTypeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO asmt_type (id, code, name) VALUES (99, 'Code1', 'test1');",
         "INSERT INTO asmt_type (id, code, name) VALUES (88, 'Code2', 'test2');",

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/CachingTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/CachingTest.java
@@ -1,5 +1,6 @@
-package org.opentestsystem.rdw.ingest.processor;
+package org.opentestsystem.rdw.ingest.processor.repository.impl;
 
+import org.opentestsystem.rdw.ingest.processor.CachingTestExecutionListener;
 import org.springframework.boot.autoconfigure.cache.CacheType;
 import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.cache.annotation.EnableCaching;
@@ -12,6 +13,9 @@ import java.lang.annotation.Target;
 
 /**
  * Composed annotation for tests of implementations that use spring caches.
+ * To use, simply annotate the test with:<pre>
+ * {@literal @}CachingTest
+ * </pre>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/CompletenessRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/CompletenessRepositoryIT.java
@@ -4,12 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.processor.repository.CompletenessRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO completeness (id, name) VALUES (99, 'test1');",
         "INSERT INTO completeness (id, name) VALUES (88, 'test2');",

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/EthnicityRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/EthnicityRepositoryIT.java
@@ -4,12 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.processor.repository.EthnicityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO ethnicity (id, name) VALUES (99, 'test1');",
         "INSERT INTO ethnicity (id, name) VALUES (88, 'test2');",

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/GenderRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/GenderRepositoryIT.java
@@ -2,7 +2,6 @@ package org.opentestsystem.rdw.ingest.processor.repository.impl;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.ingest.processor.CachingTest;
 import org.opentestsystem.rdw.ingest.processor.repository.GenderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/GenderRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/GenderRepositoryIT.java
@@ -2,14 +2,12 @@ package org.opentestsystem.rdw.ingest.processor.repository.impl;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.ingest.processor.CachingTest;
 import org.opentestsystem.rdw.ingest.processor.repository.GenderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO gender (id, name) VALUES (99, 'test1');",
         "INSERT INTO gender (id, name) VALUES (88, 'test2');",
@@ -53,5 +50,17 @@ public class GenderRepositoryIT {
         assertThat(repository.findIdByName("test55")).isEqualTo(55);
 
         assertThat(codes.get("test55", Integer.class)).isEqualTo(55);
+    }
+
+    @Test
+    @Sql(statements = { "INSERT INTO gender (id, name) VALUES (42, 'foo');"} )
+    public void cacheConflict42() {
+        assertThat(repository.findIdByName("foo")).isEqualTo(42);
+    }
+
+    @Test
+    @Sql(statements = { "INSERT INTO gender (id, name) VALUES (47, 'foo');"} )
+    public void cacheConflict47() {
+        assertThat(repository.findIdByName("foo")).isEqualTo(47);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/GradeRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/GradeRepositoryIT.java
@@ -2,15 +2,11 @@ package org.opentestsystem.rdw.ingest.processor.repository.impl;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.ingest.processor.repository.GenderRepository;
 import org.opentestsystem.rdw.ingest.processor.repository.GradeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO grade  (id, code, name) VALUES (99, 'c1', 'test1');",
         "INSERT INTO grade (id, code, name) VALUES (88, 'c2', 'test2');",

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ImportRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ImportRepositoryIT.java
@@ -5,10 +5,7 @@ import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.processor.repository.ImportRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -20,8 +17,7 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "DELETE FROM import WHERE id = 99 or id = 1",
         "INSERT INTO import (id, status, content, contentType, digest) VALUES ( 99, 0, 1, 'type', 'digest')"

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryIT.java
@@ -6,12 +6,9 @@ import org.opentestsystem.rdw.ingest.processor.model.District;
 import org.opentestsystem.rdw.ingest.processor.model.School;
 import org.opentestsystem.rdw.ingest.processor.repository.SchoolRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -24,8 +21,7 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 public class SchoolRepositoryIT {
     @Autowired
     private CacheManager cacheManager;

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SubjectRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SubjectRepositoryIT.java
@@ -4,12 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.processor.repository.SubjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.cache.CacheType;
-import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-@EnableCaching
-@AutoConfigureCache(cacheProvider = CacheType.SIMPLE)
+@CachingTest
 @Sql(statements = {
         "INSERT INTO subject (id, name) VALUES (99, 'test1');",
         "INSERT INTO subject (id, name) VALUES (88, 'test2');",


### PR DESCRIPTION
@agorina, submitted for your review. This allows an easy annotation for tests that use implementations that use caching; it clears cache before every test.

I couldn't find a built-in spring thing that does this and this is more surgical than @DirtiesContext.

If you're okay with it, i'll change all the existing ITs and merge it.