### PR TITLE
reduce number of connections in pool

### DIFF
--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -22,3 +22,6 @@ spring:
     validationQuery: SELECT 1
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
+    maxActive: 20
+    initialSize: 4
+    maxWait: 10000

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -26,6 +26,9 @@ spring:
     validationQuery: SELECT 1
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
+    maxActive: 20
+    initialSize: 4
+    maxWait: 10000
 
   jackson:
     default-property-inclusion: non_null

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
     validationQuery: SELECT 1
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
+    maxActive: 20
+    initialSize: 4
+    maxWait: 10000
 
   jackson:
     default-property-inclusion: non_null


### PR DESCRIPTION
After my Aurora experiments i felt that these services do not need a big pool of connections lying around. They aren't really web services (yeah, they have API end-points but their primary use case is not serving thousands of users). They don't spawn tons of worker threads; parallelization will happen via multiple instances of the apps, not internal threading.

The default values for pool are 10/100 (initial:10, max:100). To get the absolute optimum settings we'll need to monitor the apps under production-like pressure.

Thoughts?