### PR TITLE
Remove all entities and upsertOrganizations.

### DIFF
--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingConfiguration.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingConfiguration.java
@@ -48,7 +48,9 @@ public class MigrateReportingConfiguration {
     public Job migrateReportingJob(@Qualifier("warehouseStep") final Step warehouse,
                                    @Qualifier("warehouseCheckStep") final Step warehouseCheck,
                                    @Qualifier("upsertCodesStep") final Step upsertCodes,
-                                   @Qualifier("deleteCodesStep") final Step deleteCodes) {
+                                   @Qualifier("deleteEntitiesStep") final Step deleteEntitiesStep,
+                                   @Qualifier("deleteCodesStep") final Step deleteCodes,
+                                   @Qualifier("upsertOrganizationStep") final Step upsertOrganizationStep) {
         try {
 
             return jobBuilderFactory.get("Migrate Reporting Job")
@@ -57,6 +59,8 @@ public class MigrateReportingConfiguration {
                     .start(warehouse)
                     .next(warehouseCheck)
                     .next(upsertCodes)
+                    .next(deleteEntitiesStep)
+                    .next(upsertOrganizationStep)
                     .next(deleteCodes)
                     .build();
         } catch (Exception e) {

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/StagingToReportingStepsConfig.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/StagingToReportingStepsConfig.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.opentestsystem.rdw.ingest.common.model.ImportContent.CODES;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.EXAM;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.PACKAGE;
 
 /**
  * Configuration for batch steps responsible for moving the data from staging to reporting
@@ -25,6 +27,8 @@ public class StagingToReportingStepsConfig {
 
     public static final String stepUpsertCodesName = "stepUpsertCodes";
     public static final String stepDeleteCodesName = "stepDeleteCodes";
+    public static final String stepDeleteEntities = "stepDeleteEntities";
+    public static final String stepUpsertOrganization = "stepUpsertOrganization";
 
     @Autowired
     public StagingToReportingStepsConfig(final StepBuilderFactory stepBuilderFactory,
@@ -34,6 +38,56 @@ public class StagingToReportingStepsConfig {
         this.stepBuilderFactory = stepBuilderFactory;
         this.stagingToWarehouseSqlConfiguration = stagingToWarehouseSqlConfiguration;
         this.sqlListExecutionRepository = sqlListExecutionRepository;
+    }
+
+    // main entities in the order to be migrated due to the dependencies
+    public static final List<String> entities = newArrayList(
+            "district",
+            "school",
+
+            "asmt",
+            "item",
+            "asmt_score",
+
+            "student",
+            "student_ethnicity",
+            "student_group",
+            "user_student_group",
+            "student_group_membership",
+
+            "exam",
+            "exam_item",
+            "exam_available_accommodation",
+            "iab_exam",
+            "iab_exam_item",
+            "iab_exam_available_accommodation");
+
+    @Bean
+    public Step deleteEntitiesStep() {
+        final SqlListBuilder sqlsBuilder = new SqlListBuilder(stagingToWarehouseSqlConfiguration.getEntities());
+        for (final String entity : Lists.reverse(entities)) {
+            sqlsBuilder.addNext(entity, "delete");
+        }
+        return stepBuilderFactory.get(stepDeleteEntities)
+                //TODO: add SCHOOL and GROUPS when they are defined
+                .tasklet(new SqlListExecutionStep(newArrayList(PACKAGE, EXAM),
+                        sqlListExecutionRepository,
+                        sqlsBuilder.build())).build();
+    }
+
+    @Bean
+    public Step upsertOrganizationStep() {
+        final SqlListBuilder sqlsBuilder = new SqlListBuilder(stagingToWarehouseSqlConfiguration.getEntities());
+        sqlsBuilder.addNext("district", "update")
+                .addNext("district", "insert")
+                .addNext("school", "update")
+                .addNext("school", "insert");
+
+        return stepBuilderFactory.get(stepUpsertOrganization)
+                //TODO: add SCHOOL
+                .tasklet(new SqlListExecutionStep(newArrayList(EXAM),
+                        sqlListExecutionRepository,
+                        sqlsBuilder.build())).build();
     }
 
     // Code entities, in the order to be migrated due to the dependencies noted below

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/Warehouse.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/Warehouse.java
@@ -37,9 +37,9 @@ public class Warehouse extends StepTasklet {
 
         logger.info("=== query for warehouse ===  Max exam import id: " + max);
         final List<ImportContent> contentList = newArrayList();
-        // fake in CODES to be able to test the job with codes
-        if (max == null) contentList.add(ImportContent.CODES);
-        else contentList.add(ImportContent.EXAM);
+        // fake in ImportContent to be able to test the job with multiple steps
+        contentList.add(ImportContent.CODES);
+        contentList.add(ImportContent.EXAM);
 
         setJobBatch(chunkContext, new MigrateBatch(0, 1000, contentList));
         return RepeatStatus.FINISHED;

--- a/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
@@ -315,3 +315,160 @@ sql:
             delete: >-
                 DELETE ridc FROM reporting.item_difficulty_cuts ridc
                     WHERE NOT EXISTS(SELECT id FROM staging.staging_item_difficulty_cuts WHERE id = ridc.id);
+
+      # ############## IAB Exams #######################################################################
+      # ------------ iab_exam_available_accommodation --------------------------------------------------
+        iab_exam_available_accommodation:
+          sql:
+            delete: >-
+              DELETE FROM reporting.iab_exam_available_accommodation
+                WHERE iab_exam_id IN
+                      (SELECT id from staging.staging_iab_exam WHERE deleted = 1 );
+
+        # ------------ iab_exam_item -------------------------------------------------------------------
+        iab_exam_item:
+          sql:
+            delete: >-
+              DELETE FROM reporting.iab_exam_item
+                WHERE iab_exam_id IN (SELECT id from staging.staging_iab_exam WHERE deleted = 1 );
+
+        # ------------ iab_exam -------------------------------------------------------------------
+        iab_exam:
+          sql:
+            delete: >-
+              DELETE FROM reporting.iab_exam
+                WHERE id IN (SELECT id from staging.staging_iab_exam WHERE deleted = 1 );
+
+        # ############## ICA and Summative Exams ####################################################################
+        # ------------ exam_available_accommodation -------------------------------------------------------------------
+        exam_available_accommodation:
+          sql:
+            delete: >-
+              DELETE FROM reporting.exam_available_accommodation
+                WHERE exam_id IN (SELECT id from staging.staging_exam WHERE deleted = 1 );
+
+        # ------------ exam_item -------------------------------------------------------------------
+        exam_item:
+          sql:
+            delete: >-
+              DELETE FROM reporting.exam_item
+                WHERE exam_id IN (SELECT id from staging.staging_exam WHERE deleted = 1 );
+
+        # ------------ exam -------------------------------------------------------------------
+        exam:
+          sql:
+            delete: >-
+              DELETE FROM reporting.exam WHERE id IN (SELECT id from staging.staging_exam WHERE deleted = 1 );
+
+      # ############## Student Group #######################################################################
+      # ------------ iab_exam_available_accommodation --------------------------------------------------
+        student_group_membership:
+          sql:
+            delete: >-
+              DELETE from reporting.student_group_membership
+                WHERE student_group_id IN
+                  (SELECT id FROM staging.staging_student_group WHERE deleted = 1 or active = 0);
+
+      # ------------ user_student_group --------------------------------------------------
+        user_student_group:
+          sql:
+            delete: >-
+              DELETE from reporting.user_student_group
+                WHERE student_group_id IN
+                  (SELECT id FROM staging.staging_student_group WHERE deleted = 1 or active = 0);
+
+      # ------------ student_group --------------------------------------------------
+        student_group:
+          sql:
+            delete: >-
+              DELETE FROM reporting.student_group
+                WHERE id IN
+                  (SELECT id FROM staging.staging_student_group WHERE deleted = 1 or active = 0);
+
+      # ############## School/District ###################################################################
+      # ------------ school ------------------------------------------------------------------------------
+        school:
+          sql:
+            insert: >-
+              INSERT INTO reporting.school (id, natural_id, name, district_id, import_id)
+               SELECT
+                 ss.id,
+                 ss.natural_id,
+                 ss.name,
+                 ss.district_id,
+                 ss.import_id
+               FROM staging.staging_school ss
+                 LEFT JOIN reporting.school rs ON rs.id = ss.id
+               WHERE rs.id IS NULL AND ss.deleted = 0;
+
+            update: >-
+              UPDATE reporting.school rs
+                JOIN staging.staging_school ss ON ss.id = rs.id
+              SET rs.name = ss.name,
+                rs.district_id = ss.district_id,
+                rs.import_id = ss.import_id
+              WHERE ss.deleted = 0;
+
+            delete: >-
+              DELETE FROM reporting.school WHERE id IN (SELECT id FROM staging.staging_school WHERE deleted = 1);
+
+      # ------------ district ------------------------------------------------------------------------------
+        district:
+          sql:
+            insert: >-
+              INSERT INTO reporting.district(id, natural_id,name)
+                SELECT
+                  sd.id,
+                  sd.natural_id,
+                  sd.name
+                FROM staging.staging_district sd
+                  LEFT JOIN reporting.district rd ON rd.id = sd.id
+                WHERE rd.id IS NULL;
+
+            update: >-
+              UPDATE reporting.district d
+                JOIN staging.staging_district sd ON sd.id = d.id
+              SET d.name = sd.name;
+
+            delete: >-
+              DELETE FROM reporting.district
+                WHERE id in (SELECT district_id from staging.staging_school WHERE deleted = 1)
+                    AND NOT EXISTS(SELECT id from reporting.school WHERE district_id = id);
+
+      # ############## Student  ###################################################################
+      # ------------ student_ethnicity -----------------------------------------------------------------------
+        student_ethnicity:
+          sql:
+            delete: >-
+              DELETE FROM reporting.student_ethnicity
+                WHERE student_id IN (SELECT id FROM staging.staging_student WHERE deleted = 1);
+
+      # ------------ student -----------------------------------------------------------------------
+        student:
+          sql:
+            delete: >-
+              DELETE FROM reporting.student
+                WHERE id in (SELECT id FROM staging.staging_student WHERE deleted = 1);
+
+      # ############## Assessment  ###################################################################
+      # ------------ asmt_score -----------------------------------------------------------------------
+        asmt_score:
+          sql:
+            delete: >-
+              DELETE FROM reporting.asmt_score
+                WHERE asmt_id IN (SELECT id FROM staging.staging_asmt WHERE deleted = 1);
+
+      # ------------ item -----------------------------------------------------------------------
+        item:
+          sql:
+            delete: >-
+              DELETE FROM reporting.item
+                WHERE asmt_id IN (SELECT id FROM staging.staging_asmt WHERE deleted = 1);
+
+      # ------------ asmt -----------------------------------------------------------------------
+        asmt:
+          sql:
+            delete: >-
+                DELETE FROM reporting.asmt
+                  WHERE id IN (SELECT id FROM staging.staging_asmt WHERE deleted = 1);
+

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
@@ -24,8 +24,10 @@ public class ReportingMigrateJobIT extends SpringBatchIT {
     private JdbcTemplate jdbcTemplate;
 
     @SqlGroup({
+            //TODO: this should be changed to be handled by the migration from warehouse to staging
             //loads all code tables with one row each with id = -98
             @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingForDeleteSetup.sql"}),
+
             //loads all code tables with one row each with id = -99
             @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesPreloadReportingSetup.sql"}),
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
@@ -47,7 +49,32 @@ public class ReportingMigrateJobIT extends SpringBatchIT {
             }
         }
 
-        //TODO: for now the warehouse tasks adds ImportContent.CODES to the batch if import table is empty
+        //TODO: for now the warehouse tasks adds ImportContent.CODES
+        final JobExecution jobExecution = getJobLauncherTestUtils().launchJob();
+
+        assertThat(jobExecution.getExitStatus()).isEqualTo(COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            //TODO: this should be changed to be handled by the migration from warehouse to staging
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingForDeleteSetup.sql"}),
+
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesPreloadReportingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldUpsertAndDeleteEntities() throws Exception {
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", -1, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 1, "id IN (-98)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", -1, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 1, "id IN (-98)"));
+
+        //TODO: for now the warehouse tasks adds ImportContent.CODES and EXAM
         final JobExecution jobExecution = getJobLauncherTestUtils().launchJob();
 
         assertThat(jobExecution.getExitStatus()).isEqualTo(COMPLETED);

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/StagingToReportingStepsConfigIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/StagingToReportingStepsConfigIT.java
@@ -25,9 +25,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.ingest.common.model.ImportContent.CODES;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.EXAM;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.PACKAGE;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.codesEntities;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.entities;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.stepDeleteCodesName;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.stepDeleteEntities;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.stepUpsertCodesName;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.stepUpsertOrganization;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {SpringBatchIT.BatchTestConfig.class})
@@ -90,6 +95,50 @@ public class StagingToReportingStepsConfigIT {
         }
 
         assertThat(argument.getSupportedContents()).containsExactly(CODES);
+        assertThat(argument.getSqls()).containsExactlyElementsOf(expectedSqls);
+    }
+
+    @Test
+    public void verifyDeleteEntitiesStepConfiguration() {
+        final StepBuilder stepBuilder = mock(StepBuilder.class);
+        when(stepBuilderFactory.get(stepDeleteEntities)).thenReturn(stepBuilder);
+        when(stepBuilder.tasklet(any())).thenReturn(mock(TaskletStepBuilder.class));
+        final ArgumentCaptor<SqlListExecutionStep> captor = ArgumentCaptor.forClass(SqlListExecutionStep.class);
+
+        configUnderTest.deleteEntitiesStep();
+        verify(stepBuilder).tasklet(captor.capture());
+
+        final SqlListExecutionStep argument = captor.getValue();
+
+        final List<String> expectedSqls = newArrayList();
+        for (final String table : Lists.reverse(entities)) {
+            expectedSqls.add(sqlConfig.getEntities().get(table).getSql().get("delete"));
+        }
+
+        assertThat(argument.getSupportedContents()).containsExactly(PACKAGE, EXAM);
+        assertThat(argument.getSqls()).containsExactlyElementsOf(expectedSqls);
+    }
+
+    @Test
+    public void verifyUpsertOrganizationStepConfiguration() {
+        final StepBuilder stepBuilder = mock(StepBuilder.class);
+        when(stepBuilderFactory.get(stepUpsertOrganization)).thenReturn(stepBuilder);
+        when(stepBuilder.tasklet(any())).thenReturn(mock(TaskletStepBuilder.class));
+        final ArgumentCaptor<SqlListExecutionStep> captor = ArgumentCaptor.forClass(SqlListExecutionStep.class);
+
+        configUnderTest.upsertOrganizationStep();
+        verify(stepBuilder).tasklet(captor.capture());
+
+        final SqlListExecutionStep argument = captor.getValue();
+
+
+        final List<String> expectedSqls = newArrayList();
+        expectedSqls.add(sqlConfig.getEntities().get("district").getSql().get("update"));
+        expectedSqls.add(sqlConfig.getEntities().get("district").getSql().get("insert"));
+        expectedSqls.add(sqlConfig.getEntities().get("school").getSql().get("update"));
+        expectedSqls.add(sqlConfig.getEntities().get("school").getSql().get("insert"));
+
+        assertThat(argument.getSupportedContents()).containsExactly(EXAM);
         assertThat(argument.getSqls()).containsExactlyElementsOf(expectedSqls);
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/DeleteEntitiesIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/DeleteEntitiesIT.java
@@ -1,0 +1,89 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting.step;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateBatch;
+import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchStepIT;
+import org.opentestsystem.rdw.ingest.migrate.reporting.TableTestCountHelper;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.stepDeleteEntities;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.TableTestCountHelper.verifyTableCountsAfterTest;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+public class DeleteEntitiesIT extends SpringBatchStepIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingForDeleteSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesPreloadReportingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldDeleteButNotInsertEntities() {
+
+        //TODO: add more entities to this test
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", -1, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 0, "id IN (-98)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", -1, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 0, "id IN (-98)"));
+
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList(ImportContent.EXAM)));
+
+        // run the step first time
+        JobExecution jobExecution = launchStep(stepDeleteEntities);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+
+        //repeat to verify that it is idempotent
+        jobExecution = launchStep(stepDeleteEntities);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingForDeleteSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesPreloadReportingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldDoNothingIfBatchDoesNotHaveRightImportContent() {
+
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 0, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 0, "id IN (-98)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 0, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 0, "id IN (-98)"));
+
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList(ImportContent.CODES)));
+
+        // run the step first time
+        JobExecution jobExecution = launchStep(stepDeleteEntities);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+
+        //repeat to verify that it is idempotent
+        jobExecution = launchStep(stepDeleteEntities);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+}

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertOrganizationIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertOrganizationIT.java
@@ -1,0 +1,131 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting.step;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateBatch;
+import org.opentestsystem.rdw.ingest.migrate.reporting.SpringBatchStepIT;
+import org.opentestsystem.rdw.ingest.migrate.reporting.TableTestCountHelper;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.StagingToReportingStepsConfig.stepUpsertOrganization;
+import static org.opentestsystem.rdw.ingest.migrate.reporting.TableTestCountHelper.verifyTableCountsAfterTest;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+public class UpsertOrganizationIT extends SpringBatchStepIT {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldDoNothingIfBatchDoesNotHaveRightImportContent() {
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 0, "id IN (-98, -99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 0, "id IN (-98, -99)"));
+
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList(ImportContent.CODES)));
+
+        JobExecution jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldInsert() {
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 2, "id IN (-98, -99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 2, "id IN (-98, -99)"));
+
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList(ImportContent.EXAM)));
+
+        // run the step first time
+        JobExecution jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+
+        //repeat to verify that it is idempotent
+        jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesPreloadReportingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldUpdateAndInsert() {
+
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 1, "id IN (-98, -99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", -1, "name like 'Before Test%'"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 1, "id IN (-98, -99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", -1, "name like 'Before Test%'"));
+
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList(ImportContent.EXAM)));
+
+        // run the step first time
+        JobExecution jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+
+        //repeat to verify that it is idempotent
+        jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingForDeleteSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesPreloadReportingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTierDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTierDown.sql"})
+    })
+    @Test
+    public void itShouldInsertButNoteDeleteCodes() {
+
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 0, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.school", 1, "id IN (-98)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 0, "id IN (-99)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "`reporting-test`.district", 1, "id IN (-98)"));
+
+        getStepExecutionContext().put("batch", new MigrateBatch(1, 1, newArrayList(ImportContent.EXAM)));
+
+        // run the step first time
+        JobExecution jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+
+        //repeat to verify that it is idempotent
+        jobExecution = launchStep(stepUpsertOrganization);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+}

--- a/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingForDeleteSetup.sql
+++ b/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingForDeleteSetup.sql
@@ -1,0 +1,3 @@
+UPDATE `staging-test`.staging_school SET deleted = 1 WHERE id = -99;
+-- district in the staging should have only updated or inserted rows
+DELETE FROM `staging-test`.staging_district WHERE id = -99;

--- a/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingSetup.sql
+++ b/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingSetup.sql
@@ -1,0 +1,11 @@
+INSERT INTO `staging-test`.staging_district (id, name, natural_id, migrate_id) VALUES
+  (-99, 'Sample District -99', 'natural_id-99', -99);
+
+INSERT INTO `staging-test`.staging_district (id, name, natural_id, migrate_id) VALUES
+  (-98, 'Sample District -98', 'natural_id-98', -99);
+
+INSERT INTO `staging-test`.staging_school (id, district_id, name, natural_id, deleted, migrate_id, import_id) VALUES
+  (-99, -99, 'Sample School -99', 'natural_id-99', 0, -99, -1);
+
+INSERT INTO `staging-test`.staging_school (id, district_id, name, natural_id, deleted, migrate_id, import_id) VALUES
+  (-98, -98, 'Sample School -98', 'natural_id-98', 0, -99, -1);

--- a/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingTierDown.sql
+++ b/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingTierDown.sql
@@ -1,0 +1,16 @@
+-- CLEAN UP staging
+DElETE FROM `staging-test`.staging_school where id in ( -99, -98);
+DElETE FROM `staging-test`.staging_district where id in ( -99, -98);
+
+DElETE FROM `staging-test`.staging_item where id in ( -990, -991, -992, -993, -980, -981, -982, -983, -984);
+DElETE FROM `staging-test`.staging_asmt_score where asmt_id in ( -99, -98);
+DElETE FROM `staging-test`.staging_asmt where id in ( -99, -98);
+
+-- CLEAN UP reporting
+DElETE FROM `reporting-test`.school where id in ( -99, -98);
+DElETE FROM `reporting-test`.district where id in ( -99, -98);
+
+DElETE FROM `reporting-test`.item where id in ( -990, -991, -992, -993, -980, -981, -982, -983, -984);
+DElETE FROM `reporting-test`.asmt_score where asmt_id in ( -99, -98);
+DElETE FROM `reporting-test`.asmt where id in ( -99, -98);
+

--- a/migrate-reporting/src/test/resources/MigrateEntitiesPreloadReportingSetup.sql
+++ b/migrate-reporting/src/test/resources/MigrateEntitiesPreloadReportingSetup.sql
@@ -1,0 +1,5 @@
+INSERT INTO `reporting-test`.district (id, name, natural_id) VALUES
+  (-99, 'Before Test -99', 'natural_id-99');
+
+INSERT INTO `reporting-test`.school (id, district_id, name, natural_id, import_id) VALUES
+  (-99, -99, 'Before Test -99', 'natural_id-99', -1);


### PR DESCRIPTION
The flow (at least for now) is to handle all the 'delete' first, and then process updates/inserts.
This adds the 'delete' all entities step and a step to update/insert School and Districts.
The tests for 'delete' is not completed, because I was lazy to load all the data. I am going to keep adding to that test as more migration is done.
