### PR TITLE
producer

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
@@ -22,7 +22,10 @@ import java.util.List;
 import static org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor.wrap;
 
 /**
- * Default implementation of ImportSource
+ * Default implementation of ImportSource.
+ * <p>
+ * It dynamically routes messages based on the content, e.g. EXAM, PACKAGE.
+ * </p>
  */
 @Service
 @EnableBinding

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -18,6 +18,21 @@ cloud:
       instance-profile: false
 
 spring:
+  # Force the (rabbit) queues to be created when posting messages so, even if
+  # there are no consumers running, the messages will not get lost. Routing is
+  # dynamic based on content but there is no way to do that here so we must
+  # explicitly declare all possible output channels here (EXAM, PACKAGE, etc.).
+  # The group names must be coordinated with the consumer application configs.
+  cloud:
+    stream:
+      bindings:
+        EXAM:
+          producer:
+            requiredGroups: default
+        PACKAGE:
+          producer:
+            requiredGroups: default
+
   datasource:
     url: jdbc:mysql://localhost:3306/warehouse?useSSL=false
     username: root


### PR DESCRIPTION
This change will force the (rabbit) durable queues to be created when messages are posted instead of waiting for a consumer to come online. Upshot is no more lost messages due to a lack of running consumers.