### PR TITLE
make tenancy chains more correct

### DIFF
--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
@@ -87,7 +87,7 @@ public class DefaultTDSReportProcessorIT {
     public void itShouldNotProcessForUnauthorized() {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/" + "TDSReport.iab.sample.xml"));
-        processor.process(tdsReport, TenancyChain.fromString("|AP|ASMTDATALOAD|STATE|||||NA|ARMED FORCES PACIFIC|||||||||"));
+        processor.process(tdsReport, TenancyChain.fromString("|NA|ASMTDATALOAD|STATE|||||NA|ARMED FORCES PACIFIC|||||||||"));
     }
 
 //    // this is a test that loads external TDSReports that can't be checked in with source

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/RdwUserTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/RdwUserTest.java
@@ -13,7 +13,7 @@ public class RdwUserTest {
     public static RdwUser testUser() {
         final RdwUser.Essence essence = new RdwUser.Essence("test@example.com", "password",
                 Lists.newArrayList(new SimpleGrantedAuthority("ASMTDATALOAD")),
-                TenancyChain.fromString("||ASMTDATALOAD|||SBAC|||||||||||||"));
+                TenancyChain.fromString("|SBAC|ASMTDATALOAD|CLIENT|SBAC||||||||||||||"));
         essence.setDn("sbacUUID=57e3ed3de4b0e3b75702f3a0,ou=People,dc=smarterbalanced,dc=org");
         essence.addCn("Test");
         essence.setSn("Test");
@@ -24,6 +24,6 @@ public class RdwUserTest {
     public void itShouldPreserveConstructorValues() {
         final RdwUser user = testUser();
         assertThat(user.getUsername()).isEqualTo("test@example.com");
-        assertThat(user.getTenancyChain().toString()).isEqualTo("||ASMTDATALOAD|||SBAC|||||||||||||");
+        assertThat(user.getTenancyChain().toString()).isEqualTo("|SBAC|ASMTDATALOAD|CLIENT|SBAC||||||||||||||");
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/WithMockRdwUser.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/WithMockRdwUser.java
@@ -14,5 +14,5 @@ public @interface WithMockRdwUser {
     String username() default "test@example.com";
     String[] authorities() default { "ASMTDATALOAD" };
     String password() default "password";
-    String tenancyChain() default "||ASMTDATALOAD|||SBAC|||||||||||||";
+    String tenancyChain() default "|SBAC|ASMTDATALOAD|CLIENT|SBAC||||||||||||||";
 }


### PR DESCRIPTION
Based on clarifications from Landon, this makes the tenancy chains more correct, with the entityId matching the level. This is in anticipation of consolidation of the helper classes some time in the future.