### PR TITLE
migrate-status

### DIFF
--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/status/MigrateReportingJobStatusIndicator.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/status/MigrateReportingJobStatusIndicator.java
@@ -40,6 +40,6 @@ public class MigrateReportingJobStatusIndicator extends AbstractStatusIndicator 
 
     @Override
     protected boolean doLevelCheck(final int level) {
-        return DiagnosticLevel.Configuration.isLessThanOrEqualTo(level);
+        return DiagnosticLevel.Ping.isLessThanOrEqualTo(level);
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/status/MigrateReportingJobStatusIndicatorTest.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/status/MigrateReportingJobStatusIndicatorTest.java
@@ -28,8 +28,8 @@ public class MigrateReportingJobStatusIndicatorTest {
     }
 
     @Test
-    public void itShouldBeAtConfigurationLevel() {
-        assertThat(statusIndicator.doLevelCheck(1)).isFalse();
+    public void itShouldBeAtPingLevel() {
+        assertThat(statusIndicator.doLevelCheck(0)).isTrue();
         assertThat(statusIndicator.doLevelCheck(2)).isTrue();
     }
 


### PR DESCRIPTION
This moves the "lifecycle" status to level 0. Why? It is cheap, i.e. just reflecting state which is in memory; it is useful to know that the service is running/enabled. Response looks like this:
```json
{
  "statusText": "Warning",
  "statusRating": 2,
  "level": 0,
  "dateTime": "2017-06-12T15:29:46.964+0000",
  "migrate-reporting-job": {
    "statusText": "Warning",
    "statusRating": 2,
    "lifecycle": "running,disabled"
  }
}
```