### PR TITLE
DWR-359

### DIFF
--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepository.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepository.java
@@ -49,6 +49,9 @@ class JdbcReportRepository implements ReportRepository {
     @Value("${sql.import.status}")
     private String sqlImportStatus;
 
+    @Value("${sql.import.count}")
+    private String sqlImportCount;
+
     @Autowired
     public JdbcReportRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -72,6 +75,11 @@ class JdbcReportRepository implements ReportRepository {
         }
 
         return new ReconciliationReport(filename, baos.toByteArray());
+    }
+
+    @Override
+    public long countExamImports(final RdwImportQuery query) {
+        return jdbcTemplate.queryForObject(sqlImportCount, mapQueryToSqlParameterSource(query), Long.class);
     }
 
     @Override

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/ReportRepository.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/ReportRepository.java
@@ -9,11 +9,21 @@ import org.opentestsystem.rdw.ingest.tasking.model.ReconciliationReport;
 public interface ReportRepository {
     /**
      * Return a reconciliation report for exam imports matching the query parameters.
+     * Note that query content is ignored, only EXAM content is queried.
      *
-     * @param query import query; note that query.getContent() must be EXAM
+     * @param query import query
      * @return reconciliation report
      */
     ReconciliationReport getReconciliationReport(RdwImportQuery query);
+
+    /**
+     * Return count of exam import records matching the query parameters.
+     * Note that query content and status are ignored; EXAM content of any status is queried.
+     *
+     * @param query import query
+     * @return number of import records matching the query
+     */
+    long countExamImports(RdwImportQuery query);
 
     /**
      * @return return true if repository is available to get reports

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
@@ -36,6 +36,11 @@ public class DefaultReconciliationService implements ReconciliationService {
         final RdwImportQuery query = RdwImportQuery.builder().params(properties.getQuery()).build();
         checkArgument(!query.isEmpty(), "Report query must not be empty");
 
+        if (!anyImportActivity(query)) {
+            logger.info("No import activity, skipping reconciliation report");
+            return;
+        }
+
         final ReconciliationReport report = reportRepository.getReconciliationReport(query);
 
         try {
@@ -52,9 +57,20 @@ public class DefaultReconciliationService implements ReconciliationService {
             helper.addAttachment(report.getFilename(), new ByteArrayResource(report.getData()));
             mailSender.send(message);
         } catch (final MessagingException e) {
-            // To do: Is there anything more we can do here?
             logger.error("Failed to send reconciliation report.", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Determine if there as been any import activity by querying for all import records
+     * that match the query parameters while ignoring any status criterium.
+     *
+     * @param reportQuery query for generating report
+     * @return true if any import records exist matching query while ignoring status
+     */
+    private boolean anyImportActivity(final RdwImportQuery reportQuery) {
+        final RdwImportQuery query = reportQuery.copy().status((String) null).build();
+        return reportRepository.countExamImports(query) > 0;
     }
 }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/task/ReconciliationReportProperties.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/task/ReconciliationReportProperties.java
@@ -13,7 +13,7 @@ public class ReconciliationReportProperties {
         return query;
     }
 
-    public void setQuery(String query) {
+    public void setQuery(final String query) {
         this.query = query;
     }
 
@@ -21,22 +21,22 @@ public class ReconciliationReportProperties {
         return email;
     }
 
-    public void setEmail(Email email) {
+    public void setEmail(final Email email) {
         this.email = email;
     }
 
     @ConfigurationProperties
     public static class Email {
-        private String to;
+        private String[] to;
         private String from;
         private String subject;
         private String message;
 
-        public String getTo() {
+        public String[] getTo() {
             return to;
         }
 
-        public void setTo(String to) {
+        public void setTo(final String[] to) {
             this.to = to;
         }
 
@@ -44,7 +44,7 @@ public class ReconciliationReportProperties {
             return from;
         }
 
-        public void setFrom(String from) {
+        public void setFrom(final String from) {
             this.from = from;
         }
 
@@ -52,7 +52,7 @@ public class ReconciliationReportProperties {
             return subject;
         }
 
-        public void setSubject(String subject) {
+        public void setSubject(final String subject) {
             this.subject = subject;
         }
 
@@ -60,7 +60,7 @@ public class ReconciliationReportProperties {
             return message;
         }
 
-        public void setMessage(String message) {
+        public void setMessage(final String message) {
             this.message = message;
         }
     }

--- a/task-service/src/main/resources/application.sql.yml
+++ b/task-service/src/main/resources/application.sql.yml
@@ -7,7 +7,7 @@ sql:
         JOIN exam_student es ON es.id = e.exam_student_id
         JOIN student s ON s.id = es.student_id
         JOIN asmt a ON a.id = e.asmt_id
-      WHERE (:content IS NULL OR i.content=:content)
+      WHERE (i.content=1)
         AND (:status IS NULL OR i.status = :status)
         AND (:batch IS NULL OR i.batch = :batch)
         AND (:creator IS NULL OR i.creator = :creator)
@@ -22,13 +22,21 @@ sql:
         JOIN iab_exam_student ies ON ies.id = ie.iab_exam_student_id
         JOIN student s ON s.id = ies.student_id
         JOIN asmt a ON a.id = ie.asmt_id
-      WHERE (:content IS NULL OR i.content=:content)
+      WHERE (i.content=1)
         AND (:status IS NULL OR i.status = :status)
         AND (:batch IS NULL OR i.batch = :batch)
         AND (:creator IS NULL OR i.creator = :creator)
         AND (:before IS NULL OR i.created < :before)
         AND (:after IS NULL OR i.created > :after)
       LIMIT 100000
+
+    count: >-
+      SELECT count(*) FROM import i
+      WHERE (content=1)
+        AND (:batch IS NULL OR i.batch = :batch)
+        AND (:creator IS NULL OR i.creator = :creator)
+        AND (:before IS NULL OR i.created < :before)
+        AND (:after IS NULL OR i.created > :after)
 
     status: >-
       SELECT  s.ssid, a.natural_id, ie.completed_at

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 task:
   send-reconciliation-report:
     cron: 0 0 14 * * *
-    query: content=EXAM&status=PROCESSED&after=-PT24H
+    query: status=PROCESSED&after=-PT24H
     email:
       to: fairway.sbac.rdw.dev@gmail.com
       from: fairway.sbac.rdw.dev@gmail.com

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepositoryIT.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepositoryIT.java
@@ -68,6 +68,12 @@ public class JdbcReportRepositoryIT {
     }
 
     @Test
+    public void itShouldCount() {
+        // this won't work if there are pre-existing import records
+        assertThat(repository.countExamImports(RdwImportQuery.builder().build())).isEqualTo(3);
+    }
+
+    @Test
     public void itShouldBeAvailable() {
         assertThat(repository.isAvailable()).isTrue();
     }

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationServiceTest.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationServiceTest.java
@@ -14,14 +14,17 @@ import javax.mail.internet.MimeMessage;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class DefaultReconciliationServiceTest {
     private DefaultReconciliationService reconciliationService;
-    private JavaMailSender javaMailSender;
     private ReportRepository reportRepository;
+    private JavaMailSender javaMailSender;
     private MimeMessage messageSpy;
     private String querySpy;
 
@@ -32,6 +35,7 @@ public class DefaultReconciliationServiceTest {
 
         messageSpy = new MimeMessage(Session.getInstance(new Properties()));
         when(javaMailSender.createMimeMessage()).thenReturn(messageSpy);
+        when(reportRepository.countExamImports(any(RdwImportQuery.class))).thenReturn(5L);
         when(reportRepository.getReconciliationReport(isA(RdwImportQuery.class))).thenAnswer(invocation -> {
                     querySpy = ((RdwImportQuery)invocation.getArguments()[0]).asParamString();
                     return new ReconciliationReport("sample.csv", new byte[20]);
@@ -43,27 +47,45 @@ public class DefaultReconciliationServiceTest {
 
     @Test
     public void itShouldSendReportWithConfiguredValues() throws MessagingException {
+        final ReconciliationReportProperties props = createProperties();
+
+        reconciliationService.sendReport(props);
+
+        assertThat(messageSpy.getAllRecipients()[0].toString()).isEqualTo(props.getEmail().getTo()[0]);
+        assertThat(messageSpy.getFrom()[0].toString()).isEqualTo(props.getEmail().getFrom());
+        assertThat(messageSpy.getSubject()).isEqualTo(props.getEmail().getSubject());
+        assertThat(querySpy).isEqualTo(props.getQuery());
+    }
+
+    @Test
+    public void itShouldNotSendAReportIfThereHaveBeenNoImports() {
+        when(reportRepository.countExamImports(any(RdwImportQuery.class))).thenReturn(0L);
+
+        reconciliationService.sendReport(createProperties());
+
+        verify(reportRepository).countExamImports(any(RdwImportQuery.class));
+        verifyNoMoreInteractions(reportRepository, javaMailSender);
+    }
+
+    private ReconciliationReportProperties createProperties() {
         final String from = "ops@example.com";
-        final String to = "customer@example.com";
+        final String[] to = new String[]{"customer@example.com"};
         final String subject = "This is the subject";
         final String message = "This is the body";
         final String query = "status=PROCESSED";
 
-        ReconciliationReportProperties.Email email = new ReconciliationReportProperties.Email();
+        final ReconciliationReportProperties.Email email = new ReconciliationReportProperties.Email();
         email.setFrom(from);
         email.setTo(to);
         email.setSubject(subject);
         email.setMessage(message);
 
-        ReconciliationReportProperties props = new ReconciliationReportProperties();
+        final ReconciliationReportProperties props = new ReconciliationReportProperties();
         props.setEmail(email);
         props.setQuery(query);
 
-        reconciliationService.sendReport(props);
-
-        assertThat(messageSpy.getAllRecipients()[0].toString()).isEqualTo(to);
-        assertThat(messageSpy.getFrom()[0].toString()).isEqualTo(from);
-        assertThat(messageSpy.getSubject()).isEqualTo(subject);
-        assertThat(querySpy).isEqualTo(query);
+        return props;
     }
+
+
 }


### PR DESCRIPTION
skip the report if there have been no exam imports
allow email to have multiple "to" recipients

This came from talking to Venu. He doesn't think a report should be sent if no imports were attempted in the query period. He also said they would want multiple recipients; i know we could push back and tell them to use a distribution but we're going to want to send the emails to ops ... and it was an easy change.