### PR TITLE
change imports end-points

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportContent.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportContent.java
@@ -23,6 +23,6 @@ public enum ImportContent {
         for (final ImportContent status : ImportContent.values()) {
             if (value == status.value) return status;
         }
-        throw new IllegalArgumentException("Unknown ImportContent value.");
+        throw new IllegalArgumentException("Unknown ImportContent value: " + value);
     }
 }

--- a/import-service/API.md
+++ b/import-service/API.md
@@ -153,7 +153,7 @@ This end-point may be used to get the current status of an import request.
 
 This end-point requires credentials with the `ASMTDATALOAD` role.
 
-* URL: `/exams/imports/{id}`
+* URL: `/imports/{id}`
 * Method: `GET`
 * Params: none
 * Headers:
@@ -173,13 +173,13 @@ This end-point requires credentials with the `ASMTDATALOAD` role.
   "message": "{\"elementName\":\"Sex\",\"value\":\"M\",\"error\":\"unknown gender name [M]\"},{\"elementName\":\"GradeLevelWhenAssessed\",\"value\":\"SIXTHGRADE\",\"error\":\"unknown grade code [SIXTHGRADE]\"}",
   "_links": {
     "self": {
-      "href": "http://localhost:8080/exams/imports/19529"
+      "href": "http://localhost:8080/imports/19529"
     },
     "payload": {
-      "href": "http://localhost:8080/exams/imports/19529/payload"
+      "href": "http://localhost:8080/imports/19529/payload"
     },
     "payload-properties": {
-      "href": "http://localhost:8080/exams/imports/19529/payload/properties"
+      "href": "http://localhost:8080/imports/19529/payload/properties"
     }  
   }
 }
@@ -190,7 +190,7 @@ This end-point requires credentials with the `ASMTDATALOAD` role.
   * Code: 404 (Not Found) if no import with the given id exists.
 * Sample Call (curl):
 ```bash
-curl --header "Authorization:Bearer {access_token}" https://import-service/exams/imports/19529
+curl --header "Authorization:Bearer {access_token}" https://import-service/imports/19529
 ```
 
 #### Get Import Payload
@@ -198,7 +198,7 @@ This end-point may be used to get the payload for an import request.
 
 This end-point requires credentials with the `ASMTDATALOAD` role.
 
-* URL: `/exams/imports/{id}/payload`
+* URL: `/imports/{id}/payload`
 * Method: `GET`
 * Params: none
 * Headers:
@@ -212,7 +212,7 @@ This end-point requires credentials with the `ASMTDATALOAD` role.
   * Code: 404 (Not Found) if no import with the given id exists.
 * Sample Call (curl):
 ```bash
-curl --header "Authorization:Bearer {access_token}" https://import-service/exams/imports/19529/payload
+curl --header "Authorization:Bearer {access_token}" https://import-service/imports/19529/payload
 ```
 
 #### Get Import Payload Properties
@@ -221,7 +221,7 @@ the properties for an import are stored in the data warehouse, some are archived
 
 This end-point requires credentials with the `ASMTDATALOAD` role.
 
-* URL: `/exams/imports/{id}/payload/properties`
+* URL: `/imports/{id}/payload/properties`
 * Method: `GET`
 * Params: none
 * Headers:
@@ -244,7 +244,7 @@ This end-point requires credentials with the `ASMTDATALOAD` role.
   * Code: 404 (Not Found) if no import with the given id exists.
 * Sample Call (curl):
 ```bash
-curl --header "Authorization:Bearer {access_token}" https://import-service/exams/imports/19529/payload/properties
+curl --header "Authorization:Bearer {access_token}" https://import-service/imports/19529/payload/properties
 ```
 
 ### Status Endpoints

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
@@ -86,6 +86,7 @@ public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
                     .antMatchers("/packages/**").hasAuthority(DataLoadAuthority)
                     .antMatchers("/accommodations/imports/resubmit").authenticated()
                     .antMatchers("/accommodations/**").hasAuthority(DataLoadAuthority)
+                    .antMatchers("/imports/**").hasAuthority(DataLoadAuthority)
                     .antMatchers("/status").authenticated()
                     .antMatchers("/**").permitAll();
             }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/AccommodationController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/AccommodationController.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,23 +18,21 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
-import static java.util.Collections.singletonMap;
 
 /**
  * Controller for accommodation code end-points
  */
 @RestController
 @RequestMapping({ "/accommodations" })
-class AccommodationController extends ImportController {
+class AccommodationController extends ScopedImportController {
 
     @Autowired
     public AccommodationController(final ImportService service) {
-        super(service, ImportContent.CODES, new ImportResourceAssembler(AccommodationController.class));
+        super(service, ImportContent.CODES);
     }
 
     @PostMapping(value = "/imports")
@@ -43,8 +40,8 @@ class AccommodationController extends ImportController {
     public RdwImportResource postImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                         @RequestHeader(value = CONTENT_TYPE, required = false) final String contentType,
                                         @RequestBody final byte[] body,
-                                        @RequestParam(required = false) final String batch) {
-        return super.postImport(sbacUser, contentType, body, singletonMap("batch", batch));
+                                        @RequestParam final Map<String, String> requestParams) {
+        return super.postImport(sbacUser, contentType, body, requestParams);
     }
 
     @PostMapping(value = "/imports", consumes = "multipart/form-data")
@@ -52,22 +49,6 @@ class AccommodationController extends ImportController {
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
         return super.uploadImport(sbacUser, request);
-    }
-
-    @GetMapping("/imports/{id}/payload")
-    public ResponseEntity<Void> downloadImportPayload(@PathVariable final long id, final HttpServletResponse response) {
-        return super.downloadImportPayload(id, response);
-    }
-
-    @GetMapping("/imports/{id}/payload/properties")
-    public Properties getImportPayloadProperties(@PathVariable final Long id) {
-        return super.getImportPayloadProperties(id);
-    }
-
-    @GetMapping(value = "/imports/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    public RdwImportResource getImport(@PathVariable final Long id) {
-        return super.getImport(id);
     }
 
     @GetMapping(value = "/imports")
@@ -81,5 +62,4 @@ class AccommodationController extends ImportController {
     public ResponseEntity<Long> resubmitImports(final RdwImportQuery inputQuery) {
         return super.resubmitImports(inputQuery);
     }
-
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,10 +18,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
@@ -31,11 +28,11 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
  */
 @RestController
 @RequestMapping({ "/exams" })
-class ExamController extends ImportController {
+class ExamController extends ScopedImportController {
 
     @Autowired
     public ExamController(final ImportService service) {
-        super(service, ImportContent.EXAM, new ImportResourceAssembler(ExamController.class));
+        super(service, ImportContent.EXAM);
     }
 
     @PostMapping(value = "/imports")
@@ -52,21 +49,6 @@ class ExamController extends ImportController {
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
         return super.uploadImport(sbacUser, request);
-    }
-
-    @GetMapping("/imports/{id}")
-    public RdwImportResource getImport(@PathVariable final Long id) {
-        return super.getImport(id);
-    }
-
-    @GetMapping("/imports/{id}/payload")
-    public ResponseEntity<Void> downloadImportPayload(@PathVariable final long id, final HttpServletResponse response) {
-        return super.downloadImportPayload(id, response);
-    }
-
-    @GetMapping("/imports/{id}/payload/properties")
-    public Properties getImportPayloadProperties(@PathVariable final Long id) {
-        return super.getImportPayloadProperties(id);
     }
 
     @GetMapping("/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ImportController.java
@@ -1,103 +1,45 @@
 package org.opentestsystem.rdw.ingest.web;
 
-import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
-import org.opentestsystem.rdw.ingest.common.model.ImportContent;
-import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
-import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
-import static com.google.common.collect.Maps.newHashMap;
-
 /**
- * All the controllers in this package do the same thing with slight configurable differences.
- * Although we could use pattern matching and other cleverness, it is fighting the way the Spring
- * framework likes to do things. So the common functionality is pulled into this base class.
+ * Controller for import end-points.
  * <p>
- * Another way to fix this issue would be to remove the "content" from the request path. Instead of:<pre>
- * POST ./exams/imports
- * GET ./exams/imports?status=BAD_DATA
- * GET ./exams/imports/{id} </pre>
- * it would be:<pre>
- * POST ./imports/exams
- * GET ./imports?content=EXAM&status=BAD_DATA
- * GET ./imports/{id}
- * </pre>
+ * These are end-points that are independent of the content.
  * </p>
- *
- * @see ExamController
- * @see ReportingPackageController
- * @see ImportResourceAssembler
- * @see AccommodationController
  */
 @SuppressWarnings("ConstantConditions")
-abstract class ImportController {
+@RestController
+@RequestMapping({ "/imports" })
+class ImportController {
 
     private final ImportService service;
-    private final ImportContent content;
-    private final ResourceAssemblerSupport<RdwImport, RdwImportResource> assembler;
+    private final ImportResourceAssembler assembler;
 
-    protected ImportController(final ImportService service,
-                               final ImportContent content,
-                               final ResourceAssemblerSupport<RdwImport, RdwImportResource> assembler) {
+    @Autowired
+    public ImportController(final ImportService service) {
         this.service = service;
-        this.assembler = assembler;
-        this.content = content;
+        this.assembler = new ImportResourceAssembler();
     }
 
-    protected RdwImportResource postImport(final SbacUserDetails sbacUser,
-                                           final String contentType,
-                                           final byte[] body,
-                                           final Map<String, String> params) {
-        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, params));
-    }
-
-    protected RdwImportResource uploadImport(final SbacUserDetails sbacUser,
-                                             final MultipartHttpServletRequest request) {
-        // get the best MultipartFile (either the only one or the one named "file")
-        final MultipartFile file;
-        final Map<String, MultipartFile> fileMap = request.getFileMap();
-        if (fileMap.isEmpty()) {
-            throw new IllegalArgumentException("missing multipart file");
-        } else if (fileMap.size() == 1) {
-            file = fileMap.values().iterator().next();
-        } else {
-            file = fileMap.get("file");
-        }
-
-        final String contentType = file.getContentType();
-        final byte[] body;
-        try {
-            body = file.getBytes();
-        } catch (final IOException e) {
-            throw new IllegalArgumentException("error getting file content", e);
-        }
-
-        // extract parameter values from form data and request params
-        // note that getParameterMap returns lists of values, so take just first value for each key
-        final Map<String, String> metadata = newHashMap();
-        metadata.put("filename", file.getOriginalFilename());
-        request.getParameterMap().forEach((key, values) -> metadata.put(key, values[0]));
-
-        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, metadata));
-    }
-
-    protected RdwImportResource getImport(final Long id) {
+    @GetMapping("/{id}")
+    public RdwImportResource getImport(@PathVariable final Long id) {
         return assembler.toResource(service.getImport(id).get());
     }
 
-    protected ResponseEntity<Void> downloadImportPayload(final long id, final HttpServletResponse response) {
+    @GetMapping("/{id}/payload")
+    public ResponseEntity<Void> downloadImportPayload(@PathVariable final long id, final HttpServletResponse response) {
         final byte[] payload = service.getPayload(id).get();
         final Properties properties = service.getPayloadProperties(id).get();
 
@@ -115,29 +57,8 @@ abstract class ImportController {
         }
     }
 
-    protected Properties getImportPayloadProperties(final Long id) {
+    @GetMapping("/{id}/payload/properties")
+    public Properties getImportPayloadProperties(@PathVariable final Long id) {
         return service.getPayloadProperties(id).get();
-    }
-
-    protected List<RdwImportResource> getImports(final RdwImportQuery query) {
-        if (query.isEmpty()) {
-            throw new IllegalArgumentException("at least one query parameter must be specified");
-        }
-        return assembler.toResources(service.getImports(ensureQueryForContent(query)));
-    }
-
-    protected ResponseEntity<Long> resubmitImports(final RdwImportQuery inputQuery) {
-        final RdwImportQuery query = inputQuery.isEmpty()
-                ? RdwImportQuery.builder()
-                .content(content)
-                .status(ImportStatus.ACCEPTED)
-                .build()
-                : ensureQueryForContent(inputQuery);
-
-        return ResponseEntity.ok(service.resubmitImports(query));
-    }
-
-    private RdwImportQuery ensureQueryForContent(final RdwImportQuery query) {
-        return content == query.getContent() ? query : query.copy().content(content).build();
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ImportResourceAssembler.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ImportResourceAssembler.java
@@ -8,16 +8,11 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 /**
  * Common assembler functionality for import controllers.
- *
- * @see ImportController
  */
 class ImportResourceAssembler extends ResourceAssemblerSupport<RdwImport, RdwImportResource> {
 
-    private final Class<? extends ImportController> controllerClass;
-
-    public ImportResourceAssembler(final Class<? extends ImportController> controllerClass) {
-        super(controllerClass, RdwImportResource.class);
-        this.controllerClass = controllerClass;
+    public ImportResourceAssembler() {
+        super(ImportController.class, RdwImportResource.class);
     }
 
     @Override
@@ -26,9 +21,9 @@ class ImportResourceAssembler extends ResourceAssemblerSupport<RdwImport, RdwImp
 
         final RdwImportResource resource = new RdwImportResource();
         resource.setRdwImport(rdwImport);
-        resource.add(linkTo(methodOn(controllerClass).getImport(rdwImport.getId())).withSelfRel());
-        resource.add(linkTo(methodOn(controllerClass).downloadImportPayload(rdwImport.getId(), null)).withRel("payload"));
-        resource.add(linkTo(methodOn(controllerClass).getImportPayloadProperties(rdwImport.getId())).withRel("payload-properties"));
+        resource.add(linkTo(methodOn(ImportController.class).getImport(rdwImport.getId())).withSelfRel());
+        resource.add(linkTo(methodOn(ImportController.class).downloadImportPayload(rdwImport.getId(), null)).withRel("payload"));
+        resource.add(linkTo(methodOn(ImportController.class).getImportPayloadProperties(rdwImport.getId())).withRel("payload-properties"));
         return resource;
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/PackageController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/PackageController.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,23 +18,21 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
-import static java.util.Collections.singletonMap;
 
 /**
  * Controller for reporting package / assessments end-points
  */
 @RestController
 @RequestMapping({ "/packages" })
-class ReportingPackageController extends ImportController {
+class PackageController extends ScopedImportController {
 
     @Autowired
-    public ReportingPackageController(final ImportService service) {
-        super(service, ImportContent.PACKAGE, new ImportResourceAssembler(ReportingPackageController.class));
+    public PackageController(final ImportService service) {
+        super(service, ImportContent.PACKAGE);
     }
 
     @PostMapping("/imports")
@@ -43,8 +40,8 @@ class ReportingPackageController extends ImportController {
     public RdwImportResource postImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                         @RequestHeader(value = CONTENT_TYPE, required = false) final String contentType,
                                         @RequestBody final byte[] body,
-                                        @RequestParam(required = false) final String batch) {
-        return super.postImport(sbacUser, contentType, body, singletonMap("batch", batch));
+                                        @RequestParam final Map<String, String> requestParams) {
+        return super.postImport(sbacUser, contentType, body, requestParams);
     }
 
     @PostMapping(value = "/imports", consumes = "multipart/form-data")
@@ -54,24 +51,9 @@ class ReportingPackageController extends ImportController {
         return super.uploadImport(sbacUser, request);
     }
 
-    @GetMapping("/imports/{id}")
-    public RdwImportResource getImport(@PathVariable final Long id) {
-        return super.getImport(id);
-    }
-
     @GetMapping("/imports")
     public List<RdwImportResource> getImports(final RdwImportQuery query) {
         return super.getImports(query);
-    }
-
-    @GetMapping("/imports/{id}/payload")
-    public ResponseEntity<Void> downloadImportPayload(@PathVariable final long id, final HttpServletResponse response) {
-        return super.downloadImportPayload(id, response);
-    }
-
-    @GetMapping("/imports/{id}/payload/properties")
-    public Properties getImportPayloadProperties(@PathVariable final Long id) {
-        return super.getImportPayloadProperties(id);
     }
 
     @PostMapping("/imports/resubmit")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
@@ -1,0 +1,100 @@
+package org.opentestsystem.rdw.ingest.web;
+
+import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
+import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
+import org.opentestsystem.rdw.ingest.service.ImportService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+/**
+ * All the controllers in this package do the same thing with slight configurable differences.
+ * Although we could use pattern matching and other cleverness, it is fighting the way the Spring
+ * framework likes to do things. So the common functionality is pulled into this base class.
+ *
+ * @see ExamController
+ * @see PackageController
+ * @see ImportResourceAssembler
+ * @see AccommodationController
+ */
+@SuppressWarnings("ConstantConditions")
+abstract class ScopedImportController {
+
+    private final ImportService service;
+    private final ImportContent content;
+    private final ImportResourceAssembler assembler;
+
+    protected ScopedImportController(final ImportService service,
+                                     final ImportContent content) {
+        this.service = service;
+        this.content = content;
+        this.assembler = new ImportResourceAssembler();
+    }
+
+    protected RdwImportResource postImport(final SbacUserDetails sbacUser,
+                                           final String contentType,
+                                           final byte[] body,
+                                           final Map<String, String> params) {
+        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, params));
+    }
+
+    protected RdwImportResource uploadImport(final SbacUserDetails sbacUser,
+                                             final MultipartHttpServletRequest request) {
+        // get the best MultipartFile (either the only one or the one named "file")
+        final MultipartFile file;
+        final Map<String, MultipartFile> fileMap = request.getFileMap();
+        if (fileMap.isEmpty()) {
+            throw new IllegalArgumentException("missing multipart file");
+        } else if (fileMap.size() == 1) {
+            file = fileMap.values().iterator().next();
+        } else {
+            file = fileMap.get("file");
+        }
+
+        final String contentType = file.getContentType();
+        final byte[] body;
+        try {
+            body = file.getBytes();
+        } catch (final IOException e) {
+            throw new IllegalArgumentException("error getting file content", e);
+        }
+
+        // extract parameter values from form data and request params
+        // note that getParameterMap returns lists of values, so take just first value for each key
+        final Map<String, String> metadata = newHashMap();
+        metadata.put("filename", file.getOriginalFilename());
+        request.getParameterMap().forEach((key, values) -> metadata.put(key, values[0]));
+
+        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, metadata));
+    }
+
+    protected List<RdwImportResource> getImports(final RdwImportQuery query) {
+        if (query.isEmpty()) {
+            throw new IllegalArgumentException("at least one query parameter must be specified");
+        }
+        return assembler.toResources(service.getImports(ensureQueryForContent(query)));
+    }
+
+    protected ResponseEntity<Long> resubmitImports(final RdwImportQuery inputQuery) {
+        final RdwImportQuery query = inputQuery.isEmpty()
+                ? RdwImportQuery.builder()
+                .content(content)
+                .status(ImportStatus.ACCEPTED)
+                .build()
+                : ensureQueryForContent(inputQuery);
+
+        return ResponseEntity.ok(service.resubmitImports(query));
+    }
+
+    private RdwImportQuery ensureQueryForContent(final RdwImportQuery query) {
+        return content == query.getContent() ? query : query.copy().content(content).build();
+    }
+}

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/AccommodationsControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/AccommodationsControllerIT.java
@@ -19,9 +19,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Optional;
-import java.util.Properties;
-
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -59,14 +56,15 @@ public class AccommodationsControllerIT {
     @Test
     public void itShouldUseServiceToImportAccommodationsUpload() throws Exception {
         final byte[] body = "<Accessibility/>".getBytes();
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(testImport(123L));
+        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
         mvc.perform(fileUpload(ACCOMMODATIONS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
-                .andExpect(jsonPath("$._links['self'].href", endsWith(ACCOMMODATIONS_URI + "/123")));
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
     }
 
     @Test
@@ -78,37 +76,13 @@ public class AccommodationsControllerIT {
     @Test
     public void itShouldUseServiceToImportAccommodationsRawBody() throws Exception {
         final byte[] body = "<Accessibility/>".getBytes();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(testImport(123L));
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
+        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
         mvc.perform(post(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
-                .andExpect(jsonPath("$._links['self'].href", endsWith(ACCOMMODATIONS_URI + "/123")));
-    }
-
-    @Test
-    public void itShouldReturn4xxForUnsupportedOperation() throws Exception {
-        final byte[] body = "<Accessibility/>".getBytes();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenThrow(UnsupportedOperationException.class);
-        mvc.perform(post(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
-                .andExpect(status().is4xxClientError());
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImport() throws Exception {
-        final long id = 123;
-        when(importService.getImport(id)).thenReturn(Optional.of(testImport(id)));
-        mvc.perform(get(ACCOMMODATIONS_URI + "/" + id).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("" + id)));
-    }
-
-    @Test
-    public void itShouldReturn404ForUnknownImport() throws Exception {
-        final long id = 23;
-        when(importService.getImport(id)).thenReturn(Optional.empty());
-        mvc.perform(get(ACCOMMODATIONS_URI + "/" + id).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isNotFound());
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
     }
 
     @Test
@@ -201,40 +175,5 @@ public class AccommodationsControllerIT {
         final RdwImportQuery query = argumentCaptor.getValue();
         assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
         assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
-    }
-
-    @Test
-    public void itShouldUseServiceToGetPayload() throws Exception {
-        final long id = 123L;
-        final byte[] payload = "<Accessibility/>".getBytes();
-        final Properties properties = new Properties();
-        properties.setProperty("filename", "test.xml");
-        properties.setProperty("content-type", "application/xml");
-
-        when(importService.getPayload(id)).thenReturn(Optional.of(payload));
-        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
-        mvc.perform(get(ACCOMMODATIONS_URI + "/123/payload").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType("application/xml"))
-                .andExpect(content().bytes(payload));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetPayloadProperties() throws Exception {
-        final long id = 123L;
-        final Properties properties = new Properties();
-        properties.setProperty("filename", "test.xml");
-
-        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
-        mvc.perform(get(ACCOMMODATIONS_URI + "/123/payload/properties").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("test.xml")));
-    }
-
-
-    private RdwImport testImport(final long id) {
-        return RdwImport.builder()
-                .id(id)
-                .build();
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
@@ -19,9 +19,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Optional;
-import java.util.Properties;
-
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -48,6 +45,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebAppConfiguration
 public class ExamControllerIT {
 
+    private static final String EXAMS_URI = "/exams/imports";
+
     @Autowired
     private MockMvc mvc;
 
@@ -57,56 +56,33 @@ public class ExamControllerIT {
     @Test
     public void itShouldUseServiceToImportExamUpload() throws Exception {
         final byte[] body = "<TDSReport/>".getBytes();
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(testImport(123L));
-        mvc.perform(fileUpload("/exams/imports").file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
+        mvc.perform(fileUpload(EXAMS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
-                .andExpect(jsonPath("$._links['self'].href", endsWith("exams/imports/123")));
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
     }
 
     @Test
     public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload("/exams/imports").header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(fileUpload(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldUseServiceToImportExamRawBody() throws Exception {
         final byte[] body = "<TDSReport/>".getBytes();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(testImport(123L));
-        mvc.perform(post("/exams/imports").header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
+        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
+        mvc.perform(post(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
-                .andExpect(jsonPath("$._links['self'].href", endsWith("exams/imports/123")));
-    }
-
-    @Test
-    public void itShouldReturn4xxForUnsupportedOperation() throws Exception {
-        final byte[] body = "<TDSReport/>".getBytes();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenThrow(UnsupportedOperationException.class);
-        mvc.perform(post("/exams/imports").header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
-                .andExpect(status().is4xxClientError());
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImport() throws Exception {
-        final long id = 123;
-        when(importService.getImport(id)).thenReturn(Optional.of(testImport(id)));
-        mvc.perform(get("/exams/imports/" + id).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("" + id)));
-    }
-
-    @Test
-    public void itShouldReturn404ForUnknownImport() throws Exception {
-        final long id = 23;
-        when(importService.getImport(id)).thenReturn(Optional.empty());
-        mvc.perform(get("/exams/imports/" + id).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isNotFound());
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
     }
 
     @Test
@@ -114,7 +90,7 @@ public class ExamControllerIT {
         final String batch = "abc";
         when(importService.getImports(any(RdwImportQuery.class)))
                 .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-        mvc.perform(get("/exams/imports?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(EXAMS_URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(batch)))
                 .andExpect(content().string(containsString("123")));
@@ -125,7 +101,7 @@ public class ExamControllerIT {
         final ImportStatus status = ImportStatus.BAD_FORMAT;
         when(importService.getImports(any(RdwImportQuery.class)))
                 .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-        mvc.perform(get("/exams/imports?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(EXAMS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(status.toString())))
                 .andExpect(content().string(containsString("123")));
@@ -133,38 +109,38 @@ public class ExamControllerIT {
 
     @Test
     public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
-        mvc.perform(get("/exams/imports?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(EXAMS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get("/exams/imports").header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get("/exams/imports?status=ACCEPTED"))
+        mvc.perform(get(EXAMS_URI + "?status=ACCEPTED"))
                 .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
     }
 
     @Test
     public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get("/exams/imports?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
+        mvc.perform(get(EXAMS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
                 .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
     }
 
     @Test
     public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get("/exams/imports?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
+        mvc.perform(get(EXAMS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
                 .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
     }
 
     @Test
     public void itShouldResubmitImports() throws Exception {
         when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post("/exams/imports/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
+        mvc.perform(post(EXAMS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(equalTo("1")));
         final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
@@ -177,21 +153,21 @@ public class ExamControllerIT {
     @Test
     public void itShouldAllowResubmitIfNoAuthority() throws Exception {
         when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post("/exams/imports/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
+        mvc.perform(post(EXAMS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(equalTo("1")));
     }
 
     @Test
     public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post("/exams/imports/resubmit").param("status", "BAD_DATA"))
+        mvc.perform(post(EXAMS_URI + "/resubmit").param("status", "BAD_DATA"))
                 .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
     }
 
     @Test
     public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
         when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post("/exams/imports/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(post(EXAMS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(equalTo("1")));
         final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
@@ -199,40 +175,5 @@ public class ExamControllerIT {
         final RdwImportQuery query = argumentCaptor.getValue();
         assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
         assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
-    }
-
-    @Test
-    public void itShouldUseServiceToGetPayload() throws Exception {
-        final long id = 123L;
-        final byte[] payload = "<TDSReport/>".getBytes();
-        final Properties properties = new Properties();
-        properties.setProperty("filename", "test.xml");
-        properties.setProperty("content-type", "application/xml");
-
-        when(importService.getPayload(id)).thenReturn(Optional.of(payload));
-        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
-        mvc.perform(get("/exams/imports/123/payload").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType("application/xml"))
-                .andExpect(content().bytes(payload));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetPayloadProperties() throws Exception {
-        final long id = 123L;
-        final Properties properties = new Properties();
-        properties.setProperty("filename", "test.xml");
-        
-        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
-        mvc.perform(get("/exams/imports/123/payload/properties").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("test.xml")));
-    }
-
-
-    private RdwImport testImport(final long id) {
-        return RdwImport.builder()
-                .id(id)
-                .build();
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ImportControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ImportControllerIT.java
@@ -1,0 +1,98 @@
+package org.opentestsystem.rdw.ingest.web;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.ingest.common.model.RdwImport;
+import org.opentestsystem.rdw.ingest.service.ImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.StringEndsWith.endsWith;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ImportController.class)
+@ContextConfiguration(classes = TestAppConfig.class)
+@WebAppConfiguration
+public class ImportControllerIT {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private ImportService importService;
+
+    @Test
+    public void itShouldReturn4xxForUnsupportedOperation() throws Exception {
+        final long id = 123;
+        //noinspection unchecked
+        when(importService.getImport(id)).thenThrow(UnsupportedOperationException.class);
+        mvc.perform(get("/imports/" + id).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void itShouldUseServiceToGetImport() throws Exception {
+        final long id = 123;
+        final RdwImport rdwImport = RdwImport.builder().id(id).build();
+        when(importService.getImport(id)).thenReturn(Optional.of(rdwImport));
+        mvc.perform(get("/imports/" + id).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("" + id)))
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")))
+                .andExpect(jsonPath("$._links['payload'].href", endsWith("imports/123/payload")))
+                .andExpect(jsonPath("$._links['payload-properties'].href", endsWith("imports/123/payload/properties")))
+        ;
+    }
+
+    @Test
+    public void itShouldReturn404ForUnknownImport() throws Exception {
+        final long id = 23;
+        when(importService.getImport(id)).thenReturn(Optional.empty());
+        mvc.perform(get("/imports/" + id).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void itShouldUseServiceToGetPayload() throws Exception {
+        final long id = 123L;
+        final byte[] payload = "<TDSReport/>".getBytes();
+        final Properties properties = new Properties();
+        properties.setProperty("filename", "test.xml");
+        properties.setProperty("content-type", "application/xml");
+
+        when(importService.getPayload(id)).thenReturn(Optional.of(payload));
+        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
+        mvc.perform(get("/imports/123/payload").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/xml"))
+                .andExpect(content().bytes(payload));
+    }
+
+    @Test
+    public void itShouldUseServiceToGetPayloadProperties() throws Exception {
+        final long id = 123L;
+        final Properties properties = new Properties();
+        properties.setProperty("filename", "test.xml");
+
+        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
+        mvc.perform(get("/imports/123/payload/properties").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("test.xml")));
+    }
+}

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ImportResourceAssemblerTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ImportResourceAssemblerTest.java
@@ -29,7 +29,7 @@ public class ImportResourceAssemblerTest {
 
     @Test
     public void itShouldAddExamLinks() {
-        final ImportResourceAssembler assembler = new ImportResourceAssembler(ExamController.class);
+        final ImportResourceAssembler assembler = new ImportResourceAssembler();
         final RdwImport rdwImport = RdwImport.builder()
                 .content(ImportContent.EXAM)
                 .id(123L)
@@ -37,12 +37,12 @@ public class ImportResourceAssemblerTest {
 
         final RdwImportResource resource = assembler.toResource(rdwImport);
         assertThat(resource.getLinks()).hasSize(3);
-        assertThat(resource.getLinks().get(0).getHref()).endsWith("exams/imports/123");
+        assertThat(resource.getLinks().get(0).getHref()).endsWith("imports/123");
     }
 
     @Test
     public void itShouldPassThroughNulls() {
-        final ImportResourceAssembler assembler = new ImportResourceAssembler(ExamController.class);
+        final ImportResourceAssembler assembler = new ImportResourceAssembler();
         assertThat(assembler.toResource(null)).isNull();
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/PackageControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/PackageControllerIT.java
@@ -43,7 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(ReportingPackageController.class)
+@WebMvcTest(PackageController.class)
 @ContextConfiguration(classes = TestAppConfig.class)
 @WebAppConfiguration
 public class PackageControllerIT {
@@ -59,61 +59,35 @@ public class PackageControllerIT {
     @Test
     public void itShouldUseServiceToImportPackage() throws Exception {
         final byte[] body = "assessmentId,assessmentName".getBytes();
-        
-		when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(testImport(123L));
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
+
+        when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(rdwImport);
         
         mvc.perform(post(ASSESSMENTS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.TEXT_PLAIN).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
 				.andExpect(content().string(not(containsString("null"))))
-                .andExpect(jsonPath("$._links['self'].href", endsWith(ASSESSMENTS_URI + "/123")));
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
     }
 	
 	@Test
     public void itShouldUseServiceToImportPackageUpload() throws Exception {
         final byte[] body = "assessmentId,assessmentName".getBytes();
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/plain", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(testImport(123L));
+        when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(rdwImport);
         mvc.perform(fileUpload(ASSESSMENTS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
-                .andExpect(jsonPath("$._links['self'].href", endsWith(ASSESSMENTS_URI + "/123")));
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
     }
 
     @Test
     public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
         mvc.perform(fileUpload(ASSESSMENTS_URI).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturn4xxForUnsupportedOperation() throws Exception {
-        final byte[] body = "assessmentId,assessmentName".getBytes();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.APPLICATION_XML_VALUE), any())).thenThrow(UnsupportedOperationException.class);
-
-        mvc.perform(post(ASSESSMENTS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
-                .andExpect(status().is4xxClientError());
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImport() throws Exception {
-        final long id = 123;
-        when(importService.getImport(id)).thenReturn(Optional.of(testImport(id)));
-
-        mvc.perform(get(ASSESSMENTS_URI + "/" + id).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("" + id)));
-    }
-
-    @Test
-    public void itShouldReturn404ForUnknownImport() throws Exception {
-        final long id = 23;
-        when(importService.getImport(id)).thenReturn(Optional.empty());
-
-        mvc.perform(get(ASSESSMENTS_URI + "/" + id).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -209,40 +183,5 @@ public class PackageControllerIT {
         final RdwImportQuery query = argumentCaptor.getValue();
         assertThat(query.getContent()).isEqualTo(ImportContent.PACKAGE);
         assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
-    }
-
-    @Test
-    public void itShouldUseServiceToGetPayload() throws Exception {
-        final long id = 123L;
-        final byte[] payload = "assessmentId,assessmentName".getBytes();
-        final Properties properties = new Properties();
-        properties.setProperty("filename", "test.csv");
-        properties.setProperty("content-type", "text/plain");
-
-        when(importService.getPayload(id)).thenReturn(Optional.of(payload));
-        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
-        mvc.perform(get(ASSESSMENTS_URI + "/123/payload").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType("text/plain"))
-                .andExpect(content().bytes(payload));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetPayloadProperties() throws Exception {
-        final long id = 123L;
-        final Properties properties = new Properties();
-        properties.setProperty("filename", "test.csv");
-
-        when(importService.getPayloadProperties(id)).thenReturn(Optional.of(properties));
-        mvc.perform(get(ASSESSMENTS_URI + "/123/payload/properties").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("test.csv")));
-    }
-
-
-    private RdwImport testImport(final long id) {
-        return RdwImport.builder()
-                .id(id)
-                .build();
     }
 }


### PR DESCRIPTION
Please vote on this change. 

The import service has evolved as more import tasks have been added. The end-points for getting the import resources included the `content` (e.g. EXAM, PACKAGE). That is odd since the import doesn't really care what content it represents. So, this patch changes the URL for those end-points that don't care about content. For example, all these go away:
```
GET ./exams/imports/{id}
GET ./packages/imports/{id}/payload
GET ./accommodations/imports/{id}/payload/properties
```
and get replaced with the generic end-points:
```
GET ./imports/{id}
GET ./imports/{id}/payload
GET ./imports/{id}/payload/properties
```