### PR TITLE
Added import_id to support migrate.

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/model/Student.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/model/Student.java
@@ -1,7 +1,7 @@
 package org.opentestsystem.rdw.ingest.processor.model;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import javax.validation.constraints.Null;
 
@@ -21,12 +21,12 @@ public class Student {
     private String ssid;
 
     @Null
-    private Date firsEntryIntoUSSchoolAt;
+    private LocalDate firsEntryIntoUSSchoolAt;
     @Null
-    private Date lepEntryAt;
+    private LocalDate lepEntryAt;
     @Null
-    private Date lepExitAt;
-    private Date birthday;
+    private LocalDate lepExitAt;
+    private LocalDate birthday;
 
     public String getSsid() {
         return ssid;
@@ -52,19 +52,19 @@ public class Student {
         return ethnicityIds == null ? newArrayList() : ethnicityIds;
     }
 
-    public Date getFirsEntryIntoUSSchoolAt() {
+    public LocalDate getFirsEntryIntoUSSchoolAt() {
         return firsEntryIntoUSSchoolAt;
     }
 
-    public Date getLepEntryAt() {
+    public LocalDate getLepEntryAt() {
         return lepEntryAt;
     }
 
-    public Date getLepExitAt() {
+    public LocalDate getLepExitAt() {
         return lepExitAt;
     }
 
-    public Date getBirthday() {
+    public LocalDate getBirthday() {
         return birthday;
     }
 
@@ -82,10 +82,10 @@ public class Student {
         private String middleName;
         private Integer genderId;
         private List<Integer> ethnicityIds = newArrayList();
-        private Date firsEntryIntoUSSchoolAt;
-        private Date lepEntryAt;
-        private Date lepExitAt;
-        private Date birthday;
+        private LocalDate firsEntryIntoUSSchoolAt;
+        private LocalDate lepEntryAt;
+        private LocalDate lepExitAt;
+        private LocalDate birthday;
 
         public Student build() {
             checkArgument(genderId != null, "genderId may not be null");
@@ -134,22 +134,22 @@ public class Student {
             return this;
         }
 
-        public Builder firsEntryIntoUSSchoolAt(final Date firsEntryIntoUSSchoolAt) {
+        public Builder firsEntryIntoUSSchoolAt(final LocalDate firsEntryIntoUSSchoolAt) {
             this.firsEntryIntoUSSchoolAt = firsEntryIntoUSSchoolAt;
             return this;
         }
 
-        public Builder lepEntryAt(final Date lepEntryAt) {
+        public Builder lepEntryAt(final LocalDate lepEntryAt) {
             this.lepEntryAt = lepEntryAt;
             return this;
         }
 
-        public Builder lepExitAt(final Date lepExitAt) {
+        public Builder lepExitAt(final LocalDate lepExitAt) {
             this.lepExitAt = lepExitAt;
             return this;
         }
 
-        public Builder birthday(final Date birthday) {
+        public Builder birthday(final LocalDate birthday) {
             this.birthday = birthday;
             return this;
         }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/SchoolRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/SchoolRepository.java
@@ -9,9 +9,11 @@ public interface SchoolRepository {
     /**
      * Finds a {@link School} by its natural id if one exists.
      * Otherwise creates a new one.
+     * If the given object is the same as the persisted one, its import id is not updated.
      *
-     * @param school a school to find or create
+     * @param school   a school to find or create
+     * @param importId an id of the import that is manipulating this entity
      * @return an id of the found or created school
      */
-    int upsert(School school);
+    int upsert(School school, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StudentGroupRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StudentGroupRepository.java
@@ -13,9 +13,10 @@ public interface StudentGroupRepository {
      * Save a new student group
      *
      * @param group group to save
+     * @param importId id of the import that creates the {@link StudentGroup}
      * @return newly saved group (with id set)
      */
-    StudentGroup create(StudentGroup group);
+    StudentGroup create(StudentGroup group, long importId);
 
     /**
      * Lookup a group by name and school and year, returning the id.

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StudentRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StudentRepository.java
@@ -8,10 +8,12 @@ import org.opentestsystem.rdw.ingest.processor.model.Student;
 public interface StudentRepository {
 
     /**
-     * Upsert a {@link Student}
+     * Upsert a {@link Student}.
+     * If the given object is the same as the persisted one, its import id is not updated.
      *
-     * @param student a student to create or find/update
+     * @param student  a student to create or find/update
+     * @param importId an id of the import that is manipulating this entity
      * @return an id of the updated or created student
      */
-    long upsert(Student student);
+    long upsert(Student student, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryImpl.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryImpl.java
@@ -20,13 +20,14 @@ class SchoolRepositoryImpl implements SchoolRepository {
     }
 
     @Override
-    @Cacheable(value = "school")
-    public int upsert(final School school) {
+    @Cacheable(value = "school", key = "#school")
+    public int upsert(final School school, final long importId) {
         return (int) new SimpleJdbcCall(jdbcTemplate)
                 .withProcedureName("school_upsert").execute(new MapSqlParameterSource()
                         .addValue("p_district_natural_id", school.getDistrict().getNaturalId())
                         .addValue("p_district_name", school.getDistrict().getName())
                         .addValue("p_name", school.getName())
-                        .addValue("p_natural_id", school.getNaturalId())).get("p_id");
+                        .addValue("p_natural_id", school.getNaturalId())
+                        .addValue("p_import_id", importId)).get("p_id");
     }
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentGroupRepositoryImpl.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentGroupRepositoryImpl.java
@@ -44,7 +44,7 @@ public class StudentGroupRepositoryImpl implements StudentGroupRepository {
     }
 
     @Override
-    public StudentGroup create(final StudentGroup group) {
+    public StudentGroup create(final StudentGroup group, final long importId) {
         final KeyHolder keyHolder = new GeneratedKeyHolder();
         final SqlParameterSource parameterSource = new MapSqlParameterSource()
                 .addValue("name", group.getName())
@@ -53,7 +53,8 @@ public class StudentGroupRepositoryImpl implements StudentGroupRepository {
                 .addValue("subject_id", group.getSubjectId())
                 .addValue("active", group.isActive())
                 .addValue("creator", group.getCreator())
-                .addValue("created", Timestamp.from(group.getCreated()));
+                .addValue("created", Timestamp.from(group.getCreated()))
+                .addValue("import_id", importId);
 
         jdbcTemplate.update(sqlCreate, parameterSource, keyHolder);
 
@@ -89,7 +90,6 @@ public class StudentGroupRepositoryImpl implements StudentGroupRepository {
             }
         });
     }
-
 
     private static class StudentGroupRowMapper implements RowMapper<StudentGroup> {
         @Override

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentRepositoryImpl.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcCall;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -26,6 +27,12 @@ class StudentRepositoryImpl implements StudentRepository {
     @Value("${sql.studentEthnicity.delete}")
     private String deleteStudentEthnicitySql;
 
+    @Value("${sql.studentEthnicity.findAllIds}")
+    private String findlAllStudentEthnicityIdsSql;
+
+    @Value("${sql.student.updateImportId}")
+    private String updateStudentImportIdSql;
+
     @Autowired
     StudentRepositoryImpl(final NamedParameterJdbcTemplate namedParameterJdbcTemplate, final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -33,7 +40,9 @@ class StudentRepositoryImpl implements StudentRepository {
     }
 
     @Override
-    public long upsert(final Student student) {
+    @Transactional
+    public long upsert(final Student student, final long importId) {
+
         final Long studentId = (long) new SimpleJdbcCall(jdbcTemplate)
                 .withProcedureName("student_upsert")
                 .execute(new MapSqlParameterSource()
@@ -45,22 +54,37 @@ class StudentRepositoryImpl implements StudentRepository {
                         .addValue("p_first_entry_into_us_school_at", student.getFirsEntryIntoUSSchoolAt())
                         .addValue("p_lep_entry_at", student.getLepEntryAt())
                         .addValue("p_lep_exit_at", student.getLepExitAt())
-                        .addValue("p_birthday", student.getBirthday()))
+                        .addValue("p_birthday", student.getBirthday())
+                        .addValue("p_import_id", importId))
                 .get("p_id");
 
-        updateEthnicity(student.getEthnicityIds(), studentId);
+        updateEthnicity(student.getEthnicityIds(), studentId, importId);
 
         return studentId;
     }
 
-    private void updateEthnicity(final List<Integer> ethnicity, final long studentId) {
-        namedParameterJdbcTemplate.update(deleteStudentEthnicitySql, new MapSqlParameterSource("student_id", studentId));
-        if (ethnicity.isEmpty()) return;
+    private void updateEthnicity(final List<Integer> newIds, final long studentId, final long importId) {
 
-        final List<SqlParameterSource> batchParameters = newArrayList();
-        for (int ethnicityVal : ethnicity) {
-            batchParameters.add(new MapSqlParameterSource("student_id", studentId).addValue("ethnicity_id", ethnicityVal));
+        if (!needsUpdate(newIds, studentId)) return;
+
+        namedParameterJdbcTemplate.update(deleteStudentEthnicitySql, new MapSqlParameterSource("student_id", studentId));
+        if (!newIds.isEmpty()) {
+            final List<SqlParameterSource> batchParameters = newArrayList();
+            for (int newId : newIds) {
+                batchParameters.add(new MapSqlParameterSource("student_id", studentId).addValue("ethnicity_id", newId));
+            }
+            namedParameterJdbcTemplate.batchUpdate(createStudentEthnicitySql, batchParameters.toArray(new SqlParameterSource[batchParameters.size()]));
         }
-        namedParameterJdbcTemplate.batchUpdate(createStudentEthnicitySql, batchParameters.toArray(new SqlParameterSource[batchParameters.size()]));
+        namedParameterJdbcTemplate.update(updateStudentImportIdSql, new MapSqlParameterSource("student_id", studentId).addValue("import_id", importId));
+    }
+
+    private boolean needsUpdate(final List<Integer> newIds, final long studentId) {
+        final List<Integer> existingIds = namedParameterJdbcTemplate.queryForList(findlAllStudentEthnicityIdsSql, new MapSqlParameterSource("student_id", studentId), Integer.class);
+        if (existingIds.size() != newIds.size()) return true;
+
+        for (final Integer existingId : existingIds) {
+            if (!newIds.contains(existingId)) return true;
+        }
+        return false;
     }
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/ExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/ExamineeProcessor.java
@@ -27,10 +27,11 @@ public interface ExamineeProcessor {
      * @param examinee the {@link Examinee} to be process
      * @param test the associated {@link Test}; needed for certain values
      * @param school   the {@link School}
+     * @param importId the id of the import associated with the {@link Test}
      * @return the parsed {@link StudentExamAttributes}
      * @throws ImportException
      */
-    StudentExamAttributes process(Examinee examinee, Test test, School school) throws ImportException;
+    StudentExamAttributes process(Examinee examinee, Test test, School school, long importId) throws ImportException;
 
     /**
      * Parses {@link School} from the {@link Examinee}

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
@@ -67,7 +67,7 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
     }
 
     @Override
-    public StudentExamAttributes process(final Examinee examinee, final Test test, final School school) throws ImportException {
+    public StudentExamAttributes process(final Examinee examinee, final Test test, final School school, final long importId) throws ImportException {
 
         // parse and collect all parsing issues before proceeding with other actions
         final List<String> errMsg = newArrayList();
@@ -87,8 +87,8 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
 
         if (!errMsg.isEmpty()) throw new ImportException(ImportStatus.BAD_DATA, on(",").join(errMsg));
 
-        final int schoolId = schoolRepository.upsert(school);
-        final long studentId = studentRepository.upsert(student);
+        final int schoolId = schoolRepository.upsert(school, importId);
+        final long studentId = studentRepository.upsert(student, importId);
 
         // deal with student groups: create groups if they don't already exist then add student to them
         final Set<String> groupNames = getBestGroupNames(examinee);
@@ -105,7 +105,7 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
                             .schoolYear(schoolYear)
                             .subjectId(subjectId)
                             .active(true)
-                            .build()).getId();
+                            .build(), importId).getId();
                 }
                 groupIds.add(groupId);
             }
@@ -217,6 +217,8 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         FieldAliases.put("SchoolId", "ResponsibleInstitutionIdentifier");
         FieldAliases.put("SchoolName", "NameOfInstitution");
     }
+
+    ;
 
     private static String parseMandatoryStringAttribute(final Examinee examinee,
                                                         final String element,

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
@@ -1,5 +1,9 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.opentestsystem.rdw.ingest.common.error.DataElementError;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
@@ -24,11 +28,6 @@ import org.opentestsystem.rdw.model.Examinee.ExamineeRelationship;
 import org.opentestsystem.rdw.model.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.base.Joiner.on;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -207,7 +206,8 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
      * Although it is unlikely that multiple entries will exist with different names, if that happens the
      * TRT-named attribute value will be favored.
      */
-    private static Map<String, String> FieldAliases = newHashMap();
+    private static final Map<String, String> FieldAliases = newHashMap();
+
     static {
         FieldAliases.put("StudentIdentifier", "SSID");
         FieldAliases.put("AlternateSSID", "ExternalSSID");
@@ -216,7 +216,7 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         FieldAliases.put("DistrictName", "OrganizationName");
         FieldAliases.put("SchoolId", "ResponsibleInstitutionIdentifier");
         FieldAliases.put("SchoolName", "NameOfInstitution");
-    };
+    }
 
     private static String parseMandatoryStringAttribute(final Examinee examinee,
                                                         final String element,
@@ -243,9 +243,9 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         return null;
     }
 
-    private static Date parseMandatoryDateAttribute(final Examinee examinee,
-                                                    final String element,
-                                                    final List<String> elementErrors) {
+    private static LocalDate parseMandatoryDateAttribute(final Examinee examinee,
+                                                         final String element,
+                                                         final List<String> elementErrors) {
         final ExamineeAttribute attribute = examinee.getBestAttribute(element);
 
         if (attribute != null) return parseMandatoryDate(attribute.getValue(), element, elementErrors);
@@ -278,9 +278,9 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         return parseMandatoryString(attribute.getValue(), element, elementErrors);
     }
 
-    private static Date parseOptionalDateAttribute(final Examinee examinee,
-                                                   final String element,
-                                                   final List<String> elementErrors) {
+    private static LocalDate parseOptionalDateAttribute(final Examinee examinee,
+                                                        final String element,
+                                                        final List<String> elementErrors) {
         final ExamineeAttribute attribute = examinee.getBestAttribute(element);
 
         if (attribute == null || isNullOrEmpty(attribute.getValue())) return null;

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
@@ -52,7 +52,7 @@ class DefaultTDSReportProcessor implements TDSReportProcessor {
 
             // now it is okay to start processing
             final Test test = report.getTest();
-            final StudentExamAttributes studentExamAttributes = examineeProcessor.process(examinee, test, school);
+            final StudentExamAttributes studentExamAttributes = examineeProcessor.process(examinee, test, school, importId);
             studentExamProcessor.process(test, report.getOpportunity(), studentExamAttributes, assessment, importId);
 
         } catch (final IllegalArgumentException e) {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/utils/ParseUtil.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/utils/ParseUtil.java
@@ -1,8 +1,8 @@
 package org.opentestsystem.rdw.ingest.processor.utils;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import org.opentestsystem.rdw.ingest.common.error.DataElementError;
@@ -35,31 +35,31 @@ public abstract class ParseUtil {
     }
 
     /**
-     * Converts the given string value into a {@link Date}
+     * Converts the given string value into a {@link LocalDate}
      *
      * @param value the value to convert
-     * @return the parsed {@link Date}
+     * @return the parsed {@link LocalDate}
      * @throws ParseException
      */
-    public static Date toDate(final String value) throws ParseException {
-        return new SimpleDateFormat("yyyyy-mm-dd").parse(value);
+    public static LocalDate toDate(final String value) throws ParseException {
+        return LocalDate.parse(value);
     }
 
 
     /**
-     * Parsed the given rawValue into {@link Date}
+     * Parsed the given rawValue into {@link LocalDate}
      *
      * @param rawValue      the value to parse
      * @param valueName     the name of the given value to be used in case of error
      * @param elementErrors the collection of errors to add to if an error happens
      * @return the parsed value or null in case of the error
      */
-    public static Date parseMandatoryDate(final String rawValue,
-                                          final String valueName,
-                                          @NotNull final List<String> elementErrors) {
+    public static LocalDate parseMandatoryDate(final String rawValue,
+                                               final String valueName,
+                                               @NotNull final List<String> elementErrors) {
         try {
             return toDate(rawValue);
-        } catch (final ParseException e) {
+        } catch (final DateTimeParseException | ParseException e) {
             elementErrors.add(new DataElementError(valueName, rawValue, e.getMessage()).toJson());
         }
         return null;

--- a/exam-processor/src/main/resources/application.sql.yml
+++ b/exam-processor/src/main/resources/application.sql.yml
@@ -49,8 +49,8 @@ sql:
 
     # this is a stubbed out method - TODO: to be deleted
     create: >-
-        INSERT INTO asmt (natural_id, grade_id,type_id, subject_id, school_year) VALUES
-                       (:natural_id, :grade_id, :type_id, :subject_id, :school_year)
+        INSERT INTO asmt (natural_id, grade_id,type_id, subject_id, school_year, import_id) VALUES
+                       (:natural_id, :grade_id, :type_id, :subject_id, :school_year, (select id from import limit 1))
 
     # this is a stubbed out method - TODO: to be deleted
     createItems: >-
@@ -113,16 +113,23 @@ sql:
                                   (:grade_id, :student_id, :school_id, :iep, :lep, :section504, :economic_disadvantage, :migrant_status, :eng_prof_lvl, :t3_program_type, :language_code, :prim_disability_type)
 
   studentEthnicity:
+    findAllIds:
+      SELECT ethnicity_id from student_ethnicity where student_id = :student_id
+
     create: >-
         INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (:student_id, :ethnicity_id)
 
     delete: >-
         DELETE FROM student_ethnicity where student_id = :student_id
 
+  student:
+    updateImportId:
+        UPDATE student SET import_id = :import_id WHERE id = :student_id
+
   studentGroup:
     create: >-
-      INSERT INTO student_group (name, school_id, school_year, subject_id, active, creator, created)
-        VALUES (:name, :school_id, :school_year, :subject_id, :active, :creator, :created)
+      INSERT INTO student_group (name, school_id, school_year, subject_id, active, creator, created, import_id)
+        VALUES (:name, :school_id, :school_year, :subject_id, :active, :creator, :created, :import_id)
 
     findIdByNameAndSchoolAndYear: >-
       SELECT id FROM student_group

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentRepositoryImplIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentRepositoryImplIT.java
@@ -24,8 +24,9 @@ public class AssessmentRepositoryImplIT {
 
     @Test
     @Sql(statements = {
-            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version) VALUES " +
-                    "(-22, 'exam natural id', 4, 1, 1, 2016, 'SBAC-ICA', 'Math', '9835');",
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, import_id) VALUES " +
+                    "(-22, 'exam natural id', 4, 1, 1, 2016, 'SBAC-ICA', 'Math', '9835', -99);",
             " INSERT INTO item (claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                     " (null, null, 'item1', -22, 1, 0.5, 5, null, null)," +
                     " (null, null, 'item2', -22, 1, 0.5, 5, null, null)," +
@@ -46,9 +47,9 @@ public class AssessmentRepositoryImplIT {
 
     @Test
     @Sql(statements = {
-
-            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version) VALUES " +
-                    "(-23, 'exam natural id', 4, 1, 2, 2016, 'SBAC-ICA', 'ELA', '9835');",
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, import_id) VALUES " +
+                    "(-23, 'exam natural id', 4, 1, 2, 2016, 'SBAC-ICA', 'ELA', '9835', -99);",
             " INSERT INTO item (claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                     " (null, null, 'item1', -23, 1, 0.5, 5, null, null)," +
                     " (null, null, 'item2', -23, 1, 0.5, 5, null, null)," +
@@ -68,8 +69,10 @@ public class AssessmentRepositoryImplIT {
     }
 
     @Test
-    @Sql(statements = {"INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version) VALUES " +
-            "(-23, 'exam natural id', 4, 2, 2, 2016, 'SBAC-IAB', 'ELA', '9835');",
+    @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, import_id) VALUES " +
+                    "(-23, 'exam natural id', 4, 2, 2, 2016, 'SBAC-IAB', 'ELA', '9835', -99);",
             " INSERT INTO item (claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                     " (null, null, 'item1', -23, 1, 0.5, 5, null, null)," +
                     " (null, null, 'item2', -23, 1, 0.5, 5, null, null)," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
@@ -33,12 +33,12 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
                 "(-1,0,1, 'application/xml','1D849A91956B74350FF895F067F115E6',CURRENT_DATE);" +
         "INSERT IGNORE INTO district (id, name, natural_id) VALUES\n" +
                 "  (-11, 'Sample District 1', 'District1NaturalId');",
-        "INSERT IGNORE INTO school (id, district_id, name, natural_id) VALUES\n" +
-                "  (-12, -11, 'Sample School 1', 'School1NaturalId');",
-        "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday) VALUES\n" +
-                "  (-11, '6666666666', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-01', null, null, '2006-01-01');",
-        "INSERT INTO asmt (id, natural_id, grade_id,type_id, subject_id, school_year, name, label, version) VALUES\n" +
-                "  (-1, '(SBAC)SBAC-ICA-FIXED-G5E-COMBINED-2017', 5, 1, 2, 2016, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'Grade 5 ELA', '9831');\n",
+        "INSERT IGNORE INTO school (id, district_id, name, natural_id, import_id) VALUES\n" +
+                "  (-12, -11, 'Sample School 1', 'School1NaturalId', -1);",
+        "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday, import_id) VALUES\n" +
+                "  (-11, '6666666666', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-01', null, null, '2006-01-01', -1);",
+        "INSERT INTO asmt (id, natural_id, grade_id,type_id, subject_id, school_year, name, label, version, import_id) VALUES\n" +
+                "  (-1, '(SBAC)SBAC-ICA-FIXED-G5E-COMBINED-2017', 5, 1, 2, 2016, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'Grade 5 ELA', '9831', -1);\n",
         "INSERT INTO item (id, claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                 " (-1, null, null, 'item1', -1, 1, 0.5, 5, null, null)," +
                 " (-2, null, null, 'item3', -1, 1, 0.5, 5, null, null);"

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/IabExamRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/IabExamRepositoryIT.java
@@ -32,12 +32,12 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
                 "(-1,0,1, 'application/xml','1D849A91956B74350FF895F067F115E6',CURRENT_DATE);" +
         "INSERT IGNORE INTO district (id, name, natural_id) VALUES\n" +
                 "  (-11, 'Sample District 1', 'District1NaturalId');",
-        "INSERT IGNORE INTO school (id, district_id, name, natural_id) VALUES\n" +
-                "  (-12, -11, 'Sample School 1', 'School1NaturalId');",
-        "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday) VALUES\n" +
-                "  (-11, '6666666666', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-01', null, null, '2006-01-01');",
-        "INSERT INTO asmt (id, natural_id, grade_id,type_id, subject_id, school_year, name, label, version) VALUES\n" +
-                "  (-1, 'SBAC)SBAC-ICA-FIXED-G5E-COMBINED-2017-Winter', 5, 1, 2, 2016, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'Grade 5 ELA', '9831');\n",
+        "INSERT IGNORE INTO school (id, district_id, name, natural_id, import_id) VALUES\n" +
+                "  (-12, -11, 'Sample School 1', 'School1NaturalId', -1);",
+        "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday, import_id) VALUES\n" +
+                "  (-11, '6666666666', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-01', null, null, '2006-01-01', -1);",
+        "INSERT INTO asmt (id, natural_id, grade_id,type_id, subject_id, school_year, name, label, version, import_id) VALUES\n" +
+                "  (-1, 'SBAC)SBAC-ICA-FIXED-G5E-COMBINED-2017-Winter', 5, 1, 2, 2016, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'Grade 5 ELA', '9831', -1);\n",
         "INSERT INTO item (id, claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                 " (-1, null, null, 'item1', -1, 1, 0.5, 5, null, null)," +
                 " (-2, null, null, 'item3', -1, 1, 0.5, 5, null, null);"

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryIT.java
@@ -35,8 +35,9 @@ public class SchoolRepositoryIT {
 
     @Test
     @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
             "INSERT INTO district (id, name, natural_id) VALUES (-22, 'Sample District 1', 'DistrictNaturalId');",
-            "INSERT INTO school (id, district_id, name, natural_id) VALUES (-27, -22, 'Sample School 1', 'SchoolNaturalId');"
+            "INSERT INTO school (id, district_id, name, natural_id, import_id) VALUES (-27, -22, 'Sample School 1', 'SchoolNaturalId', -99);"
     })
     public void itShouldReturnExistingSchoolForAnExistingDistrict() {
         final int schoolCount = countRowsInTable(jdbcTemplate, "school");
@@ -46,15 +47,20 @@ public class SchoolRepositoryIT {
                 .name("Sample School 1")
                 .naturalId("SchoolNaturalId")
                 .district(District.builder().naturalId("DistrictNaturalId").name("Sample District 1").build())
-                .build());
+                .build(), -100);
 
         assertThat(id).isEqualTo(-27);
         assertThat(countRowsInTable(jdbcTemplate, "school")).isEqualTo(schoolCount);
         assertThat(countRowsInTable(jdbcTemplate, "district")).isEqualTo(districtCount);
+
+        //verify that import id has not changed
+        assertThat(countRowsInTableWhere(jdbcTemplate, "school", "id = -27 and name ='Sample School 1' and natural_id = 'SchoolNaturalId' and import_id = -99")).isEqualTo(1);
+
     }
 
     @Test
     @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
             "INSERT INTO district (id, name, natural_id) VALUES (-22, 'Sample District 1', 'DistrictNaturalId');"
     })
     public void itShouldCreateNewSchoolForAnExistingDistrict() {
@@ -65,14 +71,20 @@ public class SchoolRepositoryIT {
                 .name("Sample School 11")
                 .naturalId("SchoolNaturalId")
                 .district(District.builder().naturalId("DistrictNaturalId").name("Sample District 1").build())
-                .build());
+                .build(), -99);
 
         assertThat(id).isNotNull();
         assertThat(countRowsInTable(jdbcTemplate, "school")).isEqualTo(schoolCount + 1);
         assertThat(countRowsInTable(jdbcTemplate, "district")).isEqualTo(districtCount);
+
+        //verify import id
+        assertThat(countRowsInTableWhere(jdbcTemplate, "school", "natural_id = 'SchoolNaturalId' and import_id = -99")).isEqualTo(1);
     }
 
     @Test
+    @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')"
+    })
     public void itShouldCreateNewSchoolAndDistrict() {
         final int schoolCount = countRowsInTable(jdbcTemplate, "school");
         final int districtCount = countRowsInTable(jdbcTemplate, "district");
@@ -84,7 +96,7 @@ public class SchoolRepositoryIT {
                 .name("Sample School 12")
                 .naturalId("SchoolNaturalId")
                 .district(District.builder().naturalId("DistrictNaturalId").name("Sample District 1").build())
-                .build());
+                .build(), -99);
 
         assertThat(id).isNotNull();
         assertThat(countRowsInTable(jdbcTemplate, "school")).isEqualTo(schoolCount + 1);
@@ -93,22 +105,30 @@ public class SchoolRepositoryIT {
 
     @Test
     @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -100, 0, 1, 'type', 'digest')",
             "INSERT INTO district (id, name, natural_id) VALUES (-22, 'Sample District 1', 'DistrictNaturalId');",
-            "INSERT INTO school (id, district_id, name, natural_id) VALUES (-27, -22, 'Sample School 1', 'SchoolNaturalId');"
+            "INSERT INTO school (id, district_id, name, natural_id, import_id) VALUES (-27, -22, 'Sample School 1', 'SchoolNaturalId', -99);"
     })
-    public void itShouldUpdatExistingSchoolForAnExistingDistrict() {
+    public void itShouldUpdateExistingSchoolForAnExistingDistrict() {
         final int id = repository.upsert(School.builder()
                 .name("Sample School New Name")
                 .naturalId("SchoolNaturalId")
                 .district(District.builder().naturalId("DistrictNaturalId").name("District New Name").build())
-                .build());
+                .build(), -100);
 
+        assertThat(id).isEqualTo(-27)
+        ;
+        //verify that impoert id has been updated
         assertThat(id).isEqualTo(-27);
-        assertThat(countRowsInTableWhere(jdbcTemplate, "school", "id = -27 and name ='Sample School New Name'")).isEqualTo(1);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "school", "id = -27 and name ='Sample School New Name' and import_id = -100")).isEqualTo(1);
         assertThat(countRowsInTableWhere(jdbcTemplate, "district", "id = -22 and name ='District New Name'")).isEqualTo(1);
     }
 
     @Test
+    @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')"
+    })
     public void itShouldCacheReturnedIdForSchool() {
 
         final School school = School.builder()
@@ -120,7 +140,7 @@ public class SchoolRepositoryIT {
         final Cache codes = this.cacheManager.getCache("school");
         assertThat(codes.get(school)).isNull();
 
-        final int newSchoolId = repository.upsert(school);
+        final int newSchoolId = repository.upsert(school, -99);
 
         assertThat(codes.get(school, Integer.class)).isEqualTo(newSchoolId);
     }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentGroupRepositoryImplIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentGroupRepositoryImplIT.java
@@ -21,12 +21,13 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
 @SpringBootTest
 @Transactional
 @Sql(statements = {
+        "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
         "INSERT INTO subject (id, name) VALUES (-11, 'SCIENCE');",
         "INSERT INTO district (id, natural_id, name) VALUES (-20, 'DS009', 'District 9');",
-        "INSERT INTO school (id, district_id, natural_id, name) VALUES (-21, -20, 'S001', 'School 1');",
-        "INSERT INTO student (id, ssid, last_or_surname, first_name, gender_id, birthday) VALUES " +
-                "(-100, '100', 'Smith', 'Alice', 2, '2004-09-02'), " +
-                "(-101, '101', 'Jones', 'Bob', 1, '2004-03-02')"
+        "INSERT INTO school (id, district_id, natural_id, name, import_id) VALUES (-21, -20, 'S001', 'School 1', -99);",
+        "INSERT INTO student (id, ssid, last_or_surname, first_name, gender_id, birthday, import_id) VALUES " +
+                "(-100, '100', 'Smith', 'Alice', 2, '2004-09-02', -99), " +
+                "(-101, '101', 'Jones', 'Bob', 1, '2004-03-02', -99)"
 })
 public class StudentGroupRepositoryImplIT {
 
@@ -36,10 +37,12 @@ public class StudentGroupRepositoryImplIT {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    private final long importId = -99;
+
     @Test
     public void itShouldCreateAndFindGroups() {
-        repository.create(createTestGroup("one"));
-        repository.create(createTestGroup("two"));
+        repository.create(createTestGroup("one"), importId);
+        repository.create(createTestGroup("two"), importId);
 
         assertThat(repository.findIdByNameAndSchoolAndYear("one", -21, 2017)).isNotNull();
         assertThat(repository.findIdByNameAndSchoolAndYear("one", -21, 2016)).isNull();
@@ -50,8 +53,8 @@ public class StudentGroupRepositoryImplIT {
     public void itShouldAddStudentMembership() {
         final int membershipRows = countRowsInTable(jdbcTemplate, "student_group_membership");
 
-        final StudentGroup group1 = repository.create(createTestGroup("one"));
-        final StudentGroup group2 = repository.create(createTestGroup("two"));
+        final StudentGroup group1 = repository.create(createTestGroup("one"),importId);
+        final StudentGroup group2 = repository.create(createTestGroup("two"),importId);
 
         repository.addStudentToGroups(-100, newArrayList(group1.getId(), group2.getId()));
         repository.addStudentToGroups(-101, newArrayList(group1.getId()));

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentRepositoryIT.java
@@ -34,8 +34,8 @@ public class StudentRepositoryIT {
     private Student.Builder studentBuilder;
 
     private final Long studentId = -999L;
-    private final String studentSQL = "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday) " +
-            "VALUES  (-999, '6666666669', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-02', null, null, '2006-07-08')";
+    private final String studentSQL = "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday, import_id) " +
+            "VALUES  (-999, '6666666669', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-02', null, null, '2006-07-08', -99)";
 
     @Before
     public void setUp() throws ParseException {
@@ -53,6 +53,7 @@ public class StudentRepositoryIT {
 
     @Test
     @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
             studentSQL,
             "INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (-999, 6), (-999, 4)"
     })
@@ -64,19 +65,26 @@ public class StudentRepositoryIT {
         ethnicity.add(4);
         ethnicity.add(6);
 
-        assertThat(repository.upsert(studentBuilder.ethnicityIds(ethnicity).build())).isEqualTo(studentId);
+        assertThat(repository.upsert(studentBuilder.ethnicityIds(ethnicity).build(), -100)).isEqualTo(studentId);
 
         //verify that number of rows has not changed
         assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student_ethnicity", "student_id =" + studentId)).isEqualTo(2);
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
+
+        //verify that import id has not changed
+        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "id =" + studentId + " and import_id = -99")).isEqualTo(1);
     }
 
+    @Test
+    @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+    })
     public void itShouldCreateNew() throws ParseException {
 
         final int countRowInStudentBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student");
         assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "ssid = '6666666669'")).isZero();
 
-        repository.upsert(studentBuilder.build());
+        repository.upsert(studentBuilder.build(), -99);
 
         assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "ssid = '6666666669'")).isEqualTo(1);
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore + 1);
@@ -84,6 +92,8 @@ public class StudentRepositoryIT {
 
     @Test
     @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -100, 0, 1, 'type', 'digest')",
             studentSQL,
             "INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (-999, 6), (-999, 4)"
 
@@ -109,14 +119,19 @@ public class StudentRepositoryIT {
                 .birthday(LocalDate.parse("1999-05-01"))
                 .ethnicityIds(ethnicity)
                 .genderId(0)
-                .build())).isEqualTo(-999);
+                .build(), -100)).isEqualTo(-999);
 
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
         assertThat(countRowsInTableWhere(jdbcTemplate, "student", newStudentSQL)).isEqualTo(1);
+
+        //verify that import id has changed
+        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "id =" + studentId + " and import_id = -100")).isEqualTo(1);
     }
 
     @Test
     @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -100, 0, 1, 'type', 'digest')",
             studentSQL,
             "INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (-999, 6), (-999, 4)"
     })
@@ -128,14 +143,44 @@ public class StudentRepositoryIT {
         final List<Integer> ethnicity = newArrayList();
         ethnicity.add(4);
 
-        assertThat(repository.upsert(studentBuilder.ethnicityIds(ethnicity).build())).isEqualTo(studentId);
+        assertThat(repository.upsert(studentBuilder.ethnicityIds(ethnicity).build(), -100)).isEqualTo(studentId);
 
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(countRowInEthnBefore - 1);
+        //verify that import id has changed
+        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "id =" + studentId + " and import_id = -100")).isEqualTo(1);
 
-        assertThat(repository.upsert(studentBuilder.ethnicityIds(newArrayList()).build())).isEqualTo(studentId);
+        assertThat(repository.upsert(studentBuilder.ethnicityIds(newArrayList()).build(), -99)).isEqualTo(studentId);
 
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
         assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(countRowInEthnBefore - 2);
+        //verify that import id has changed
+        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "id =" + studentId + " and import_id = -99")).isEqualTo(1);
+    }
+
+
+    @Test
+    @Sql(statements = {
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -100, 0, 1, 'type', 'digest')",
+            studentSQL
+    })
+    public void itShouldHandleNullableDatesComparison() throws ParseException {
+
+        final int countRowInStudentBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student");
+
+        assertThat(repository.upsert(studentBuilder.firsEntryIntoUSSchoolAt(null).build(), -100)).isEqualTo(studentId);
+
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student",
+                "id = " + studentId + " and first_entry_into_us_school_at is null and lep_entry_at is null and lep_exit_at is null and import_id = -100")).isEqualTo(1);
+
+        assertThat(repository.upsert(studentBuilder.lepExitAt(LocalDate.parse("2017-05-03")).build(), -99)).isEqualTo(studentId);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student",
+                "id = " + studentId + " and first_entry_into_us_school_at is null and lep_entry_at is null and lep_exit_at = '2017-05-03' and import_id = -99")).isEqualTo(1);
+
+        assertThat(repository.upsert(studentBuilder.lepEntryAt(LocalDate.parse("2017-05-03")).build(), -100)).isEqualTo(studentId);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student",
+                "id = " + studentId + " and first_entry_into_us_school_at is null and lep_entry_at = '2017-05-03' and lep_exit_at = '2017-05-03' and import_id = -100")).isEqualTo(1);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentRepositoryIT.java
@@ -1,8 +1,9 @@
 package org.opentestsystem.rdw.ingest.processor.repository.impl;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.processor.model.Student;
@@ -23,86 +24,118 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 @SpringBootTest
 @Transactional
 public class StudentRepositoryIT {
+
     @Autowired
     private StudentRepository repository;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    private Student.Builder studentBuilder;
+
+    private final Long studentId = -999L;
+    private final String studentSQL = "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday) " +
+            "VALUES  (-999, '6666666669', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-02', null, null, '2006-07-08')";
+
+    @Before
+    public void setUp() throws ParseException {
+        studentBuilder = Student.builder()
+                .ssid("6666666669")
+                .firstName("FirstName6")
+                .lastOrSurname("LastName6")
+                .middleName("MiddleName6")
+                .birthday(LocalDate.parse("2006-07-08"))
+                .firsEntryIntoUSSchoolAt(LocalDate.parse("2015-09-02"))
+                .lepEntryAt(null)
+                .lepExitAt(null)
+                .genderId(1);
+    }
+
     @Test
     @Sql(statements = {
-            "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday) VALUES\n" +
-                    "  (-999, '6666666669', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-01', null, null, '2006-01-01');"
+            studentSQL,
+            "INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (-999, 6), (-999, 4)"
     })
     public void itShouldFindExisting() throws ParseException {
+        final int countRowInStudentBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student");
+        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student_ethnicity", "student_id = " + studentId)).isEqualTo(2);
+
         final List<Integer> ethnicity = newArrayList();
         ethnicity.add(4);
         ethnicity.add(6);
 
-        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student_ethnicity", "student_id = '-999'")).isZero();
+        assertThat(repository.upsert(studentBuilder.ethnicityIds(ethnicity).build())).isEqualTo(studentId);
 
-        assertThat(repository.upsert(Student.builder()
-                .ssid("6666666669")
-                .firstName("FirstName6")
-                .lastOrSurname("LastName6")
-                .middleName("MiddleName6")
-                .birthday(new SimpleDateFormat("yyyyy-mm-dd").parse("2006-01-01"))
-                .genderId(1)
-                .ethnicityIds(ethnicity)
-                .build())).isEqualTo(-999);
-
-        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student_ethnicity", "student_id = '-999'")).isEqualTo(2);
-
-        //test that ethnicity is removed
-        assertThat(repository.upsert(Student.builder()
-                .ssid("6666666669")
-                .firstName("FirstName6")
-                .lastOrSurname("LastName6")
-                .middleName("MiddleName6")
-                .birthday(new SimpleDateFormat("yyyyy-mm-dd").parse("2006-01-01"))
-                .genderId(1)
-                .ethnicityIds(newArrayList())
-                .build())).isEqualTo(-999);
-        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student_ethnicity", "student_id = '-999'")).isZero();
-
-
+        //verify that number of rows has not changed
+        assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student_ethnicity", "student_id =" + studentId)).isEqualTo(2);
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
     }
 
-    @Test
     public void itShouldCreateNew() throws ParseException {
+
+        final int countRowInStudentBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student");
         assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "ssid = '6666666669'")).isZero();
-        repository.upsert(Student.builder()
-                .ssid("6666666669")
-                .firstName("FirstName6")
-                .lastOrSurname("LastName6")
-                .middleName("MiddleName6")
-                .birthday(new SimpleDateFormat("yyyyy-mm-dd").parse("2007-01-01"))
-                .genderId(1)
-                .build());
+
+        repository.upsert(studentBuilder.build());
+
         assertThat(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "student", "ssid = '6666666669'")).isEqualTo(1);
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore + 1);
     }
 
     @Test
     @Sql(statements = {
-            "INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at, lep_exit_at, birthday) VALUES\n" +
-                    "  (-999, '6666666669', 'LastName6', 'FirstName6', 'MiddleName6', 1, '2015-09-01', null, null, '2006-01-01');"
+            studentSQL,
+            "INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (-999, 6), (-999, 4)"
+
     })
-    public void itShouldFindAndUpdateExisting() throws ParseException {
-        assertThat(countRowsInTableWhere(jdbcTemplate, "student", "id=-999 and first_name ='FirstName - New Name' and " +
-                "last_or_surname = 'LastName - New Name' and middle_name='MiddleName - New Name' and birthday='2007-01-01' and " +
-                "gender_id=0")).isZero();
+    public void itShouldFindAndUpdateExistingWithNoChangeToEthnicity() throws ParseException {
+
+        final String newStudentSQL = "id=" + studentId + " and first_name ='FirstName - New Name' and " +
+                "last_or_surname = 'LastName - New Name' and middle_name='MiddleName - New Name' and birthday='1999-05-01' and " +
+                "gender_id=0";
+
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student", newStudentSQL)).isZero();
+        final int countRowInStudentBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student");
+
+        final List<Integer> ethnicity = newArrayList();
+        ethnicity.add(4);
+        ethnicity.add(6);
 
         assertThat(repository.upsert(Student.builder()
                 .ssid("6666666669")
                 .firstName("FirstName - New Name")
                 .lastOrSurname("LastName - New Name")
                 .middleName("MiddleName - New Name")
-                .birthday(new SimpleDateFormat("yyyyy-mm-dd").parse("2007-01-01"))
+                .birthday(LocalDate.parse("1999-05-01"))
+                .ethnicityIds(ethnicity)
                 .genderId(0)
                 .build())).isEqualTo(-999);
 
-        assertThat(countRowsInTableWhere(jdbcTemplate, "student", "id=-999 and first_name ='FirstName - New Name' and " +
-                "last_or_surname = 'LastName - New Name' and middle_name='MiddleName - New Name' and birthday='2007-01-01' and " +
-                "gender_id=0")).isEqualTo(1);
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student", newStudentSQL)).isEqualTo(1);
+    }
+
+    @Test
+    @Sql(statements = {
+            studentSQL,
+            "INSERT INTO student_ethnicity (student_id, ethnicity_id) VALUES (-999, 6), (-999, 4)"
+    })
+    public void itShouldFindAndUpdateExistingIfOnlyEthnicityChanges() throws ParseException {
+
+        final int countRowInStudentBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student");
+        final int countRowInEthnBefore = JdbcTestUtils.countRowsInTable(jdbcTemplate, "student_ethnicity");
+
+        final List<Integer> ethnicity = newArrayList();
+        ethnicity.add(4);
+
+        assertThat(repository.upsert(studentBuilder.ethnicityIds(ethnicity).build())).isEqualTo(studentId);
+
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(countRowInEthnBefore - 1);
+
+        assertThat(repository.upsert(studentBuilder.ethnicityIds(newArrayList()).build())).isEqualTo(studentId);
+
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student")).isEqualTo(countRowInStudentBefore);
+        assertThat(JdbcTestUtils.countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(countRowInEthnBefore - 2);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
@@ -13,6 +13,7 @@ import org.opentestsystem.rdw.model.XmlUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @Transactional
 @CachingTest
 @ContextConfiguration(classes = {ExamProcessorApplication.class})
+@Sql(statements = {
+        "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+})
 public class DefaultExamineeProcessorIT {
     @Autowired
     private DefaultExamineeProcessor processor;
@@ -35,7 +39,7 @@ public class DefaultExamineeProcessorIT {
             processor.process(tdsReport.getExaminee(), tdsReport.getTest(), School.builder()
                     .district(District.builder().name("district").naturalId("error test").stateCode("tt").build())
                     .name("test")
-                    .naturalId("error test").build());
+                    .naturalId("error test").build(), -99);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"elementName\":\"FirstName\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
                     "{\"elementName\":\"LastOrSurname\",\"value\":\"\",\"error\":\"value may not be blank\"}," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
@@ -40,11 +40,11 @@ public class DefaultExamineeProcessorIT {
             assertThat(e.getMessage()).isEqualTo("{\"elementName\":\"FirstName\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
                     "{\"elementName\":\"LastOrSurname\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
                     "{\"elementName\":\"StudentIdentifier\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"Birthdate\",\"value\":\"bad data\",\"error\":\"Unparseable date: \\\"bad data\\\"\"}," +
+                    "{\"elementName\":\"Birthdate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
                     "{\"elementName\":\"Sex\",\"value\":\"bad data\",\"error\":\"unknown gender name [bad data]\"}," +
-                    "{\"elementName\":\"FirstEntryDateIntoUSSchool\",\"value\":\"bad data\",\"error\":\"Unparseable date: \\\"bad data\\\"\"}," +
-                    "{\"elementName\":\"LimitedEnglishProficiencyEntryDate\",\"value\":\"bad data\",\"error\":\"Unparseable date: \\\"bad data\\\"\"}," +
-                    "{\"elementName\":\"LEPExitDate\",\"value\":\"bad data\",\"error\":\"Unparseable date: \\\"bad data\\\"\"}," +
+                    "{\"elementName\":\"FirstEntryDateIntoUSSchool\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
+                    "{\"elementName\":\"LimitedEnglishProficiencyEntryDate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
+                    "{\"elementName\":\"LEPExitDate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
                     "{\"elementName\":\"AmericanIndianOrAlaskaNative\",\"value\":\"bad data\",\"error\":\"an invalid value [bad data]\"}," +
                     "{\"elementName\":\"Asian\",\"value\":\"bad data\",\"error\":\"an invalid value [bad data]\"}," +
                     "{\"elementName\":\"BlackOrAfricanAmerican\",\"value\":\"bad data\",\"error\":\"an invalid value [bad data]\"}," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
@@ -78,7 +78,7 @@ public class DefaultTDSReportProcessorTest {
         when(examineeProcessor.parseExamineeRelationship(any(Examinee.class))).thenReturn(school);
 
         final StudentExamAttributes studentExamAttributes = mock(StudentExamAttributes.class);
-        when(examineeProcessor.process(examinee, test, school)).thenReturn(studentExamAttributes);
+        when(examineeProcessor.process(examinee, test, school, importId)).thenReturn(studentExamAttributes);
 
         final Assessment assessment = mock(Assessment.class);
         when(assessmentService.findOneByNaturalId(tdsReport)).thenReturn(assessment);

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/StudentExamProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/StudentExamProcessorIT.java
@@ -38,8 +38,8 @@ public class StudentExamProcessorIT {
 
     @Test
     @Sql(statements = { insertImportSql,
-            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version) VALUES " +
-            "(-1, 'exam natural id', 6, 1, 2, 2016, 'SBAC-ICA', 'ELA', '9835');",
+            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, import_id) VALUES " +
+            "(-1, 'exam natural id', 6, 1, 2, 2016, 'SBAC-ICA', 'ELA', '9835', -1);",
             " INSERT INTO item (claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                     " (null, null, '200-56561', -1, 1, 0.5, 5, null, null)," +
                     " (null, null, '200-46849', -1, 1, 0.5, 5, null, null);"
@@ -69,8 +69,8 @@ public class StudentExamProcessorIT {
 
     @Test
     @Sql(statements = { insertImportSql,
-            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version) VALUES " +
-            "(-1, 'exam natural id', 6, 2, 2, 2016, 'SBAC-ICA', 'ELA', '9835');",
+            "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, import_id) VALUES " +
+            "(-1, 'exam natural id', 6, 2, 2, 2016, 'SBAC-ICA', 'ELA', '9835', -1);",
             " INSERT INTO item (claim_id, target_id, natural_id, asmt_id, dok_id, difficulty, max_points, math_practice, allow_calc) VALUES \n" +
                     " (null, null, '200-56561', -1, 1, 0.5, 5, null, null)," +
                     " (null, null, '200-46849', -1, 1, 0.5, 5, null, null);"

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/utils/ParseUtilTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/utils/ParseUtilTest.java
@@ -2,7 +2,7 @@ package org.opentestsystem.rdw.ingest.processor.utils;
 
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.Test;
 import org.opentestsystem.rdw.ingest.common.error.DataElementError;
@@ -47,7 +47,9 @@ public class ParseUtilTest {
 
     @Test
     public void ItShouldParseToDate() throws ParseException {
-        assertThat(toDate("2000-01-07")).isEqualTo(new SimpleDateFormat("yyyyy-mm-dd").parse("2000-01-07"));
+        assertThat(toDate("2015-09-07").getYear()).isEqualTo(2015);
+        assertThat(toDate("2015-09-07").getMonthValue()).isEqualTo(9);
+        assertThat(toDate("2000-09-07").getDayOfMonth()).isEqualTo(7);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -67,7 +69,7 @@ public class ParseUtilTest {
     public void ItShouldParseMandatoryDate() throws ParseException {
         final List<String> elementErrors = newArrayList();
 
-        assertThat(parseMandatoryDate("2001-01-01", "test", elementErrors)).isEqualTo(new SimpleDateFormat("yyyyy-mm-dd").parse("2001-01-01"));
+        assertThat(parseMandatoryDate("2001-01-01", "test", elementErrors)).isEqualTo(LocalDate.parse("2001-01-01"));
         assertThat(elementErrors).isEmpty();
     }
 
@@ -93,7 +95,7 @@ public class ParseUtilTest {
         final List<String> elementErrors = newArrayList();
 
         assertThat(parseMandatoryDate("bad data", "test", elementErrors)).isNull();
-        assertThat(elementErrors).containsExactly(new DataElementError("test", "bad data", "Unparseable date: \"bad data\"").toJson());
+        assertThat(elementErrors).containsExactly(new DataElementError("test", "bad data", "Text \u0027bad data\u0027 could not be parsed at index 0").toJson());
     }
 
     @Test

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfiguration.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfiguration.java
@@ -45,7 +45,7 @@ public class PackageProcessorConfiguration {
 
     private void process(final String assessmentPackage, final long importId) {
         try {
-            packageProcessor.process(assessmentPackage);
+            packageProcessor.process(assessmentPackage, importId);
             importRepository.updateStatusAndMessageById(importId, ImportStatus.PROCESSED, null);
         } catch (final ImportException ie) {
             logger.error("failed with an import error: " + ie);

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/AssessmentPackageRepository.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/AssessmentPackageRepository.java
@@ -13,7 +13,8 @@ public interface AssessmentPackageRepository {
      *
      * @param assessments array of {@link Assessment} objects
      * @param items       array of {@link Item} objects
+     * @param importId    id of the import that is creating the {@link Assessment}s
      */
-    void createPackage(final Assessment[] assessments, final Item[] items);
+    void createPackage(Assessment[] assessments, Item[] items, long importId);
 }
 

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentPackageRepositoryImpl.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentPackageRepositoryImpl.java
@@ -41,13 +41,13 @@ public class AssessmentPackageRepositoryImpl implements AssessmentPackageReposit
      */
     @Override
     @Transactional
-    public void createPackage(final Assessment[] assessments, final Item[] items) {
-        bulkCreateAssessments(assessments);
+    public void createPackage(final Assessment[] assessments, final Item[] items, final long importId) {
+        bulkCreateAssessments(assessments, importId);
         bulkCreateScores(assessments);
         bulkCreateItems(items);
     }
 
-    private void bulkCreateAssessments(final Assessment[] assessments) {
+    private void bulkCreateAssessments(final Assessment[] assessments, final long importId) {
         if (assessments.length == 0) return;
 
         final MapSqlParameterSource[] batchParameters = new MapSqlParameterSource[assessments.length];
@@ -61,7 +61,8 @@ public class AssessmentPackageRepositoryImpl implements AssessmentPackageReposit
                     .addValue("schoolYear", assessments[i].getsSchoolYear())
                     .addValue("name", assessments[i].getName())
                     .addValue("label", assessments[i].getLabel())
-                    .addValue("version", assessments[i].getVersion());
+                    .addValue("version", assessments[i].getVersion())
+                    .addValue("import_id", importId);
 
         }
         jdbcTemplate.batchUpdate(sqlAssessmentCreate, batchParameters);

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/AssessmentPackageProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/AssessmentPackageProcessor.java
@@ -9,8 +9,11 @@ import org.opentestsystem.rdw.ingest.common.model.ImportException;
 public interface AssessmentPackageProcessor {
 
     /**
+     * Processes an assessment package in Tabulator output (csv) format
+     *
      * @param assessmentRecord the record to process
+     * @param importId         id of the import
      * @throws ImportException
      */
-    void process(final String assessmentRecord) throws ImportException;
+    void process(String assessmentRecord, long importId) throws ImportException;
 }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/DataElementErrorCollector.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/DataElementErrorCollector.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 /**
  * DataElementErrorCollector - a class to capture validation errors when parsing an assessment package
  */
-@Component
 public class DataElementErrorCollector {
     private ArrayList<DataElementError> messages;
 

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentPackageProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentPackageProcessor.java
@@ -32,35 +32,27 @@ public class DefaultAssessmentPackageProcessor implements AssessmentPackageProce
     private final AssessmentParser assessmentParser;
     private final ItemParser itemParser;
     private final AssessmentPackageRepository packageRepository;
-    private Set<Assessment> assessments;
-    private List<Item> items;
-
 
     @Autowired
     public DefaultAssessmentPackageProcessor(final AssessmentParser assessmentParser,
                                              final ItemParser itemParser,
                                              final AssessmentPackageRepository packageRepository) {
-        this.assessments = new LinkedHashSet<>();
-        this.items = new ArrayList<>();
         this.assessmentParser = assessmentParser;
         this.itemParser = itemParser;
         this.packageRepository = packageRepository;
     }
 
-    /**
-     * Processes an assessment package in Tabulator output (csv) format
-     *
-     * @param assessmentPackage Entire Tabulator output loaded in a String
-     * @throws ImportException if any errors encountered during processing
-     */
     @Override
-    public void process(final String assessmentPackage) {
+    public void process(final String assessmentPackage, final long importId) {
         final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
         try {
             final Iterable<CSVRecord> records = CSVFormat.RFC4180.withFirstRecordAsHeader().parse(new StringReader(assessmentPackage));
 
+            final List<Item> items = new ArrayList<>();
+            final Set<Assessment> assessments = new LinkedHashSet<>();
+
             //Throw bad data import exception
-            for (CSVRecord record : records) {
+            for (final CSVRecord record : records) {
                 final Assessment asmt = assessmentParser.parse(record, errorCollector);
                 final Item item = itemParser.parse(record, errorCollector);
 
@@ -77,7 +69,7 @@ public class DefaultAssessmentPackageProcessor implements AssessmentPackageProce
 
             //Insert into database
             packageRepository.createPackage(assessments.toArray(new Assessment[assessments.size()]),
-                    items.toArray(new Item[items.size()]));
+                    items.toArray(new Item[items.size()]), importId);
 
             logger.info(String.format("Processed %d assessments and %d items", assessments.size(), items.size()));
         } catch (final IllegalArgumentException e) {

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultItemParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultItemParser.java
@@ -8,6 +8,7 @@ import org.opentestsystem.rdw.ingest.processor.model.Item;
 import org.opentestsystem.rdw.ingest.processor.repository.ClaimRepository;
 import org.opentestsystem.rdw.ingest.processor.repository.DepthOfKnowledgeRepository;
 import org.opentestsystem.rdw.ingest.processor.repository.MathPracticeRepository;
+import org.opentestsystem.rdw.ingest.processor.repository.SubjectRepository;
 import org.opentestsystem.rdw.ingest.processor.repository.TargetRepository;
 import org.opentestsystem.rdw.ingest.processor.service.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.processor.service.ItemParser;
@@ -34,16 +35,19 @@ public class DefaultItemParser implements ItemParser {
     private final TargetRepository targetRepository;
     private final DepthOfKnowledgeRepository depthOfKnowledgeRepository;
     private final MathPracticeRepository mathPracticeRepository;
+    private final SubjectRepository subjectRepository;
 
     @Autowired
     public DefaultItemParser(final ClaimRepository claimRepository,
                              final TargetRepository targetRepository,
                              final DepthOfKnowledgeRepository depthOfKnowledgeRepository,
-                             final MathPracticeRepository mathPracticeRepository) {
+                             final MathPracticeRepository mathPracticeRepository,
+                             final SubjectRepository subjectRepository) {
         this.claimRepository = claimRepository;
         this.targetRepository = targetRepository;
         this.depthOfKnowledgeRepository = depthOfKnowledgeRepository;
         this.mathPracticeRepository = mathPracticeRepository;
+        this.subjectRepository = subjectRepository;
     }
 
     /**
@@ -56,6 +60,10 @@ public class DefaultItemParser implements ItemParser {
     @Override
     public Item parse(final CSVRecord record, final DataElementErrorCollector errorCollector) {
         final ParserHelper parserHelper = new ParserHelper(errorCollector);
+
+        //TODO: add more tests
+        parserHelper.repositoryValidation(ASSESSMENT_SUBJECT, record.get(ASSESSMENT_SUBJECT).trim(), Strings::emptyToNull, subjectRepository::findIdByName);
+
         Item.Builder itemBuilder = Item.builder()
                 .naturalId(parserHelper.basicValidation(FULL_ITEM_KEY, record.get(FULL_ITEM_KEY).trim(),
                         Strings::emptyToNull))

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultItemParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultItemParser.java
@@ -5,7 +5,10 @@ import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
 import org.apache.commons.csv.CSVRecord;
 import org.opentestsystem.rdw.ingest.processor.model.Item;
-import org.opentestsystem.rdw.ingest.processor.repository.*;
+import org.opentestsystem.rdw.ingest.processor.repository.ClaimRepository;
+import org.opentestsystem.rdw.ingest.processor.repository.DepthOfKnowledgeRepository;
+import org.opentestsystem.rdw.ingest.processor.repository.MathPracticeRepository;
+import org.opentestsystem.rdw.ingest.processor.repository.TargetRepository;
 import org.opentestsystem.rdw.ingest.processor.service.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.processor.service.ItemParser;
 import org.opentestsystem.rdw.ingest.processor.utils.ParserHelper;
@@ -31,34 +34,28 @@ public class DefaultItemParser implements ItemParser {
     private final TargetRepository targetRepository;
     private final DepthOfKnowledgeRepository depthOfKnowledgeRepository;
     private final MathPracticeRepository mathPracticeRepository;
-    private final SubjectRepository subjectRepository;
 
     @Autowired
     public DefaultItemParser(final ClaimRepository claimRepository,
                              final TargetRepository targetRepository,
                              final DepthOfKnowledgeRepository depthOfKnowledgeRepository,
-                             final MathPracticeRepository mathPracticeRepository,
-                             final SubjectRepository subjectRepository) {
+                             final MathPracticeRepository mathPracticeRepository) {
         this.claimRepository = claimRepository;
         this.targetRepository = targetRepository;
         this.depthOfKnowledgeRepository = depthOfKnowledgeRepository;
         this.mathPracticeRepository = mathPracticeRepository;
-        this.subjectRepository = subjectRepository;
     }
 
     /**
      * Parse function to validate and extract an {@link Item}. Any errors found are gathered in the error collector.
      *
-     * @param record {@link CSVRecord} to parse
+     * @param record         {@link CSVRecord} to parse
      * @param errorCollector error collector
      * @return {@link Item} if successfully validated and parsed, null otherwise
      */
     @Override
     public Item parse(final CSVRecord record, final DataElementErrorCollector errorCollector) {
         final ParserHelper parserHelper = new ParserHelper(errorCollector);
-        final Integer subjectId = parserHelper.repositoryValidation(ASSESSMENT_SUBJECT, record.get(ASSESSMENT_SUBJECT).trim(),
-                Strings::emptyToNull, subjectRepository::findIdByName);
-
         Item.Builder itemBuilder = Item.builder()
                 .naturalId(parserHelper.basicValidation(FULL_ITEM_KEY, record.get(FULL_ITEM_KEY).trim(),
                         Strings::emptyToNull))

--- a/package-processor/src/main/resources/application.sql.yml
+++ b/package-processor/src/main/resources/application.sql.yml
@@ -20,8 +20,8 @@ sql:
       SELECT id FROM asmt WHERE natural_id= :natural_id
 
     create: >-
-      INSERT INTO asmt (natural_id, grade_id,type_id, subject_id, school_year, name, label, version) VALUES
-                       (:naturalId, :gradeId, :typeId, :subjectId, :schoolYear, :name, :label, :version)
+      INSERT INTO asmt (natural_id, grade_id,type_id, subject_id, school_year, name, label, version, import_id) VALUES
+                       (:naturalId, :gradeId, :typeId, :subjectId, :schoolYear, :name, :label, :version, :import_id)
     assessmentScore:
       create: >-
         INSERT INTO asmt_score (asmt_id, cut_point_1, cut_point_2, cut_point_3, min_score, max_score) SELECT (SELECT id FROM asmt WHERE natural_id=:asmtId), :cutPoint1, :cutPoint2, :cutPoint3, :minScore, :maxScore
@@ -45,8 +45,6 @@ sql:
   target:
     findIdByCodeAndClaim: >-
       SELECT id FROM target WHERE code= :code AND claim_id = (SELECT id FROM claim WHERE code= :claimCode)
-
-
 
   # ItemRepository
   item:

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProessorConfigurationTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProessorConfigurationTest.java
@@ -1,5 +1,10 @@
 package org.opentestsystem.rdw.ingest.processor;
+
 import com.google.common.io.CharStreams;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import org.junit.Before;
 import org.junit.Test;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
@@ -11,12 +16,10 @@ import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 
-import java.io.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -60,7 +63,7 @@ public class PackageProessorConfigurationTest {
     public void itShouldHandleImportException() throws UnsupportedEncodingException {
         doThrow(new ImportException(ImportStatus.UNKNOWN_ASMT, "message"))
                 .when(packageProcessor)
-                .process(any(String.class));
+                .process(any(String.class), anyLong());
 
         processor.process(message);
 
@@ -69,7 +72,7 @@ public class PackageProessorConfigurationTest {
 
     @Test
     public void itShouldHandleAnyRuntimeException() throws UnsupportedEncodingException {
-        doThrow(new RuntimeException("any message")).when(packageProcessor).process(any(String.class));
+        doThrow(new RuntimeException("any message")).when(packageProcessor).process(any(String.class), anyLong());
 
         processor.process(message);
 

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentPackageRepositoryIT.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/AssessmentPackageRepositoryIT.java
@@ -24,6 +24,7 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
 @Transactional
 @CachingTest
 @Sql(statements = {
+        "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
         "INSERT INTO subject (id, name) VALUES (-12, 'TMath');",
         "INSERT INTO claim (id, subject_id, code, name, description) VALUES \n" +
                 "(-12, -12, '11', 'Concepts and Procedures', 'Concepts and Procedures - Students can explain and apply mathematical concepts and interpret and carry out mathematical procedures with precision and fluency.');",
@@ -88,7 +89,7 @@ public class AssessmentPackageRepositoryIT {
         itemList.add(itemBuilder.build());
         itemList.add(itemBuilder.naturalId("20-19999").build());
         itemList.add(itemBuilder.naturalId("20-18888").build());
-        repository.createPackage(asmtArray, itemList.toArray(new Item[itemList.size()]));
+        repository.createPackage(asmtArray, itemList.toArray(new Item[itemList.size()]), -99);
 
         assertThat(countRowsInTable(jdbcTemplate, "asmt")).isEqualTo(beforeAsmtCount + 1);
         assertThat(countRowsInTable(jdbcTemplate, "asmt_score")).isEqualTo(beforeAsmScoreCount + 1);


### PR DESCRIPTION
I think I did something incorrectly since it shows changes from https://github.com/SmarterApp/RDW_Ingest/pull/112. 

The objective of this change is to support import_id in the 'root' entities for migration: 
Assessment, Student, Exams and Iab Exams, School and Student Group.

It has a corresponding RDW_Schema change: https://github.com/SmarterApp/RDW_Schema/pull/46
