### PR TITLE
bigerror

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcImportRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcImportRepository.java
@@ -7,6 +7,8 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import static org.opentestsystem.rdw.ingest.common.repository.JdbcUtils.safeText;
+
 @Repository
 class JdbcImportRepository implements ImportRepository {
 
@@ -25,7 +27,7 @@ class JdbcImportRepository implements ImportRepository {
         final int updatedCount = jdbcTemplate.update(updateStatusByIdSql, new MapSqlParameterSource()
                 .addValue("id", id)
                 .addValue("status", importStatus.getValue())
-                .addValue("message", message));
+                .addValue("message", safeText(message)));
         if (updatedCount == 0) {
             throw new IllegalArgumentException("unknown import id [" + id + "]");
         }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcUtils.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcUtils.java
@@ -1,9 +1,9 @@
-package org.opentestsystem.rdw.ingest.processor.repository.impl;
+package org.opentestsystem.rdw.ingest.common.repository;
 
 /**
  * Helper methods for JDBC
  */
-final class JdbcUtils {
+public final class JdbcUtils {
 
     private static final int TextLimit = (2 << 15) - 1;
 

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.Timestamp;
 import java.util.List;
 
-import static org.opentestsystem.rdw.ingest.processor.repository.impl.JdbcUtils.safeText;
+import static org.opentestsystem.rdw.ingest.common.repository.JdbcUtils.safeText;
 
 @Repository
 class JdbcExamRepository implements ExamRepository {


### PR DESCRIPTION
When the parsing errors accumulate, the message gets too big to save. This fix just truncates the message. That's not great but if there are that many errors during parsing, i'm sure the first few hundred will get the point across ...