### PR TITLE
Bug/loop

### DIFF
--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
@@ -56,11 +56,11 @@ class MigrateReportingJobRunner implements MigrateLifecycle {
     @Scheduled(fixedDelayString = "${migrate.batch.delay}")
     public void run() {
         try {
-            boolean firstRun = true;
+            boolean subsequent = false;
             Optional<JobParameters> jobParameters;
-            while (checkRunJobs() && (jobParameters = getNextJobParams(firstRun)).isPresent()) {
+            while (checkRunJobs() && (jobParameters = getNextJobParams(subsequent)).isPresent()) {
                 jobLauncher.run(job, jobParameters.get());
-                firstRun = false;
+                subsequent = true;
             }
         } catch (final Exception e) {
             logger.error("migrate reporting job failure [" + e.getMessage() + "]");
@@ -113,7 +113,7 @@ class MigrateReportingJobRunner implements MigrateLifecycle {
         return isRunning() && isEnabled();
     }
 
-    private Optional<JobParameters> getNextJobParams(final boolean firstRun) {
+    private Optional<JobParameters> getNextJobParams(final boolean subsequent) {
         final MigrateImportValues migrateImportValues = importRepository
                 .getMigrateImportValues(migrateRepository.findLastMigratedImportId(), batchSize);
 
@@ -138,7 +138,7 @@ class MigrateReportingJobRunner implements MigrateLifecycle {
 
         // if this is not the first run then only return work if it is a full count
         // (otherwise it keeps scraping the last few records, effectively defeating the micro-batching)
-        if (!firstRun && (migrateImportValues.getLast() - migrateImportValues.getFirst() + 1) < batchSize) {
+        if (subsequent && (migrateImportValues.getLast() - migrateImportValues.getFirst() + 1) < batchSize) {
             return Optional.empty();
         }
 

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 /**
@@ -55,9 +56,11 @@ class MigrateReportingJobRunner implements MigrateLifecycle {
     @Scheduled(fixedDelayString = "${migrate.batch.delay}")
     public void run() {
         try {
+            boolean firstRun = true;
             Optional<JobParameters> jobParameters;
-            while (checkRunJobs() && (jobParameters = getNextJobParams()).isPresent()) {
+            while (checkRunJobs() && (jobParameters = getNextJobParams(firstRun)).isPresent()) {
                 jobLauncher.run(job, jobParameters.get());
+                firstRun = false;
             }
         } catch (final Exception e) {
             logger.error("migrate reporting job failure [" + e.getMessage() + "]");
@@ -110,7 +113,7 @@ class MigrateReportingJobRunner implements MigrateLifecycle {
         return isRunning() && isEnabled();
     }
 
-    private Optional<JobParameters> getNextJobParams() {
+    private Optional<JobParameters> getNextJobParams(final boolean firstRun) {
         final MigrateImportValues migrateImportValues = importRepository
                 .getMigrateImportValues(migrateRepository.findLastMigratedImportId(), batchSize);
 
@@ -128,7 +131,17 @@ class MigrateReportingJobRunner implements MigrateLifecycle {
         // set or clear blocker based on these results
         blocker = migrateImportValues.getBlocker();
 
-        return migrateImportValues.getFirst() == null ? Optional.empty() :
-                Optional.of(JobParams.createJobParams(migrateImportValues.getFirst(), migrateImportValues.getLast()));
+        // no work to do ...
+        if (migrateImportValues.getFirst() == null) {
+            return Optional.empty();
+        }
+
+        // if this is not the first run then only return work if it is a full count
+        // (otherwise it keeps scraping the last few records, effectively defeating the micro-batching)
+        if (!firstRun && (migrateImportValues.getLast() - migrateImportValues.getFirst() + 1) < batchSize) {
+            return Optional.empty();
+        }
+
+        return Optional.of(JobParams.createJobParams(migrateImportValues.getFirst(), migrateImportValues.getLast()));
     }
 }

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
@@ -14,7 +14,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 /**

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunnerTest.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunnerTest.java
@@ -95,4 +95,15 @@ public class MigrateReportingJobRunnerTest {
         assertThat(reportingJobRunner.isEnabled()).isFalse();
         verify(jobLauncher, never()).run(same(job), any(JobParameters.class));
     }
+
+    @Test
+    public void itShouldNotLoopForPartialBlock() throws JobExecutionException {
+        when(importRepository.getMigrateImportValues(null, 10))
+                .thenReturn(new MigrateImportValues(1L, 10L, null))
+                .thenReturn(new MigrateImportValues(11L, 13L, null))
+                .thenReturn(new MigrateImportValues(null, null, null));
+
+        reportingJobRunner.run();
+        verify(jobLauncher, times(1)).run(same(job), any(JobParameters.class));
+    }
 }


### PR DESCRIPTION
The job runner is set up to loop as long as there is work to do. This is great except it leads to the migrator constantly pulling off sub-batches of work when ingest is processing things. For example, suppose ingest started up; before migrate kicks off it ingests 2500 records and is still cranking. So migrate processes 1000, then another 1000, then 650, then 120, then 10, then 10, then 10, then 10, etc. 

This change just stops that looping if there isn't a full batch of work to do. So in the example, it would process 1000, then another 1000, then it would wait until the next scheduled time. And probably do 1000 then. 