### PR TITLE
Adding a configuration for cloud settings in import-service to fix running integration tests

### DIFF
--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ cloud:
     region:
       auto: false
       static: us-west-2
+    stack:
+      auto: false
 
 spring:
   datasource:


### PR DESCRIPTION

Due to an automatic configuration of spring cloud when running on an ec2 instance, we have to disable the auto stack otherwise we get a 'stack does not exist (Service: AmazonCloudFormation; Status Code: 400;...' error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/smarterapp/rdw_ingest/96)
<!-- Reviewable:end -->
