### PR TITLE
Added batch integration tests.

### DIFF
--- a/migrate-reporting/build.gradle
+++ b/migrate-reporting/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     compile project(':rdw-ingest-common')
     testCompile 'org.springframework.boot:spring-boot-starter-test'
+    testCompile 'org.springframework.batch:spring-batch-test'
 
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
     compile 'com.google.guava:guava'

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingConfiguration.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingConfiguration.java
@@ -54,7 +54,6 @@ public class MigrateReportingConfiguration {
         return new MigrateJobCompletionListener();
     }
 
-    @Bean(name = "txManager")
     public PlatformTransactionManager transactionManager() {
         return new ResourcelessTransactionManager();
     }

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingConfiguration.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingConfiguration.java
@@ -46,12 +46,15 @@ public class MigrateReportingConfiguration {
     @Autowired
     private Warehouse warehouseStep;
 
+    public static final String stepReportingName = "stepReporting";
+    public static final String stepWarehouseName = "stepWarehouse";
+
     @Bean
     public JobExecutionListener listener() {
         return new MigrateJobCompletionListener();
     }
 
-    @Bean
+    @Bean(name = "txManager")
     public PlatformTransactionManager transactionManager() {
         return new ResourcelessTransactionManager();
     }
@@ -100,13 +103,13 @@ public class MigrateReportingConfiguration {
 
     @Bean
     public Step stepReporting() {
-        return stepBuilderFactory.get("stepReporting")
+        return stepBuilderFactory.get(stepReportingName)
                 .tasklet(reportingStep).build();
     }
 
     @Bean
     public Step stepWarehouse() {
-        return stepBuilderFactory.get("stepWarehouse")
+        return stepBuilderFactory.get(stepWarehouseName)
                 .tasklet(warehouseStep).build();
     }
 

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/Reporting.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/Reporting.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.ingest.migrate.reporting.step;
 import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.repeat.RepeatStatus;
@@ -27,6 +28,10 @@ public class Reporting extends StepTasklet {
     public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
 
         final MigrateBatch batch = getJobBatch(chunkContext);
+        if(batch == null) {
+            contribution.setExitStatus(new ExitStatus("test_failure"));
+            throw new IllegalArgumentException("test_failure");
+        }
         logger.info("batch max import id" + batch.getStartImportId());
 
         final Integer max_last_import_id = reportingJdbcTemplate

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
@@ -1,0 +1,16 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting;
+
+import org.junit.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReportingMigrateJobIT extends SpringBatchIT {
+    @Test
+    public void testJob() throws Exception {
+        final JobExecution jobExecution = getJobLauncherTestUtils().launchJob();
+
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode());
+    }
+}

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/SpringBatchIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/SpringBatchIT.java
@@ -28,7 +28,7 @@ public abstract class SpringBatchIT {
 
     @Configuration
     @ActiveProfiles("test")
-    @Import({MigrateReportingApplication.class, MigrateReportingConfiguration.class})
+    @Import({MigrateReportingApplication.class})
     static class BatchTestConfig {
         @Bean
         JobLauncherTestUtils jobLauncherTestUtils() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/SpringBatchIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/SpringBatchIT.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting;
+
+import org.junit.runner.RunWith;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ContextConfiguration(classes = {SpringBatchIT.BatchTestConfig.class})
+@ActiveProfiles("test")
+public abstract class SpringBatchIT {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    protected JobLauncherTestUtils getJobLauncherTestUtils() {
+        return jobLauncherTestUtils;
+    }
+
+    @Configuration
+    @ActiveProfiles("test")
+    @Import({MigrateReportingApplication.class, MigrateReportingConfiguration.class})
+    static class BatchTestConfig {
+        @Bean
+        JobLauncherTestUtils jobLauncherTestUtils() {
+            return new JobLauncherTestUtils();
+        }
+    }
+}

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/SpringBatchStepIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/SpringBatchStepIT.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting;
+
+import org.junit.Before;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.test.MetaDataInstanceFactory;
+
+
+public abstract class SpringBatchStepIT extends SpringBatchIT {
+
+    private StepExecution stepExecution;
+
+    @Before
+    public void createStepExecution() {
+        stepExecution = MetaDataInstanceFactory.createStepExecution();
+    }
+
+    protected JobExecution launchStep(String stepName, boolean useStepExecutionContext) {
+        if (useStepExecutionContext) return getJobLauncherTestUtils().launchStep(stepName, getStepExecutionContext());
+        else return getJobLauncherTestUtils().launchStep(stepName);
+    }
+
+    protected ExecutionContext getStepExecutionContext() {
+        return stepExecution.getExecutionContext();
+    }
+}

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/ReportingIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/ReportingIT.java
@@ -1,42 +1,31 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting.step;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateBatch;
-import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchIT;
+import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchStepIT;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.test.MetaDataInstanceFactory;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.MigrateReportingConfiguration.stepReportingName;
 
 
-public class ReportingIT extends SpringBatchIT {
-    private StepExecution stepExecution;
-
-    @Before
-    public void setUp() {
-        stepExecution = MetaDataInstanceFactory.createStepExecution();
-    }
+public class ReportingIT extends SpringBatchStepIT {
 
     @Test
-    public void testStep() throws Exception {
-        stepExecution.getExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList()));
+    public void testStep() {
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList()));
 
-        final JobExecution jobExecution = getJobLauncherTestUtils().launchStep(stepReportingName, stepExecution.getExecutionContext());
-
+        final JobExecution jobExecution = launchStep(stepReportingName, true);
         assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode());
     }
 
     @Test
-    public void testStepWithError() throws Exception {
-        stepExecution.getExecutionContext().put("batch", null);
+    public void testStepWithError() {
+        getStepExecutionContext().put("batch", null);
 
-        final JobExecution jobExecution = getJobLauncherTestUtils().launchStep(stepReportingName, stepExecution.getExecutionContext());
-
+        final JobExecution jobExecution = launchStep(stepReportingName, true);
         assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo("test_failure");
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/ReportingIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/ReportingIT.java
@@ -1,0 +1,42 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting.step;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateBatch;
+import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchIT;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.test.MetaDataInstanceFactory;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.MigrateReportingConfiguration.stepReportingName;
+
+
+public class ReportingIT extends SpringBatchIT {
+    private StepExecution stepExecution;
+
+    @Before
+    public void setUp() {
+        stepExecution = MetaDataInstanceFactory.createStepExecution();
+    }
+
+    @Test
+    public void testStep() throws Exception {
+        stepExecution.getExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList()));
+
+        final JobExecution jobExecution = getJobLauncherTestUtils().launchStep(stepReportingName, stepExecution.getExecutionContext());
+
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode());
+    }
+
+    @Test
+    public void testStepWithError() throws Exception {
+        stepExecution.getExecutionContext().put("batch", null);
+
+        final JobExecution jobExecution = getJobLauncherTestUtils().launchStep(stepReportingName, stepExecution.getExecutionContext());
+
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo("test_failure");
+    }
+}

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/WarehouseIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/WarehouseIT.java
@@ -1,18 +1,18 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting.step;
 
 import org.junit.Test;
-import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchIT;
+import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchStepIT;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.MigrateReportingConfiguration.stepWarehouseName;
 
-public class WarehouseIT extends SpringBatchIT {
+public class WarehouseIT extends SpringBatchStepIT {
 
     @Test
-    public void testStep() throws Exception {
-        final JobExecution jobExecution = getJobLauncherTestUtils().launchStep(stepWarehouseName);
+    public void createStepExecution() {
+        final JobExecution jobExecution = launchStep(stepWarehouseName, false);
 
         assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode());
     }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/WarehouseIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/WarehouseIT.java
@@ -1,0 +1,19 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting.step;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchIT;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.MigrateReportingConfiguration.stepWarehouseName;
+
+public class WarehouseIT extends SpringBatchIT {
+
+    @Test
+    public void testStep() throws Exception {
+        final JobExecution jobExecution = getJobLauncherTestUtils().launchStep(stepWarehouseName);
+
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode());
+    }
+}

--- a/migrate-reporting/src/test/resources/application-test.yml
+++ b/migrate-reporting/src/test/resources/application-test.yml
@@ -1,0 +1,32 @@
+spring:
+
+  batch_datasource:
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting-test?useSSL=false
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+
+  warehouse_datasource:
+    url: jdbc:mysql://localhost:3306/warehouse-test?useSSL=false
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+
+  reporting_datasource:
+    url: jdbc:mysql://localhost:3306/reporting-test?useSSL=false
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+
+  batch:
+    job:
+      enabled: false


### PR DESCRIPTION
This sets a framework for the batch and steps IT. All the code is just to show how it will/should be done. 

Since spring batch has its own transaction management, I was not able to find a way to make the transactions roll back at the end of the tests. This means that after Batch ITs execution, all three databases that have 'write' data will have the data in them: spring_batch_reporting, reporting, and staging.   Since we clean up the dbs before each IT run, and since Reporting ITs are not affected by this project, I do not think it is a big problem. Please let me know if you disagree.