### PR TITLE
add resubmit hook

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -7,14 +7,18 @@ import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
+import org.opentestsystem.rdw.utils.TenancyChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+
+import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * Default implementation of ImportService
@@ -22,6 +26,10 @@ import java.util.Properties;
 @Service
 class DefaultImportService implements ImportService {
     private static final Logger logger = LoggerFactory.getLogger(DefaultImportService.class);
+
+    private static final String ContentTypeProperty = "content-type";
+    private static final String UsernameProperty = "username";
+    private static final String TenancyChainProperty = "tenancy-chain";
 
     private final RdwImportRepository repository;
     private final ArchiveService archiveService;
@@ -48,8 +56,9 @@ class DefaultImportService implements ImportService {
 
         final String location = new LocationStrategy.ImportContentLocationStrategy(content).location(digest);
         final Properties properties = new Properties();
-        properties.setProperty("content-type", contentType);
-        properties.setProperty("username", user.getUsername());
+        properties.setProperty(ContentTypeProperty, contentType);
+        properties.setProperty(UsernameProperty, user.getUsername());
+        properties.setProperty(TenancyChainProperty, user.getTenancyChain().toString());
         if (batch != null) {
             properties.setProperty("batch", batch);
         }
@@ -64,10 +73,7 @@ class DefaultImportService implements ImportService {
                 .batch(batch)
                 .build());
 
-        // TODO - do something about this hole?
-        // TODO   i.e. what to do with import record if submitContent fails?
-
-        source.submitContent(user, payload, content, contentType, rdwImport.getId());
+        source.submitContent(user.getUsername(), user.getTenancyChain(), payload, content, contentType, rdwImport.getId());
 
         return rdwImport;
     }
@@ -80,5 +86,37 @@ class DefaultImportService implements ImportService {
     @Override
     public List<RdwImport> getImports(final RdwImportQuery query) {
         return repository.findBy(query);
+    }
+
+    @Override
+    public long resubmitImports(RdwImportQuery query) {
+        // if there is no query, resort to some reasonable default
+        if (query == null || query.isEmpty()) {
+            query = RdwImportQuery.builder()
+                    .status(ImportStatus.ACCEPTED)
+                    .after("-PT24H")
+                    .before("-PT1H")
+                    .build();
+        }
+        final Map<String, TenancyChain> userTenancyChains = newHashMap();
+        long count = 0;
+        for (final RdwImport rdwImport : repository.findBy(query)) {
+            final ImportContent content = rdwImport.getContent();
+            final String location = new LocationStrategy.ImportContentLocationStrategy(content).location(rdwImport.getDigest());
+
+            final String payload = archiveService.readResource(location);
+
+            final Properties properties = archiveService.readProperties(location);
+            final String contentType = properties.getProperty(ContentTypeProperty);
+            final String username = properties.getProperty(UsernameProperty);
+            // TODO - fetch current tenancy chain for user from authz service
+            // TODO   skipping for now because authz is changing Real Soon Now ...
+            final TenancyChain tenancyChain = userTenancyChains.computeIfAbsent(username, k ->
+                    TenancyChain.fromString(properties.getProperty(TenancyChainProperty)));
+
+            source.submitContent(username, tenancyChain, payload, content, contentType, rdwImport.getId());
+            ++count;
+        }
+        return count;
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.ingest.service;
 import org.opentestsystem.rdw.ingest.auth.RdwUser;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
+import org.opentestsystem.rdw.utils.TenancyChain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -43,12 +44,17 @@ class DefaultImportSource implements ImportSource {
     }
 
     @Override
-    public void submitContent(final RdwUser user, final String body, final ImportContent content, final String contentType, final Long importId) {
+    public void submitContent(final String username,
+                              final TenancyChain tenancyChain,
+                              final String body,
+                              final ImportContent content,
+                              final String contentType,
+                              final Long importId) {
         final RdwMessageHeaderAccessor accessor = wrap(null)
                 .setReceivedNow()
                 .setContent(content.toString())
-                .setUserLogin(user.getUsername())
-                .setUserTenancyChain(user.getTenancyChain().toString())
+                .setUserLogin(username)
+                .setUserTenancyChain(tenancyChain.toString())
                 .setContentType(contentType)
                 .setImportId(importId);
         outputChannel.send(MessageBuilder.createMessage(body, accessor.getMessageHeaders()));

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
@@ -19,8 +19,9 @@ public interface ImportService {
      * @param user user credentials
      * @param payload payload to process
      * @param content import content
-     *@param contentType content type, e.g. application/xml
-     * @param batch optional batch label   @return newly created import resource
+     * @param contentType content type, e.g. application/xml
+     * @param batch optional batch label
+     * @return newly created import resource
      */
     RdwImport importContent(RdwUser user, String payload, final ImportContent content, String contentType, String batch);
 
@@ -37,4 +38,13 @@ public interface ImportService {
      * @return list of imports matching criteria; may be empty, won't be null
      */
     List<RdwImport> getImports(RdwImportQuery query);
+
+    /**
+     * Using archived content, resubmit all the imports matching the query. For each import this
+     * will push a message onto the message queue with the original content and user credentials.
+     *
+     * @param query query parameters
+     * @return number of imports resubmitted
+     */
+    long resubmitImports(RdwImportQuery query);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportSource.java
@@ -1,7 +1,7 @@
 package org.opentestsystem.rdw.ingest.service;
 
-import org.opentestsystem.rdw.ingest.auth.RdwUser;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.utils.TenancyChain;
 
 /**
  * Abstraction for injecting a payload into the message queue.
@@ -11,11 +11,12 @@ interface ImportSource {
     /**
      * Submit the given payload to the appropriate queue, based on content.
      *
-     * @param user user credentials
+     * @param username username
+     * @param tenancyChain user tenancy chain
      * @param body content body
      * @param content {@link ImportContent}
      * @param contentType content media type of body, e.g. "text/plain"
      * @param importId id of import resource associated with this content
      */
-    void submitContent(RdwUser user, String body, final ImportContent content, String contentType, final Long importId);
+    void submitContent(String username, TenancyChain tenancyChain, String body, ImportContent content, String contentType, Long importId);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.ingest.web;
 
 import org.opentestsystem.rdw.ingest.auth.RdwUser;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.service.ImportService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +67,7 @@ class ExamController {
         if (query.isEmpty()) {
             throw new IllegalArgumentException("at least one query parameter must be specified");
         }
-        return assembler.toResources(service.getImports(query.copy().content(ImportContent.EXAM).build()));
+        return assembler.toResources(service.getImports(ensureExamQuery(query)));
     }
 
     @GetMapping(value="/imports", headers="Accept=text/csv")
@@ -78,7 +79,7 @@ class ExamController {
         }
 
         RdwImportCsv csv = new RdwImportCsv();
-        csv.setRdwImports(service.getImports(query.copy().content(ImportContent.EXAM).build()));
+        csv.setRdwImports(service.getImports(ensureExamQuery(query)));
 
         return csv;
     }
@@ -88,5 +89,18 @@ class ExamController {
     public ResponseEntity<String> getImportsReport(@PathVariable final String group,
                                                    final RdwImportQuery query) {
         return ResponseEntity.ok("report exam imports by " + group + " with query " + query.asParamString());
+    }
+
+    @PostMapping("/imports/resubmit")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ResponseEntity<Long> resubmitImports(final RdwImportQuery query) {
+        // if query is empty, force to be ACCEPTED
+        return ResponseEntity.ok(service.resubmitImports(query.isEmpty() ?
+                RdwImportQuery.builder().content(ImportContent.EXAM).status(ImportStatus.ACCEPTED).build() :
+                ensureExamQuery(query)));
+    }
+
+    private static RdwImportQuery ensureExamQuery(final RdwImportQuery query) {
+        return ImportContent.EXAM == query.getContent() ? query : query.copy().content(ImportContent.EXAM).build();
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
@@ -67,7 +67,7 @@ class ExamController {
         if (query.isEmpty()) {
             throw new IllegalArgumentException("at least one query parameter must be specified");
         }
-        return assembler.toResources(service.getImports(ensureExamQuery(query)));
+        return assembler.toResources(service.getImports(ensureQueryForExam(query)));
     }
 
     @GetMapping(value="/imports", headers="Accept=text/csv")
@@ -79,7 +79,7 @@ class ExamController {
         }
 
         RdwImportCsv csv = new RdwImportCsv();
-        csv.setRdwImports(service.getImports(ensureExamQuery(query)));
+        csv.setRdwImports(service.getImports(ensureQueryForExam(query)));
 
         return csv;
     }
@@ -97,10 +97,10 @@ class ExamController {
         // if query is empty, force to be ACCEPTED
         return ResponseEntity.ok(service.resubmitImports(query.isEmpty() ?
                 RdwImportQuery.builder().content(ImportContent.EXAM).status(ImportStatus.ACCEPTED).build() :
-                ensureExamQuery(query)));
+                ensureQueryForExam(query)));
     }
 
-    private static RdwImportQuery ensureExamQuery(final RdwImportQuery query) {
+    private static RdwImportQuery ensureQueryForExam(final RdwImportQuery query) {
         return ImportContent.EXAM == query.getContent() ? query : query.copy().content(ImportContent.EXAM).build();
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
@@ -3,18 +3,23 @@ package org.opentestsystem.rdw.ingest.service;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.ingest.auth.RdwUser;
 import org.opentestsystem.rdw.ingest.auth.RdwUserTest;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
+import org.opentestsystem.rdw.utils.TenancyChain;
 
 import java.util.List;
+import java.util.Properties;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,7 +54,7 @@ public class DefaultImportServiceTest {
 
         assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, batch).getBatch()).isEqualTo(batch);
 
-        verify(importSource).submitContent(user, body, ImportContent.EXAM, contentType, 123L);
+        verify(importSource).submitContent(user.getUsername(), user.getTenancyChain(), body, ImportContent.EXAM, contentType, 123L);
     }
 
     @Test
@@ -77,5 +82,47 @@ public class DefaultImportServiceTest {
         when(repository.findBy(query)).thenReturn(results);
 
         assertThat(service.getImports(query)).isSameAs(results);
+    }
+
+    @Test
+    public void itShouldResubmitImports() {
+        final RdwImportQuery query = RdwImportQuery.builder().status(ImportStatus.ACCEPTED).build();
+        final RdwImport rdwImport = RdwImport.builder()
+                .id(123L)
+                .content(ImportContent.EXAM)
+                .digest("12345678")
+                .build();
+        final String username = "alice";
+        final String contentType = "text/plain";
+        final TenancyChain tenancyChain = TenancyChain.fromString("|SBAC|ASMTDATALOAD|CLIENT|SBAC||||||||||||||");
+        final List<RdwImport> rdwImports = newArrayList(rdwImport);
+
+        final Properties properties = new Properties();
+        properties.setProperty("username", username);
+        properties.setProperty("content-type", contentType);
+        properties.setProperty("tenancy-chain", tenancyChain.toString());
+
+        when(repository.findBy(query)).thenReturn(rdwImports);
+        final String location = "EXAM/12/34/12345678";
+        when(archiveService.readResource(location)).thenReturn("payload");
+        when(archiveService.readProperties(location)).thenReturn(properties);
+
+        assertThat(service.resubmitImports(query)).isEqualTo(1);
+
+        verify(importSource).submitContent(eq(username), eq(tenancyChain), eq("payload"), eq(ImportContent.EXAM), eq(contentType), eq(123L));
+    }
+
+    @Test
+    public void itShouldCreateADefaultQueryForResubmit() {
+        when(repository.findBy(any(RdwImportQuery.class))).thenReturn(newArrayList());
+
+        assertThat(service.resubmitImports(RdwImportQuery.builder().build())).isEqualTo(0);
+
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(repository).findBy(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
+        assertThat(query.getAfter()).isNotNull();
+        assertThat(query.getBefore()).isNotNull();
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportSourceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportSourceTest.java
@@ -37,7 +37,7 @@ public class DefaultImportSourceTest {
         final String body = "<TDSReport/>";
         final long importId = 123L;
 
-        importSource.submitContent(user, body, ImportContent.EXAM, "application/xml", importId);
+        importSource.submitContent(user.getUsername(), user.getTenancyChain(), body, ImportContent.EXAM, "application/xml", importId);
 
         ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
         verify(channel).send(messageArgumentCaptor.capture());

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerTest.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.ingest.auth.WithMockRdwUser;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
@@ -20,12 +21,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Optional;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -115,6 +119,32 @@ public class ExamControllerTest {
     public void itShouldReturn4xxWhenNoCriteria() throws Exception {
         mvc.perform(get("exams/imports"))
                 .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void itShouldResubmitImports() throws Exception {
+        given(importService.resubmitImports(any(RdwImportQuery.class))).willReturn(1L);
+        mvc.perform(post("/exams/imports/resubmit").param("status", "BAD_DATA"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(importService).resubmitImports(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
+    }
+
+    @Test
+    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
+        given(importService.resubmitImports(any(RdwImportQuery.class))).willReturn(1L);
+        mvc.perform(post("/exams/imports/resubmit"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(importService).resubmitImports(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 
     private RdwImport testImport(final long id) {


### PR DESCRIPTION
This is just a quick change so i can easily resubmit imports that get stuck in ACCEPTED state. That will (currently) happen under two conditions (both will be fixed but for now...):
1. There are no processors running so the rabbit queue has not been created
2. A processor was brought online with items in the queue; it seems to grab a couple and do nothing with them.

This hook can also be used to resubmit in the future when exams are "parked" because the assessment packages aren't available yet. 