### PR TITLE
add database status indicator, which required a little refactoring

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/model/ImportContent.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/model/ImportContent.java
@@ -4,6 +4,7 @@ package org.opentestsystem.rdw.ingest.model;
  * The content type of an import.
  */
 public enum ImportContent {
+    PROBE(0),
     EXAM(1);
 
     private final int value;

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/AbstractStatusIndicator.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/AbstractStatusIndicator.java
@@ -1,26 +1,60 @@
 package org.opentestsystem.rdw.ingest.status;
 
+import java.util.function.Supplier;
+
 /**
  * Helper to handle general exceptions for {@link StatusIndicator}s.
  */
 public abstract class AbstractStatusIndicator implements StatusIndicator {
 
     @Override
-    public Status status() {
-        Status.Builder builder = Status.builder();
+    public Status status(final int level) {
+        if (!doLevelCheck(level)) return null;
+
+        final Status.Builder builder = Status.builder();
         try {
-            doStatusCheck(builder);
+            doStatusCheck(builder, level);
         } catch (final Exception e) {
             builder.rating(Rating.Failed);
+            builder.detail("error", e.getMessage());
         }
         return builder.build();
     }
 
     /**
      * Perform the actual status check.
+     * This method will only be called with a level that passed {@link AbstractStatusIndicator#doLevelCheck(int)}.
      *
      * @param builder status builder
-     * @throws Exception if any problem, results in status of Failed
+     * @param level diagnostic level
+     * @throws RuntimeException if any problem, results in status of Failed
      */
-    protected abstract void doStatusCheck(final Status.Builder builder);
+    protected abstract void doStatusCheck(final Status.Builder builder, final int level);
+
+    /**
+     * @param level diagnostic level
+     * @return true if this indicator will add status; false if this indicator will emit nothing
+     */
+    protected abstract boolean doLevelCheck(final int level);
+
+    /**
+     * Helper that times an operation and injects a "responseTime" detail. It also sets rating to
+     * "Degraded" if response exceeds threshold.
+     *
+     * @param builder status builder
+     * @param threshold time threshold (ms) indicating Degraded status
+     * @param supplier operation to perform and time
+     * @param <T> return type of operation
+     * @return result of operation
+     */
+    protected <T> T responseTime(final Status.Builder builder, final long threshold, final Supplier<T> supplier) {
+        final long start = System.currentTimeMillis();
+        final T result = supplier.get();
+        final long elapsed = System.currentTimeMillis() - start;
+        builder.detail("responseTime", elapsed + "ms");
+        if (elapsed > threshold) {
+            builder.rating(Rating.Degraded);
+        }
+        return result;
+    }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/ConfigurationStatusIndicator.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/ConfigurationStatusIndicator.java
@@ -1,0 +1,35 @@
+package org.opentestsystem.rdw.ingest.status;
+
+import org.springframework.boot.actuate.endpoint.ConfigurationPropertiesReportEndpoint;
+import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
+
+/**
+ * {@link StatusIndicator} for level 2 configuration diagnostics.
+ */
+public class ConfigurationStatusIndicator extends AbstractStatusIndicator {
+
+    private final ConfigurationPropertiesReportEndpoint configurationEndpoint;
+    private final EnvironmentEndpoint environmentEndpoint;
+
+    public ConfigurationStatusIndicator(final ConfigurationPropertiesReportEndpoint configurationEndpoint,
+                                        final EnvironmentEndpoint environmentEndpoint) {
+        this.configurationEndpoint = configurationEndpoint;
+        this.environmentEndpoint = environmentEndpoint;
+    }
+
+    @Override
+    public String name() {
+        return "configuration";
+    }
+
+    @Override
+    protected boolean doLevelCheck(final int level) {
+        return level >= 2;
+    }
+
+    @Override
+    protected void doStatusCheck(final Status.Builder builder, final int level) {
+        builder.detail("environmentSettings", environmentEndpoint.invoke());
+        builder.detail("configClientProperties", configurationEndpoint.invoke().get("configClientProperties"));
+    }
+}

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/LocalSystemStatusIndicator.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/LocalSystemStatusIndicator.java
@@ -30,17 +30,17 @@ public class LocalSystemStatusIndicator extends AbstractStatusIndicator {
     }
 
     @Override
-    public int level() {
-        return 1;
-    }
-
-    @Override
     public String name() {
         return "localSystem";
     }
 
     @Override
-    protected void doStatusCheck(final Status.Builder builder) {
+    protected boolean doLevelCheck(final int level) {
+        return level >= 1;
+    }
+
+    @Override
+    protected void doStatusCheck(final Status.Builder builder, final int level) {
         addApplicationInfoDetails(builder);
         addMemoryDetails(builder);
         addProcessorDetails(builder);

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusConfiguration.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.ingest.status;
 
+import org.springframework.boot.actuate.endpoint.ConfigurationPropertiesReportEndpoint;
+import org.springframework.boot.actuate.endpoint.EnvironmentEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,22 +41,9 @@ public class StatusConfiguration {
     }
 
     @Bean
-    public StatusIndicator configurationStatusIndicator() {
-        return new AbstractStatusIndicator() {
-            @Override
-            protected void doStatusCheck(final Status.Builder builder) {
-                builder.detail("environmentSettings", "TBD");
-            }
-
-            @Override
-            public int level() {
-                return 2;
-            }
-
-            @Override
-            public String name() {
-                return "configuration";
-            }
-        };
+    public ConfigurationStatusIndicator configurationStatusIndicator(
+            final ConfigurationPropertiesReportEndpoint configurationEndpoint,
+            final EnvironmentEndpoint environmentEndpoint) {
+        return new ConfigurationStatusIndicator(configurationEndpoint, environmentEndpoint);
     }
 }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusEndpoint.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusEndpoint.java
@@ -41,8 +41,10 @@ public class StatusEndpoint extends AbstractEndpoint<SystemStatus> {
                 .level(level)
                 .unit(applicationName);
         for (final StatusIndicator statusIndicator : statusIndicators) {
-            if (level < statusIndicator.level()) continue;
-            builder.sub(statusIndicator.name(), statusIndicator.status());
+            final Status status = statusIndicator.status(level);
+            if (status != null) {
+                builder.sub(statusIndicator.name(), status);
+            }
         }
         return builder.build();
     }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusIndicator.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/status/StatusIndicator.java
@@ -7,23 +7,15 @@ package org.opentestsystem.rdw.ingest.status;
 public interface StatusIndicator {
 
     /**
-     * The diagnostic level for an indicator is used to control when the status is emitted.
-     * If the requested status level is less than the indicator's level, it will be skipped.
-     * There are guidelines in the web diagnostic spec for the appropriate levels.
-     *
-     * @return diagnostic level for this status, typically 1-5
-     */
-    int level();
-
-    /**
-     * TODO - should name be here in the indicator or in the Status itself?
-     *
      * @return name of status, e.g. "configuration"
      */
     String name();
 
     /**
-     * @return status
+     * Generate status for the given level
+     *
+     * @param level diagnostic level
+     * @return status for the given level, may be null
      */
-    Status status();
+    Status status(int level);
 }

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/status/AbstractStatusIndicatorTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/status/AbstractStatusIndicatorTest.java
@@ -9,11 +9,64 @@ public class AbstractStatusIndicatorTest {
     @Test
     public void itShouldCatchException() {
         final AbstractStatusIndicator statusIndicator = new AbstractStatusIndicator() {
-            @Override protected void doStatusCheck(final Status.Builder builder) { throw new UnsupportedOperationException(); }
-            @Override public int level() { return 0; }
+            @Override protected void doStatusCheck(final Status.Builder builder, final int level) {
+                throw new UnsupportedOperationException("test error");
+            }
+            @Override protected boolean doLevelCheck(final int level) { return true; }
             @Override public String name() { return null; }
         };
 
-        assertThat(statusIndicator.status().getStatusRating()).isEqualTo(Rating.Failed.value());
+        final Status status = statusIndicator.status(1);
+        assertThat(status.getStatusRating()).isEqualTo(Rating.Failed.value());
+        assertThat(status.getDetails().get("error")).isEqualTo("test error");
+    }
+
+    @Test
+    public void itShouldCheckLevel() {
+        final AbstractStatusIndicator statusIndicator = new AbstractStatusIndicator() {
+            @Override protected void doStatusCheck(final Status.Builder builder, final int level) { }
+            @Override protected boolean doLevelCheck(final int level) { return false; }
+            @Override public String name() { return null; }
+        };
+
+        assertThat(statusIndicator.status(1)).isNull();
+    }
+
+    @Test
+    public void itShouldAddResponseTimeDetail() {
+        final AbstractStatusIndicator statusIndicator = new AbstractStatusIndicator() {
+            @Override protected void doStatusCheck(final Status.Builder builder, final int level) {
+                responseTime(builder, 200, () -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                    }
+                    return null;
+                });
+            }
+            @Override protected boolean doLevelCheck(final int level) { return true; }
+            @Override public String name() { return null; }
+        };
+
+        assertThat(statusIndicator.status(1).getDetails().get("responseTime")).isNotNull();
+    }
+
+    @Test
+    public void itShouldAddDegradedResponseTimeDetail() {
+        final AbstractStatusIndicator statusIndicator = new AbstractStatusIndicator() {
+            @Override protected void doStatusCheck(final Status.Builder builder, final int level) {
+                responseTime(builder, 10, () -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                    }
+                    return null;
+                });
+            }
+            @Override protected boolean doLevelCheck(final int level) { return true; }
+            @Override public String name() { return null; }
+        };
+
+        assertThat(statusIndicator.status(1).getStatusRating()).isEqualTo(Rating.Degraded.value());
     }
 }

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/status/LocalSystemStatusIndicatorTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/status/LocalSystemStatusIndicatorTest.java
@@ -23,8 +23,13 @@ public class LocalSystemStatusIndicatorTest {
     }
 
     @Test
-    public void itShouldProduceStatus() {
-        final Status status = statusIndicator.status();
+    public void itShouldNotProduceStatusForLevel0() {
+        assertThat(statusIndicator.status(0)).isNull();
+    }
+
+    @Test
+    public void itShouldProduceStatusForLevel1() {
+        final Status status = statusIndicator.status(1);
 
         // spot check a couple values
         assertThat(status.getStatusRating()).isEqualTo(Rating.Ideal.value());

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepository.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepository.java
@@ -10,6 +10,13 @@ import java.util.List;
  */
 public interface RdwImportRepository {
 
+    /**
+     * Create a new import record. This ignores any id on the import object; the returned
+     * object will have a newly assigned id.
+     *
+     * @param rdwImport import object to save
+     * @return newly saved import object
+     */
     RdwImport create(RdwImport rdwImport);
 
     RdwImport findOne(long id);
@@ -23,4 +30,15 @@ public interface RdwImportRepository {
     boolean exists(long id);
 
     long count();
+
+    void delete(long id);
+
+    /**
+     * Return the list of import statuses defined in the system.
+     * This list should not change except perhaps during software upgrades.
+     * This method is provided mostly as a diagnostic hook.
+     *
+     * @return list of import statuses
+     */
+    List<ImportStatus> findAllStatuses();
 }

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryImpl.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryImpl.java
@@ -36,6 +36,9 @@ class RdwImportRepositoryImpl implements RdwImportRepository {
     @Value("${sql.import.create}")
     private String sqlImportCreate;
 
+    @Value("${sql.import.delete}")
+    private String sqlImportDelete;
+
     @Value("${sql.import.exists}")
     private String sqlImportExists;
 
@@ -50,6 +53,9 @@ class RdwImportRepositoryImpl implements RdwImportRepository {
 
     @Value("${sql.import.findOneByDigest}")
     private String sqlImportFindOneByDigest;
+
+    @Value("${sql.importStatus.findAll}")
+    private String sqlImportStatusFindAll;
 
     @Autowired
     RdwImportRepositoryImpl(final NamedParameterJdbcTemplate jdbcTemplate) {
@@ -125,6 +131,27 @@ class RdwImportRepositoryImpl implements RdwImportRepository {
     @Override
     public long count() {
         return jdbcTemplate.getJdbcOperations().queryForObject(sqlImportCount, Long.class);
+    }
+
+    @Override
+    public void delete(final long id) {
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource().addValue("id", id);
+        jdbcTemplate.update(sqlImportDelete, parameterSource);
+    }
+
+    @Override
+    public List<ImportStatus> findAllStatuses() {
+        try {
+            return jdbcTemplate.query(sqlImportStatusFindAll, (rs, rowNum) -> {
+                final ImportStatus status = ImportStatus.fromValue(rs.getInt("id"));
+                if (!status.name().equals(rs.getString("name"))) {
+                    throw new IllegalStateException("Bad ImportStatus name " + rs.getString("name"));
+                }
+                return status;
+            });
+        } catch (final EmptyResultDataAccessException ignored) {
+            return newArrayList();
+        }
     }
 
     private static class RdwImportRowMapper implements RowMapper<RdwImport> {

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/status/DatabaseStatusIndicator.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/status/DatabaseStatusIndicator.java
@@ -1,0 +1,76 @@
+package org.opentestsystem.rdw.ingest.status;
+
+import org.opentestsystem.rdw.ingest.model.ImportContent;
+import org.opentestsystem.rdw.ingest.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.model.RdwImport;
+import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * A {@link StatusIndicator} for database status.
+ * <p>
+ * Slightly different than web diagnostic spec this add "databaseOperations",
+ * each being a Status with "schema", "type" (READ/WRITE), and "responseTime".
+ * </p>
+ */
+@Component
+public class DatabaseStatusIndicator extends AbstractStatusIndicator {
+
+    private final RdwImportRepository repository;
+
+    @Autowired
+    public DatabaseStatusIndicator(final RdwImportRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public String name() {
+        return "database";
+    }
+
+    @Override
+    protected boolean doLevelCheck(final int level) {
+        return level >= 3;
+    }
+
+    @Override
+    protected void doStatusCheck(final Status.Builder builder, final int level) {
+        final List<Status> databaseOperations = newArrayList();
+
+        // import, READ
+        if (level >= 3) {
+            final Status.Builder opBuilder = Status.builder().detail("schema", "import").detail("type", "READ");
+            final List<ImportStatus> importStatuses = responseTime(opBuilder, 50, repository::findAllStatuses);
+            if (importStatuses.size() != ImportStatus.values().length) {
+                opBuilder.rating(Rating.Warning);
+                opBuilder.detail("error", "import_status table not loaded properly");
+            }
+            databaseOperations.add(opBuilder.build());
+        }
+
+        // import, WRITE
+        if (level >= 4) {
+            final Status.Builder opBuilder = Status.builder().detail("schema", "import").detail("type", "WRITE");
+            final RdwImport rdwImport = responseTime(opBuilder, 200, () ->
+                repository.create(RdwImport.builder()
+                    .content(ImportContent.PROBE)
+                    .contentType("text/plain+probe")
+                    .digest("probe")
+                    .status(ImportStatus.INVALID)
+                    .build()));
+            if (rdwImport.getId() == null) {
+                opBuilder.rating(Rating.Warning);
+            } else {
+                repository.delete(rdwImport.getId());
+            }
+            databaseOperations.add(opBuilder.build());
+        }
+
+        builder.detail("databaseOperations", databaseOperations);
+    }
+}

--- a/exam-service/src/main/java/org/opentestsystem/rdw/ingest/status/ProvidersIndicator.java
+++ b/exam-service/src/main/java/org/opentestsystem/rdw/ingest/status/ProvidersIndicator.java
@@ -22,17 +22,17 @@ public class ProvidersIndicator extends AbstractStatusIndicator {
     }
 
     @Override
-    public int level() {
-        return 5;
-    }
-
-    @Override
     public String name() {
         return "providers";
     }
 
     @Override
-    protected void doStatusCheck(final Status.Builder builder) {
+    protected boolean doLevelCheck(final int level) {
+        return level >= 5;
+    }
+
+    @Override
+    protected void doStatusCheck(final Status.Builder builder, final int level) {
         // TODO - set overall Rating based on providers ratings
         // TODO - add RabbitMQ, ConfigServer?
         builder.detail("statuses", newArrayList(getAuthenticationProviderStatus()));

--- a/exam-service/src/main/resources/application.sql.yml
+++ b/exam-service/src/main/resources/application.sql.yml
@@ -7,6 +7,9 @@ sql:
       INSERT INTO import (status, content, contentType, digest, batch, creator, created, message)
         VALUES (:status, :content, :contentType, :digest, :batch, :creator, :created, :message)
 
+    delete: >-
+      DELETE FROM import WHERE id=:id
+
     exists: >-
       SELECT (CASE WHEN EXISTS (SELECT 1 FROM import WHERE id=:id) THEN true ELSE false END) exist
 
@@ -21,3 +24,7 @@ sql:
 
     findOneByDigest: >-
       SELECT * FROM import WHERE digest=:digest
+
+  importStatus:
+    findAll: >-
+      SELECT * FROM import_status

--- a/exam-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/exam-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -55,6 +55,14 @@ public class RdwImportRepositoryIT {
         assertThat(repository.findByStatus(ImportStatus.ACCEPTED)).hasSize(initialCount+3);
     }
 
+    @Test
+    public void itShouldDelete() {
+        final Map<String, Long> map = createTestData();
+        final long count = repository.count();
+        repository.delete(map.get("alice"));
+        assertThat(repository.count()).isEqualTo(count-1);
+    }
+
     private Map<String, Long> createTestData() {
         final RdwImport.Builder builder = RdwImport.builder()
                 .status(ImportStatus.ACCEPTED)


### PR DESCRIPTION
A sample of the response:
```
  "database": {
    "statusText": "Ideal",
    "statusRating": 4,
    "databaseOperations": [
      {
        "statusText": "Ideal",
        "statusRating": 4,
        "schema": "import",
        "responseTime": "2ms",
        "type": "READ"
      },
      {
        "statusText": "Ideal",
        "statusRating": 4,
        "schema": "import",
        "responseTime": "7ms",
        "type": "WRITE"
      }
    ]
  },
```