### PR TITLE
Fix for DWR-392 Migration failure with student groups and sample data

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StubbedOutAssessmentRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StubbedOutAssessmentRepository.java
@@ -12,7 +12,8 @@ public interface StubbedOutAssessmentRepository {
      * Inserts a new {@link Assessment}
      *
      * @param assessment the {@link Assessment} to be created
+     * @param importId the id that creates the assessment
      * @return the given {@link Assessment} with the id populated
      */
-    Assessment create(Assessment assessment);
+    Assessment create(Assessment assessment, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StudentGroupRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/StudentGroupRepository.java
@@ -33,6 +33,7 @@ public interface StudentGroupRepository {
      *
      * @param studentId student id
      * @param groupIds group ids
+     * @param importId id of the import that adds the student to the groups
      */
-    void addStudentToGroups(long studentId, List<Integer> groupIds);
+    void addStudentToGroups(long studentId, List<Integer> groupIds, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStubbedOutAssessmentRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStubbedOutAssessmentRepository.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.ingest.processor.repository.impl;
 
-import java.util.Set;
 import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 import org.opentestsystem.rdw.ingest.processor.repository.AssessmentRepository;
 import org.opentestsystem.rdw.ingest.processor.repository.StubbedOutAssessmentRepository;
@@ -13,6 +12,8 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
 
 
 @Repository
@@ -36,7 +37,7 @@ class JdbcStubbedOutAssessmentRepository implements StubbedOutAssessmentReposito
 
     @Transactional
     @Override
-    public Assessment create(final Assessment assessment) {
+    public Assessment create(final Assessment assessment, final long importId) {
 
         final KeyHolder keyHolder = new GeneratedKeyHolder();
         final SqlParameterSource parameterSource = new MapSqlParameterSource()
@@ -46,7 +47,9 @@ class JdbcStubbedOutAssessmentRepository implements StubbedOutAssessmentReposito
                 .addValue("grade_id", assessment.getGradeId())
                 .addValue("type_id", assessment.getTypeId())
                 .addValue("subject_id", assessment.getSubjectId())
-                .addValue("school_year", assessment.getSchoolYear());
+                .addValue("school_year", assessment.getSchoolYear())
+                .addValue("import_id", importId)
+                .addValue("update_import_id", importId);
 
         jdbcTemplate.update(sqlCreate, parameterSource, keyHolder);
 

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -16,10 +15,11 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 /**
  * JDBC implementation of {@link StudentGroupRepository}.
@@ -28,7 +28,6 @@ import java.util.List;
 class JdbcStudentGroupRepository implements StudentGroupRepository {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
-    private final StudentGroupRowMapper mapper = new StudentGroupRowMapper();
 
     @Value("${sql.studentGroup.create}")
     private String sqlCreate;
@@ -96,24 +95,11 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
             }
         });
 
+        final List<MapSqlParameterSource> batchParameters = newArrayList();
         for (final Integer groupId : groupIds) {
-            jdbcTemplate.update(sqlUpdateImportId, new MapSqlParameterSource("update_import_id", importId).addValue("id", groupId));
+            batchParameters.add(new MapSqlParameterSource("update_import_id", importId)
+                    .addValue("id", groupId));
         }
-    }
-
-    private static class StudentGroupRowMapper implements RowMapper<StudentGroup> {
-        @Override
-        public StudentGroup mapRow(final ResultSet rs, final int rowNum) throws SQLException {
-            return StudentGroup.builder()
-                    .id(rs.getInt("id"))
-                    .name(rs.getString("name"))
-                    .schoolId(rs.getInt("school_id"))
-                    .schoolYear(rs.getInt("school_year"))
-                    .subjectId(rs.getInt("subject_id"))
-                    .active(rs.getBoolean("active"))
-                    .creator(rs.getString("creator"))
-                    .created(rs.getTimestamp("created").toInstant())
-                    .build();
-        }
+        jdbcTemplate.batchUpdate(sqlUpdateImportId, batchParameters.toArray(new MapSqlParameterSource[batchParameters.size()]));
     }
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
@@ -13,6 +13,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,6 +32,9 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
 
     @Value("${sql.studentGroup.create}")
     private String sqlCreate;
+
+    @Value("${sql.studentGroup.updateImportId}")
+    private String sqlUpdateImportId;
 
     @Value("${sql.studentGroup.findIdByNameAndSchoolAndYear}")
     private String sqlFindIdByNameAndSchoolAndYear;
@@ -77,7 +81,8 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
     }
 
     @Override
-    public void addStudentToGroups(final long studentId, final List<Integer> groupIds) {
+    @Transactional
+    public void addStudentToGroups(final long studentId, final List<Integer> groupIds, long importId) {
         jdbcTemplate.getJdbcOperations().batchUpdate(sqlAddStudentMembership, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(final PreparedStatement ps, final int i) throws SQLException {
@@ -90,6 +95,10 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
                 return groupIds.size();
             }
         });
+
+        for (final Integer groupId : groupIds) {
+            jdbcTemplate.update(sqlUpdateImportId, new MapSqlParameterSource("update_import_id", importId).addValue("id", groupId));
+        }
     }
 
     private static class StudentGroupRowMapper implements RowMapper<StudentGroup> {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/AssessmentService.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/AssessmentService.java
@@ -1,7 +1,7 @@
 package org.opentestsystem.rdw.ingest.processor.service;
 
-import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 import org.opentestsystem.rdw.common.model.trt.TDSReport;
+import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 
 /**
  * An interface for managing {@link Assessment}
@@ -13,7 +13,8 @@ public interface AssessmentService {
      * TODO: for now it accepts a TDSReport object. This needs to be change once we have an assessment loaded.
      *
      * @param test
+     * @param importId
      * @return the {@link Assessment}, null if not found
      */
-    Assessment findOneByNaturalId(TDSReport test);
+    Assessment findOneByNaturalId(TDSReport test, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentService.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentService.java
@@ -29,7 +29,7 @@ class DefaultAssessmentService implements AssessmentService {
     }
 
     @Override
-    public Assessment findOneByNaturalId(final TDSReport tdsReport) {
+    public Assessment findOneByNaturalId(final TDSReport tdsReport, final long importId) {
         final Test test = tdsReport.getTest();
         final Assessment assessment = assessmentRepository.findOneByNaturalId(test.getName());
         //TODO: this needs to be removed once we have assessments ingest working
@@ -50,6 +50,6 @@ class DefaultAssessmentService implements AssessmentService {
                 .subjectId(subjectRepository.findIdByCode(test.getSubject()))
                 .typeId(iab ? 2 : 1)
                 .items(items)
-                .build());
+                .build(), importId);
     }
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
@@ -97,7 +97,7 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
                 }
                 groupIds.add(groupId);
             }
-            studentGroupRepository.addStudentToGroups(studentId, groupIds);
+            studentGroupRepository.addStudentToGroups(studentId, groupIds, importId);
         }
 
         return studentExamAttrBuilder

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
@@ -1,16 +1,16 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
+import org.opentestsystem.rdw.common.model.trt.Examinee;
+import org.opentestsystem.rdw.common.model.trt.TDSReport;
+import org.opentestsystem.rdw.common.model.trt.Test;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
-import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
 import org.opentestsystem.rdw.ingest.processor.service.AssessmentService;
 import org.opentestsystem.rdw.ingest.processor.service.ExamineeProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.StudentExamProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
-import org.opentestsystem.rdw.common.model.trt.Examinee;
-import org.opentestsystem.rdw.common.model.trt.TDSReport;
-import org.opentestsystem.rdw.common.model.trt.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -44,7 +44,7 @@ class DefaultTDSReportProcessor implements TDSReportProcessor {
             final School school = examineeProcessor.parseExamineeRelationship(examinee);
 
             // then check if there is a matching assessment
-            final Assessment assessment = assessmentService.findOneByNaturalId(report);
+            final Assessment assessment = assessmentService.findOneByNaturalId(report, importId);
             //TODO: add comparison of the assessment subject, grade, year and type to the incoming test
 
             // now it is okay to start processing

--- a/exam-processor/src/main/resources/application.sql.yml
+++ b/exam-processor/src/main/resources/application.sql.yml
@@ -58,7 +58,7 @@ sql:
     # this is a stubbed out method - TODO: to be deleted
     create: >-
         INSERT INTO asmt (natural_id, name, label, grade_id, type_id, subject_id, school_year, import_id, update_import_id) VALUES
-                       (:natural_id, :name, :label, :grade_id, :type_id, :subject_id, :school_year, (select id from import limit 1), (select id from import limit 1))
+                       (:natural_id, :name, :label, :grade_id, :type_id, :subject_id, :school_year, :import_id, :update_import_id)
 
     # this is a stubbed out method - TODO: to be deleted
     createItems: >-
@@ -127,3 +127,8 @@ sql:
 
     addStudentMembership: >-
       INSERT IGNORE INTO student_group_membership (student_group_id, student_id) VALUES (?, ?)
+
+    updateImportId:
+      UPDATE student_group
+       SET update_import_id = :update_import_id
+      WHERE id = :id

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentGroupRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/StudentGroupRepositoryIT.java
@@ -17,13 +17,14 @@ import java.time.Instant;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
+import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
 @Sql(statements = {
-        "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
+        "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest'), ( -98, 0, 1, 'type', 'digest2')",
         "INSERT INTO subject (id, code) VALUES (-11, 'SCIENCE');",
         "INSERT INTO district (id, natural_id, name) VALUES (-20, 'DS009', 'District 9');",
         "INSERT INTO school (id, district_id, natural_id, name, import_id, update_import_id) VALUES (-21, -20, 'S001', 'School 1', -99, -99);",
@@ -40,6 +41,7 @@ public class StudentGroupRepositoryIT {
     private JdbcTemplate jdbcTemplate;
 
     private final long importId = -99;
+    private final long updateImportId = -98;
 
     @Test
     public void itShouldCreateAndFindGroups() {
@@ -55,16 +57,23 @@ public class StudentGroupRepositoryIT {
     public void itShouldAddStudentMembership() {
         final int membershipRows = countRowsInTable(jdbcTemplate, "student_group_membership");
 
-        final StudentGroup group1 = repository.create(createTestGroup("one"),importId);
-        final StudentGroup group2 = repository.create(createTestGroup("two"),importId);
+        final StudentGroup group1 = repository.create(createTestGroup("one"), importId);
+        final StudentGroup group2 = repository.create(createTestGroup("two"), importId);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student_group",
+                "id in (" + group1.getId() + "," + group2.getId() + ") " + "and import_id = " + importId + " and update_import_id = " + importId)
+        ).isEqualTo(2);
 
-        repository.addStudentToGroups(-100, newArrayList(group1.getId(), group2.getId()));
-        repository.addStudentToGroups(-101, newArrayList(group1.getId()));
-        assertThat(countRowsInTable(jdbcTemplate, "student_group_membership")).isEqualTo(membershipRows+3);
+        repository.addStudentToGroups(-100, newArrayList(group1.getId(), group2.getId()), updateImportId);
+        repository.addStudentToGroups(-101, newArrayList(group1.getId()), updateImportId);
+        assertThat(countRowsInTable(jdbcTemplate, "student_group_membership")).isEqualTo(membershipRows + 3);
+        assertThat(countRowsInTableWhere(jdbcTemplate, "student_group",
+                "id in (" + group1.getId() + "," + group2.getId() + ") " + "and import_id = " + importId + " and update_import_id = " + updateImportId)
+        ).isEqualTo(2);
+
 
         // it should tolerate adding the same membership again, by doing nothing
-        repository.addStudentToGroups(-100, newArrayList(group2.getId()));
-        assertThat(countRowsInTable(jdbcTemplate, "student_group_membership")).isEqualTo(membershipRows+3);
+        repository.addStudentToGroups(-100, newArrayList(group2.getId()), 1);
+        assertThat(countRowsInTable(jdbcTemplate, "student_group_membership")).isEqualTo(membershipRows + 3);
     }
 
     private StudentGroup createTestGroup(final String name) {

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
@@ -2,18 +2,18 @@ package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.opentestsystem.rdw.ingest.common.model.ImportException;
-import org.opentestsystem.rdw.ingest.processor.model.Assessment;
+import org.opentestsystem.rdw.common.model.trt.Examinee;
+import org.opentestsystem.rdw.common.model.trt.Opportunity;
+import org.opentestsystem.rdw.common.model.trt.TDSReport;
 import org.opentestsystem.rdw.ingest.common.model.District;
+import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
 import org.opentestsystem.rdw.ingest.processor.service.AssessmentService;
 import org.opentestsystem.rdw.ingest.processor.service.ExamineeProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.StudentExamProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
-import org.opentestsystem.rdw.common.model.trt.Examinee;
-import org.opentestsystem.rdw.common.model.trt.Opportunity;
-import org.opentestsystem.rdw.common.model.trt.TDSReport;
 
 import java.text.ParseException;
 
@@ -72,7 +72,7 @@ public class DefaultTDSReportProcessorTest {
         when(examineeProcessor.process(examinee, test, school, importId)).thenReturn(studentExamAttributes);
 
         final Assessment assessment = mock(Assessment.class);
-        when(assessmentService.findOneByNaturalId(tdsReport)).thenReturn(assessment);
+        when(assessmentService.findOneByNaturalId(tdsReport, importId)).thenReturn(assessment);
 
         processor.process(tdsReport, importId);
 

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -359,8 +359,9 @@ sql:
                 JOIN warehouse.student_group wsg ON wsg.id = wsgm.student_group_id
                 JOIN warehouse.student ws ON ws.id = wsgm.student_id
               WHERE
-                ( wsg.import_id IN (SELECT id FROM warehouse.import WHERE status = 1 AND id >= :start_import_id AND id <= :end_import_id) OR
-                  wsg.update_import_id IN (SELECT id FROM warehouse.import WHERE status = 1 AND id >= :start_import_id AND id <= :end_import_id) )
+                    ( wsg.import_id IN (SELECT id FROM warehouse.import WHERE status = 1 AND id >= :start_import_id AND id <= :end_import_id) OR
+                      wsg.update_import_id IN (SELECT id FROM warehouse.import WHERE status = 1 AND id >= :start_import_id AND id <= :end_import_id) )
+                AND (ws.import_id IN (SELECT id FROM warehouse.import WHERE status = 1 AND id <= :end_import_id) OR  ws.update_import_id IN (SELECT id FROM warehouse.import WHERE status = 1 AND id <= :end_import_id) )
                 AND (wsg.deleted = 0 and wsg.active = 1)
             stagingInsert: >-
               INSERT INTO staging.staging_student_group_membership (student_group_id, student_id) VALUES

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -10,7 +10,7 @@ migrate:
 
 spring:
   batch_datasource:
-    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false&rewriteBatchedStatements
     username: root
     password:
     testWhileIdle: true

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -10,7 +10,7 @@ migrate:
 
 spring:
   batch_datasource:
-    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false&rewriteBatchedStatements
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false
     username: root
     password:
     testWhileIdle: true

--- a/migrate-reporting/src/test/resources/ImportContentSetup.sql
+++ b/migrate-reporting/src/test/resources/ImportContentSetup.sql
@@ -3,9 +3,9 @@ DELETE FROM warehouse_test.import
 WHERE id = 1;
 
 -- Content types
--- 1	EXAM
--- 2	PACKAGE
--- 3	CODES
+-- 1  EXAM
+-- 2  PACKAGE
+-- 3  CODES
 -- 4  ORGANIZATION
 -- 5  GROUPS
 
@@ -30,7 +30,8 @@ INSERT INTO warehouse_test.import (id, status, content, contentType, digest, bat
   (-89, 1, 5, 'application/xml', 'hash-student', 'batch', 'dwtest@example.com'),
   (-88, 1, 5, 'application/xml', 'hash-student', 'batch', 'dwtest@example.com'),
   (-87, 1, 5, 'application/xml', 'hash-student', 'batch', 'dwtest@example.com'),
-  (-86, 1, 5, 'application/xml', 'hash-student', 'batch', 'dwtest@example.com');
+  (-86, 1, 5, 'application/xml', 'hash-student', 'batch', 'dwtest@example.com'),
+  (2000, 1, 2, 'application/xml', 'hash-student-future-time', 'batch', 'dwtest@example.com');
 
 INSERT INTO warehouse_test.import (id, status, content, contentType, digest, batch, creator) VALUES
   (-90, 1, 1, 'application/xml', 'hash-iab_exam', 'batch', 'dwtest@example.com');

--- a/migrate-reporting/src/test/resources/ImportContentTeardown.sql
+++ b/migrate-reporting/src/test/resources/ImportContentTeardown.sql
@@ -4,4 +4,4 @@ INSERT INTO warehouse_test.import (id, status, content, contentType, digest) VAL
 
 -- Delete imports
 DELETE FROM warehouse_test.import
-WHERE id IN (-1, -2, -20, -89, -88, -87, -86, -79, -90, -99, -5000);
+WHERE id IN (-1, -2, -20, -89, -88, -87, -86, -79, -90, -99, -5000, 2000);

--- a/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
@@ -77,7 +77,8 @@ INSERT INTO warehouse_test.student (id, ssid, last_or_surname, first_name, middl
   (-89, '89', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -5000, -89, 1),
   (-88, '88', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -88, -88, 0),
   (-87, '87', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -87, -87, 0),
-  (-86, '86', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -86, -86, 0);
+  (-86, '86', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -86, -86, 0),
+  (-33, '33', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', 2000, 2000, 0);
 
 INSERT INTO warehouse_test.student_ethnicity(student_id, ethnicity_id) values
   (-89,  -99),
@@ -99,7 +100,8 @@ INSERT INTO warehouse_test.student_group_membership (student_group_id, student_i
   (-91, -86),
   (-8, -87),
   (-7, -87),
-  (-7, -86);
+  (-7, -86),
+  (-7, -33);
 
 INSERT INTO warehouse_test.user_student_group (student_group_id, user_login) VALUES
   (-91, 'dwtest@example.com-91'),

--- a/migrate-reporting/src/test/resources/WarehouseEntitiesTearDown.sql
+++ b/migrate-reporting/src/test/resources/WarehouseEntitiesTearDown.sql
@@ -11,7 +11,7 @@ DELETE FROM warehouse_test.exam_student where id in (-18, -17, -16);
 DELETE FROM warehouse_test.student_group_membership where student_group_id in ( -91, -8, -7);
 DELETE FROM warehouse_test.user_student_group where student_group_id in ( -91, -8, -7);
 DELETE FROM warehouse_test.student_ethnicity where student_id in ( -89, -88, -87, -86);
-DELETE FROM warehouse_test.student where id in (-11,  -89, -88, -87, -86);
+DELETE FROM warehouse_test.student where id in (-11,  -89, -88, -87, -86, -33);
 DELETE FROM warehouse_test.student_group where id in ( -91, -8, -7);
 
 -- ------------------------------------------ School/Districts --------------------------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ DELETE FROM reporting_test.exam where id in (-88, -87, -86, -85, -84);
 DELETE FROM reporting_test.student_group_membership where student_group_id in ( -91, -8, -7);
 DELETE FROM reporting_test.user_student_group where student_group_id in ( -91, -8, -7);
 DELETE FROM reporting_test.student_ethnicity where student_id in ( -89, -88, -87, -86);
-DELETE FROM reporting_test.student where id in ( -11, -89, -88, -87, -86);
+DELETE FROM reporting_test.student where id in ( -11, -89, -88, -87, -86, -33);
 DELETE FROM reporting_test.student_group where id in ( -91, -8, -7);
 
 -- ------------------------------------------ School/Districts --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the above mentioned issues, but while testing it I found more problems.

Migrating at the same time as the Import is running fails. After researching it a little bit further I know the following facts:
1. When migrate started it found only one record to migrate with **import id 1** and content CODE. **We preload this record when the schema is created**.
2. It was immediately migrated and then the migrate process went to sleep for 3 minutes while import was running.
4. After the migrate woke up, it ran a few batches of import ids and failed between import id 4000-5000.  
5. The failure was while moving exams due to missing assessment in the reporting DB.
6. I found that the reporting was missing assessments with ids 1-4 (at least).  

What is interesting and puzzling is that the warehouse had **4** assessment records with **import id 1** ??!!  I do not have an explanation on how this could have happened and planning on looking into it further.  I suspect that some of it may be related to the message queue (4 records), so most likely will involve Mark into this. 

While analyzing the above failure I have come to the conclusion that we have the following issues (outside of the mentioned above): 
1.	Stubbed out assessment and student group create methods are not conscious of the concurrency. If two threads/processes will try to create the same assessment (or group), they may collide. We have not planned for the stubbed out version to live that long but since they are still around we need to do something about it.
2.	Identifying migrate records by import id has two problems:
a.	We made a conscious design decision to not wrap the entire TRT into one transactions when writing into the warehouse. Because of that an import status may be failed while some traces of the TRT could had been successfully created: for example, a Student is created but not an exam. Since we are migrating by the status = 1, we will ignore the student in the above example. It is problematic.
b.	Import Id indicates a start of the import into the warehouse, but not the end. We want to pull records in the ‘end order of import’ not the ‘start order’. For example, if two threads run two imports in parallel, let’s say the first one creates an import id 100, and the second one 101. They may finish in the different order, so the status will be updated on the 101 first, and then on the 100th. If the migrate request X records from the 99 that have been processed, depending on the timing it may miss the 100th record.

There are multiple ways to address the above issues. I will call a meeting to discuss it. Just wanted to share it and give people time to ponder.
