### PR TITLE
add aliases for examinee attribute/relationship field names

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
@@ -1,7 +1,5 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
-import java.util.Date;
-import java.util.List;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.processor.model.District;
@@ -22,9 +20,14 @@ import org.opentestsystem.rdw.model.Examinee.ExamineeRelationship;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
 import static com.google.common.base.Joiner.on;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
 import static org.opentestsystem.rdw.ingest.processor.utils.ParseUtil.parseMandatoryBoolean;
 import static org.opentestsystem.rdw.ingest.processor.utils.ParseUtil.parseMandatoryDate;
 import static org.opentestsystem.rdw.ingest.processor.utils.ParseUtil.parseMandatoryString;
@@ -87,11 +90,11 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         final Builder schoolBuilder = School.builder()
                 .district(District.builder()
                         .stateCode(parseMandatoryRelationship(examinee, "StateAbbreviation", elementErrors))
-                        .naturalId(parseMandatoryRelationship(examinee, "ResponsibleDistrictIdentifier", elementErrors))
-                        .name(parseMandatoryRelationship(examinee, "OrganizationName", elementErrors))
+                        .naturalId(parseMandatoryRelationship(examinee, "DistrictId", elementErrors))
+                        .name(parseMandatoryRelationship(examinee, "DistrictName", elementErrors))
                         .build())
-                .naturalId(parseMandatoryRelationship(examinee, "ResponsibleInstitutionIdentifier", elementErrors))
-                .name(parseMandatoryRelationship(examinee, "NameOfInstitution", elementErrors));
+                .naturalId(parseMandatoryRelationship(examinee, "SchoolId", elementErrors))
+                .name(parseMandatoryRelationship(examinee, "SchoolName", elementErrors));
 
         if (elementErrors.isEmpty()) return schoolBuilder.build();
         throw new ImportException(ImportStatus.BAD_DATA, on(",").join(elementErrors));
@@ -162,10 +165,31 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         }
     }
 
+    /**
+     * Map of aliases for TRT attribute field names. The key is the documented TRT attribute field name,
+     * while the value is an alternate name, typically from the DWSA (the CSV import file) spec.
+     * These will be used when looking for attribute values; for now for efficiency, just string attributes.
+     * Although it is unlikely that multiple entries will exist with different names, if that happens the
+     * TRT-named attribute value will be favored.
+     */
+    private static Map<String, String> FieldAliases = newHashMap();
+    static {
+        FieldAliases.put("StudentIdentifier", "SSID");
+        FieldAliases.put("AlternateSSID", "ExternalSSID");
+        FieldAliases.put("GradeLevelWhenAssessed", "Grade");
+        FieldAliases.put("DistrictId", "ResponsibleDistrictIdentifier");
+        FieldAliases.put("DistrictName", "OrganizationName");
+        FieldAliases.put("SchoolId", "ResponsibleInstitutionIdentifier");
+        FieldAliases.put("SchoolName", "NameOfInstitution");
+    };
+
     private static String parseMandatoryStringAttribute(final Examinee examinee,
                                                         final String element,
                                                         final List<String> elementErrors) {
-        final ExamineeAttribute attribute = examinee.getBestAttribute(element);
+        ExamineeAttribute attribute = examinee.getBestAttribute(element);
+        if (attribute == null && FieldAliases.containsKey(element)) {
+            attribute = examinee.getBestAttribute(FieldAliases.get(element));
+        }
 
         if (attribute != null) return parseMandatoryString(attribute.getValue(), element, elementErrors);
 
@@ -209,7 +233,10 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
     private static String parseOptionalStringAttribute(final Examinee examinee,
                                                        final String element,
                                                        final List<String> elementErrors) {
-        final ExamineeAttribute attribute = examinee.getBestAttribute(element);
+        ExamineeAttribute attribute = examinee.getBestAttribute(element);
+        if (attribute == null && FieldAliases.containsKey(element)) {
+            attribute = examinee.getBestAttribute(FieldAliases.get(element));
+        }
 
         if (attribute == null || isNullOrEmpty(attribute.getValue())) return null;
 
@@ -229,7 +256,10 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
     private static String parseMandatoryRelationship(final Examinee examinee,
                                                      final String element,
                                                      final List<String> elementErrors) {
-        final ExamineeRelationship attribute = examinee.getBestRelationship(element);
+        ExamineeRelationship attribute = examinee.getBestRelationship(element);
+        if (attribute == null && FieldAliases.containsKey(element)) {
+            attribute = examinee.getBestRelationship(FieldAliases.get(element));
+        }
 
         if (attribute != null) return parseMandatoryString(attribute.getValue(), element, elementErrors);
 

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
@@ -70,10 +70,10 @@ public class DefaultExamineeProcessorIT {
 
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"elementName\":\"StateAbbreviation\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"ResponsibleDistrictIdentifier\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"OrganizationName\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"ResponsibleInstitutionIdentifier\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"NameOfInstitution\",\"value\":\"\",\"error\":\"value may not be blank\"}");
+                    "{\"elementName\":\"DistrictId\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
+                    "{\"elementName\":\"DistrictName\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
+                    "{\"elementName\":\"SchoolId\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
+                    "{\"elementName\":\"SchoolName\",\"value\":\"\",\"error\":\"value may not be blank\"}");
         }
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
@@ -12,10 +12,13 @@ import org.opentestsystem.rdw.utils.TenancyChain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
@@ -86,4 +89,24 @@ public class DefaultTDSReportProcessorIT {
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/" + "TDSReport.iab.sample.xml"));
         processor.process(tdsReport, TenancyChain.fromString("|AP|ASMTDATALOAD|STATE|||||NA|ARMED FORCES PACIFIC|||||||||"));
     }
+
+//    // this is a test that loads external TDSReports that can't be checked in with source
+//    @Test
+//    public void testExternalReports() throws FileNotFoundException {
+//        // need to tweak this to match state in external reports
+//        final TenancyChain tenancyChain = TenancyChain.fromString("||ASMTDATALOAD|STATE|||||CA||||||||||");
+//
+//        final File srcdir = new File("/Users/marklaffoon/git/rdw_datagenerator/out");
+//        for (final File file : srcdir.listFiles((dir, name) -> name.endsWith(".xml"))) {
+//            System.out.println("PROCESSING " + file.getAbsolutePath());
+//            try {
+//                final TDSReport tdsReport = XmlUtils.tdsReportFromXml(new FileInputStream(file));
+//                processor.process(tdsReport, tenancyChain);
+//                System.out.println("   TDSReport: " + XmlUtils.tdsReportToXml(tdsReport).substring(0, 80));
+//            } catch (final Exception e) {
+//                System.out.println("   Exception: " + e.getMessage());
+//                throw e;
+//            }
+//        }
+//    }
 }


### PR DESCRIPTION
The SBAC data model has at least three different sets of field names. To be a bit more forgiving, this adds aliases for a few critical fields.