### PR TITLE
Fix the issues with mySQL timestamp defaulting the current timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ mysql> GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
 mysql> exit
 ```
 
+Additionaly, you need to configure MySQL setting in my.cnf file. Locate the file and add the following lines:
+```
+[mysqld]
+explicit_defaults_for_timestamp=1
+```
+
+If you do not know the location of my.cnf file, one way to check it is to run:
+```bash
+sudo fs_usage | grep my.cnf
+```
+This will report any filesystem activity in real-time related to that file.
+In another Terminal, restart your MySQL:
+```bash
+brew services restart mysql@5.6
+```
+On terminal with fs_usage, the proper location should be shown, e.g.
+```
+15:52:22  open            /usr/local/var/mysql/my.cnf
+```
+
+To verify that MySQL explicit_defaults_for_timestamp was set to 1:
+```bash
+mysql 
+mysql> SELECT @@explicit_defaults_for_timestamp;
+```
+
 The applications depend on the database being configured properly. See instructions below under [Running](#running)
 
 

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
@@ -68,7 +68,7 @@ class JdbcExamRepository implements ExamRepository {
                 .addValue("scale_score", exam.getScaleScore())
                 .addValue("scale_score_std_err", exam.getScaleScoreStdErr())
                 .addValue("performance_level", exam.getPerformanceLevel())
-                .addValue("completed_at", Timestamp.from(exam.getCompletedAt()));
+                .addValue("completed_at", exam.getCompletedAt() == null ? null : Timestamp.from(exam.getCompletedAt()));
 
         jdbcTemplate.update(sqlCreate, parameterSource, keyHolder);
         final Long id = keyHolder.getKey().longValue();

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
@@ -12,6 +12,7 @@ import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
 import org.opentestsystem.rdw.ingest.processor.repository.ExamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -242,5 +243,17 @@ public class ExamRepositoryIT {
         assertThat(countRowsInTable(jdbcTemplate, "exam_claim_score")).isEqualTo(beforeExamClaimScoreCount + 6);
         assertThat(countRowsInTable(jdbcTemplate, "exam_item")).isEqualTo(beforeExamItemCount + 4);
         assertThat(countRowsInTable(jdbcTemplate, "exam_available_accommodation")).isEqualTo(beforeExamAccommodationCount + 2);
+    }
+
+    /**
+     * The exam's completed date is defined as not null in the schema.
+     * If `explicit_defaults_for_timestamp` mySQL setting is turned off, this causes an undesirable behaviour.
+     * This test verifies that this setting is turned on.
+     */
+    @Test(expected = DataIntegrityViolationException.class)
+    public void testExplicitDefaultsForTimestampIsOn() {
+        final Exam exam = builder.completedAt(null).build();
+        exam.setStudentId(-11);
+        repository.create(exam, -1);
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
@@ -9,6 +9,7 @@ import org.opentestsystem.rdw.ingest.migrate.reporting.TableTestCountHelper;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
@@ -129,5 +130,34 @@ public class UpsertExamsIT extends SpringBatchStepIT {
         jobExecution = launchStep(upsertExamsStepName);
         assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
         verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingCodesPreloadToReporting.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingSetup.sql"}),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:MigrateEntitiesPreloadReportingSetup.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateEntitiesFromStagingTearDown.sql"}),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:MigrateCodesFromStagingTearDown.sql"})
+    })
+
+    /**
+     * The exam's completed date is defined as not null in the schema.
+     * If `explicit_defaults_for_timestamp` mySQL setting is turned off, this causes an undesirable behaviour.
+     * This test verifies that this setting is turned on.
+     */
+    @Test(expected = DataIntegrityViolationException.class)
+    public void testExplicitDefaultsForTimestampIsOn() {
+        jdbcTemplate.execute("INSERT INTO reporting_test.exam ( id, type_id, school_year, asmt_id, asmt_version, opportunity, completeness_id,\n" +
+                "                                administration_condition_id, session_id, performance_level, scale_score, scale_score_std_err,\n" +
+                "                                completed_at, import_id, grade_id, student_id, school_id, iep, lep,\n" +
+                "                                section504, economic_disadvantage, migrant_status, eng_prof_lvl, t3_program_type, language_code,\n" +
+                "                                prim_disability_type,\n" +
+                "                                claim1_scale_score, claim1_scale_score_std_err,claim1_category,\n" +
+                "                                claim2_scale_score, claim2_scale_score_std_err,claim2_category,\n" +
+                "                                claim3_scale_score, claim3_scale_score_std_err,claim3_category,\n" +
+                "                                claim4_scale_score, claim4_scale_score_std_err,claim4_category ) VALUES\n" +
+                "(-100, 1,  2016, -99,  null, 1, 1, 1, 'test', 1, 2145, 0.17, null, -88, -98, -89, -1, 1, 1, 0, 0, 1, 'test', 'test', 'eng', null,\n" +
+                "    2000, 0.11, 1, 2100, 0.12, 2, 2500, 0.13, 3, 3000, .15, 4);"
+        );
     }
 }

--- a/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingSetup.sql
+++ b/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingSetup.sql
@@ -61,10 +61,10 @@ INSERT INTO staging_test.staging_student_ethnicity(student_id, ethnicity_id) val
     (-86,  -98),
     (-86,  -99);
 
-INSERT INTO staging_test.staging_student_group (id, creator, school_id, school_year, name, subject_id, import_id, migrate_id, active, deleted) VALUES
-   (-91, 'dwtest@example.com', -99, 2017, 'Test Student Group 9', null, -79, -99, 1, 0),
-   (-8, 'dwtest@example.com', -1, 2017, 'Test Student Group 8', null, -79, -99, 1, 0),
-   (-7, 'dwtest@example.com', -1, 2017, 'Test Student Group 7', null, -79, -99, 1, 0);
+INSERT INTO staging_test.staging_student_group (id, creator, created, school_id, school_year, name, subject_id, import_id, migrate_id, active, deleted) VALUES
+   (-91, 'dwtest@example.com', NOW(), -99, 2017, 'Test Student Group 9', null, -79, -99, 1, 0),
+   (-8, 'dwtest@example.com',  NOW(), -1, 2017, 'Test Student Group 8', null, -79, -99, 1, 0),
+   (-7, 'dwtest@example.com',  NOW(), -1, 2017, 'Test Student Group 7', null, -79, -99, 1, 0);
 
  INSERT INTO staging_test.staging_student_group_membership (student_group_id, student_id) VALUES
    (-91, -89),

--- a/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingTearDown.sql
+++ b/migrate-reporting/src/test/resources/MigrateEntitiesFromStagingTearDown.sql
@@ -28,7 +28,7 @@ DELETE FROM staging_test.staging_student_group where id in ( -91, -8, -7);
 -- ------------------------------------------  Exams ---------------------------------------------------------------------------------------------
 DELETE FROM reporting_test.exam_available_accommodation where exam_id in (-88, -87, -86, -85, -84);
 DELETE FROM reporting_test.exam_item where exam_id in (-88, -87, -86, -85, -84);
-DELETE FROM reporting_test.exam where id in (-88, -87, -86, -85, -84);
+DELETE FROM reporting_test.exam where id in (-88, -87, -86, -85, -84, -100);
 
 -- ------------------------------------------ Student and Groups  ------------------------------------------------------------------------------------------------
 DELETE FROM reporting_test.student_group_membership where student_group_id in ( -91, -8, -7);


### PR DESCRIPTION
This will affect everybody, so PLEASE read.
MySQL 5.6 has this very strange default setting that causes the NULL timestamp to be automatically replaced with the current timestamp: https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp

Aurora does not have this problem.

In order to have the right configuration you will need to configure your local mySQL.
@rcordeau , I will need your help with configuring CI too.

