### PR TITLE
add organizations end-points

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportContent.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportContent.java
@@ -7,7 +7,8 @@ public enum ImportContent {
     PROBE(0),
     EXAM(1),
     PACKAGE(2),
-    CODES(3);
+    CODES(3),
+    ORGANIZATION(4);
 
     private final int value;
 

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportContent.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportContent.java
@@ -8,7 +8,8 @@ public enum ImportContent {
     EXAM(1),
     PACKAGE(2),
     CODES(3),
-    ORGANIZATION(4);
+    ORGANIZATION(4),
+    GROUPS(5);
 
     private final int value;
 

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/common/model/ImportContentTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/common/model/ImportContentTest.java
@@ -11,6 +11,8 @@ public class ImportContentTest {
         assertThat(ImportContent.EXAM.getValue()).isEqualTo(1);
         assertThat(ImportContent.PACKAGE.getValue()).isEqualTo(2);
         assertThat(ImportContent.CODES.getValue()).isEqualTo(3);
+        assertThat(ImportContent.ORGANIZATION.getValue()).isEqualTo(4);
+        assertThat(ImportContent.GROUPS.getValue()).isEqualTo(5);
     }
 
     @Test
@@ -18,6 +20,8 @@ public class ImportContentTest {
         assertThat(ImportContent.fromValue(1)).isEqualTo(ImportContent.EXAM);
         assertThat(ImportContent.fromValue(2)).isEqualTo(ImportContent.PACKAGE);
         assertThat(ImportContent.fromValue(3)).isEqualTo(ImportContent.CODES);
+        assertThat(ImportContent.fromValue(4)).isEqualTo(ImportContent.ORGANIZATION);
+        assertThat(ImportContent.fromValue(5)).isEqualTo(ImportContent.GROUPS);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
@@ -86,6 +86,8 @@ public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
                     .antMatchers("/packages/**").hasAuthority(DataLoadAuthority)
                     .antMatchers("/accommodations/imports/resubmit").authenticated()
                     .antMatchers("/accommodations/**").hasAuthority(DataLoadAuthority)
+                    .antMatchers("/organizations/imports/resubmit").authenticated()
+                    .antMatchers("/organizations/**").hasAuthority(DataLoadAuthority)
                     .antMatchers("/imports/**").hasAuthority(DataLoadAuthority)
                     .antMatchers("/status").authenticated()
                     .antMatchers("/**").permitAll();

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/OrganizationController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/OrganizationController.java
@@ -1,0 +1,65 @@
+package org.opentestsystem.rdw.ingest.web;
+
+import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
+import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
+import org.opentestsystem.rdw.ingest.service.ImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+
+/**
+ * Controller for accommodation code end-points
+ */
+@RestController
+@RequestMapping({ "/organizations" })
+class OrganizationController extends ScopedImportController {
+
+    @Autowired
+    public OrganizationController(final ImportService service) {
+        super(service, ImportContent.ORGANIZATION);
+    }
+
+    @PostMapping(value = "/imports")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public RdwImportResource postImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
+                                        @RequestHeader(value = CONTENT_TYPE, required = false) final String contentType,
+                                        @RequestBody final byte[] body,
+                                        @RequestParam final Map<String, String> requestParams) {
+        return super.postImport(sbacUser, contentType, body, requestParams);
+    }
+
+    @PostMapping(value = "/imports", consumes = "multipart/form-data")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
+                                          final MultipartHttpServletRequest request) {
+        return super.uploadImport(sbacUser, request);
+    }
+
+    @GetMapping(value = "/imports")
+    @ResponseStatus(HttpStatus.OK)
+    public List<RdwImportResource> getImports(final RdwImportQuery query) {
+        return super.getImports(query);
+    }
+
+    @PostMapping("/imports/resubmit")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ResponseEntity<Long> resubmitImports(final RdwImportQuery inputQuery) {
+        return super.resubmitImports(inputQuery);
+    }
+}

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/AccommodationControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/AccommodationControllerIT.java
@@ -1,0 +1,179 @@
+package org.opentestsystem.rdw.ingest.web;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.opentestsystem.rdw.ingest.common.model.ImportContent;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.common.model.RdwImport;
+import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
+import org.opentestsystem.rdw.ingest.service.ImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.StringEndsWith.endsWith;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(AccommodationController.class)
+@ContextConfiguration(classes = TestAppConfig.class)
+@WebAppConfiguration
+public class AccommodationControllerIT {
+
+    private final String ACCOMMODATIONS_URI = "/accommodations/imports";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private ImportService importService;
+
+    @Test
+    public void itShouldUseServiceToImportAccommodationsUpload() throws Exception {
+        final byte[] body = "<Accessibility/>".getBytes();
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
+        final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
+
+        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
+        mvc.perform(fileUpload(ACCOMMODATIONS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(containsString("123")))
+                .andExpect(content().string(not(containsString("null"))))
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
+    }
+
+    @Test
+    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
+        mvc.perform(fileUpload(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void itShouldUseServiceToImportAccommodationsRawBody() throws Exception {
+        final byte[] body = "<Accessibility/>".getBytes();
+        final RdwImport rdwImport = RdwImport.builder().id(123L).build();
+        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
+        mvc.perform(post(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(containsString("123")))
+                .andExpect(content().string(not(containsString("null"))))
+                .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
+    }
+
+    @Test
+    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
+        final String batch = "abc";
+        when(importService.getImports(any(RdwImportQuery.class)))
+                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
+        mvc.perform(get(ACCOMMODATIONS_URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(batch)))
+                .andExpect(content().string(containsString("123")));
+    }
+
+    @Test
+    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
+        final ImportStatus status = ImportStatus.BAD_FORMAT;
+        when(importService.getImports(any(RdwImportQuery.class)))
+                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
+        mvc.perform(get(ACCOMMODATIONS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(status.toString())))
+                .andExpect(content().string(containsString("123")));
+    }
+
+    @Test
+    public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
+        mvc.perform(get(ACCOMMODATIONS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
+        mvc.perform(get(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
+        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED"))
+                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
+        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
+        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    public void itShouldResubmitImports() throws Exception {
+        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
+        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(importService).resubmitImports(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
+    }
+
+    @Test
+    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
+        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
+        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+    }
+
+    @Test
+    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
+        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").param("status", "BAD_DATA"))
+                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
+        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
+        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(importService).resubmitImports(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
+    }
+}

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/OrganizationControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/OrganizationControllerIT.java
@@ -40,12 +40,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(AccommodationController.class)
+@WebMvcTest(OrganizationController.class)
 @ContextConfiguration(classes = TestAppConfig.class)
 @WebAppConfiguration
-public class AccommodationsControllerIT {
+public class OrganizationControllerIT {
 
-    private final String ACCOMMODATIONS_URI = "/accommodations/imports";
+    private final String ORGANIZATIONS_URI = "/organizations/imports";
 
     @Autowired
     private MockMvc mvc;
@@ -55,12 +55,12 @@ public class AccommodationsControllerIT {
 
     @Test
     public void itShouldUseServiceToImportAccommodationsUpload() throws Exception {
-        final byte[] body = "<Accessibility/>".getBytes();
+        final byte[] body = "{ \"districts\": [], \"schools\": [] }".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
-        final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
+        final MockMultipartFile file = new MockMultipartFile("file", "test.json", "application/json", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(fileUpload(ACCOMMODATIONS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(ImportContent.ORGANIZATION), eq(MediaType.APPLICATION_JSON_VALUE), any())).thenReturn(rdwImport);
+        mvc.perform(fileUpload(ORGANIZATIONS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
@@ -69,16 +69,16 @@ public class AccommodationsControllerIT {
 
     @Test
     public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(fileUpload(ORGANIZATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldUseServiceToImportAccommodationsRawBody() throws Exception {
-        final byte[] body = "<Accessibility/>".getBytes();
+        final byte[] body = "{ \"districts\": [], \"schools\": [] }".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(post(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
+        when(importService.importContent(any(), eq(body), eq(ImportContent.ORGANIZATION), eq(MediaType.APPLICATION_JSON_VALUE), any())).thenReturn(rdwImport);
+        mvc.perform(post(ORGANIZATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_JSON).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
@@ -86,22 +86,11 @@ public class AccommodationsControllerIT {
     }
 
     @Test
-    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
-        final String batch = "abc";
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-        mvc.perform(get(ACCOMMODATIONS_URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(batch)))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
     public void itShouldUseServiceToGetImportsByStatus() throws Exception {
         final ImportStatus status = ImportStatus.BAD_FORMAT;
         when(importService.getImports(any(RdwImportQuery.class)))
                 .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(ORGANIZATIONS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(status.toString())))
                 .andExpect(content().string(containsString("123")));
@@ -109,71 +98,58 @@ public class AccommodationsControllerIT {
 
     @Test
     public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(ORGANIZATIONS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
+        mvc.perform(get(ORGANIZATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED"))
+        mvc.perform(get(ORGANIZATIONS_URI + "?status=ACCEPTED"))
                 .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
     }
 
     @Test
     public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
+        mvc.perform(get(ORGANIZATIONS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
                 .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
     }
 
     @Test
     public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
+        mvc.perform(get(ORGANIZATIONS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
                 .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
     }
 
     @Test
     public void itShouldResubmitImports() throws Exception {
         when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
+        mvc.perform(post(ORGANIZATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(equalTo("1")));
         final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
         verify(importService).resubmitImports(argumentCaptor.capture());
         final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
+        assertThat(query.getContent()).isEqualTo(ImportContent.ORGANIZATION);
         assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
     }
 
     @Test
     public void itShouldAllowResubmitIfNoAuthority() throws Exception {
         when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
+        mvc.perform(post(ORGANIZATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(equalTo("1")));
     }
 
     @Test
     public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").param("status", "BAD_DATA"))
+        mvc.perform(post(ORGANIZATIONS_URI + "/resubmit").param("status", "BAD_DATA"))
                 .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 }


### PR DESCRIPTION
I believe the organization data needs to be processed all at once so i created a single end-point / import content. The alternative would be to have DISTRICT, SCHOOL, etc. but then there would be order-of-operation and resolution problems.