### PR TITLE
Fix for DWR-456: Un-scored TRT should not be migrated

### DIFF
--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/SqlCopyExecutionStep.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/SqlCopyExecutionStep.java
@@ -1,18 +1,13 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting.step;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
-import org.opentestsystem.rdw.ingest.migrate.reporting.Migrate;
 import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateBatch;
-import org.opentestsystem.rdw.ingest.migrate.reporting.MigrateStatus;
 import org.opentestsystem.rdw.ingest.migrate.reporting.repository.SqlCopyWarehouseToStagingRepository;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.repeat.RepeatStatus;
 
 import java.util.List;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 /**
  * A generic step for executing {@link SqlCopyExecutionStep#sqlCopyStatements} in the given order if
@@ -41,28 +36,12 @@ class SqlCopyExecutionStep extends StepTasklet {
 
     @Override
     public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
-
-        final MigrateBatch mb = getJobBatch(chunkContext);
-
         for (final ImportContent supportedContent : supportedContents) {
-
             if (getJobBatch(chunkContext).getImportContent().contains(supportedContent)) {
-
                 repository.execute(sqlCopyStatements, getJobBatch(chunkContext));
-
                 return RepeatStatus.FINISHED;
             }
         }
         return RepeatStatus.FINISHED;
-    }
-
-    @VisibleForTesting
-    List<SqlCopyStatements> getSqlCopyStatements() {
-        return sqlCopyStatements;
-    }
-
-    @VisibleForTesting
-    Iterable<ImportContent> getSupportedContents() {
-        return newArrayList(supportedContents);
     }
 }

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/WarehouseToStagingStepsConfig.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/WarehouseToStagingStepsConfig.java
@@ -139,7 +139,7 @@ public class WarehouseToStagingStepsConfig {
                 .addNext("exam_claim_score_by_update_import_id");
 
         return stepBuilderFactory.get(StageExamStepName)
-                .tasklet(new SqlCopyExecutionStep(newArrayList(EXAM, PACKAGE),
+                .tasklet(new SqlCopyExecutionStep(newArrayList(EXAM),
                         repository,
                         sqlsBuilder.build())
                 ).build();

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -740,7 +740,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam_student (id, grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage, migrant_status,
@@ -771,7 +770,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam_student (id, grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage, migrant_status,
@@ -803,7 +801,6 @@ sql:
               FROM warehouse.exam we
                JOIN warehouse.import wi on wi.id = we.import_id
               WHERE wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam (id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity,completeness_id, administration_condition_id,
@@ -833,7 +830,6 @@ sql:
               FROM warehouse.exam we
                 JOIN warehouse.import wi on wi.id = we.update_import_id
               WHERE wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam (id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity,completeness_id, administration_condition_id,
@@ -865,7 +861,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam_item (id, exam_id, item_id, score, score_status, position, response, trait_evidence_elaboration_score,
@@ -900,7 +895,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam_item (id, exam_id, item_id, score, score_status, position, response, trait_evidence_elaboration_score,
@@ -925,7 +919,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
              INSERT INTO staging.staging_exam_available_accommodation (exam_id, accommodation_id) VALUES
@@ -943,7 +936,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
              INSERT IGNORE INTO staging.staging_exam_available_accommodation (exam_id, accommodation_id) VALUES
@@ -966,7 +958,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND we.type_id in (1,3)
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES
@@ -988,7 +979,6 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
-                AND we.type_id in (1,3)
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -740,6 +740,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam_student (id, grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage, migrant_status,
@@ -770,6 +771,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam_student (id, grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage, migrant_status,
@@ -801,6 +803,7 @@ sql:
               FROM warehouse.exam we
                JOIN warehouse.import wi on wi.id = we.import_id
               WHERE wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam (id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity,completeness_id, administration_condition_id,
@@ -830,6 +833,7 @@ sql:
               FROM warehouse.exam we
                 JOIN warehouse.import wi on wi.id = we.update_import_id
               WHERE wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam (id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity,completeness_id, administration_condition_id,
@@ -861,6 +865,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam_item (id, exam_id, item_id, score, score_status, position, response, trait_evidence_elaboration_score,
@@ -895,6 +900,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam_item (id, exam_id, item_id, score, score_status, position, response, trait_evidence_elaboration_score,
@@ -919,6 +925,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
              INSERT INTO staging.staging_exam_available_accommodation (exam_id, accommodation_id) VALUES
@@ -936,6 +943,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND (we.type_id in (1,3) OR (we.type_id = 2 and we.scale_score is not null))
 
             stagingInsert: >-
              INSERT IGNORE INTO staging.staging_exam_available_accommodation (exam_id, accommodation_id) VALUES
@@ -958,6 +966,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND we.type_id in (1,3)
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES
@@ -979,6 +988,7 @@ sql:
               WHERE
                 wi.status = 1 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
                 AND we.deleted = 0
+                AND we.type_id in (1,3)
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
@@ -116,7 +116,7 @@ public class ReportingMigrateJobIT extends SpringBatchIT {
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam_available_accommodation", -1, "exam_id in (-88)"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam_item", 1, "exam_id in (-87)"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam_item", -1, "exam_id in (-88)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam", 2, "id in (-87, -86)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam", 2, "id in (-87, -85)"));
 
         // Range matches ImportContentSetup.sql
         final JobExecution jobExecution = getJobLauncherTestUtils().launchJob(JobParams.createJobParams(-99, -1));

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
@@ -77,17 +77,16 @@ public class StageExamIT extends SpringBatchStepIT {
     public void itShouldCopyExams() {
         // Collect counts of rows in each staging table before the step call and the expected change.
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 3, "id in (-88, -87, -85)"));
-        // exam with id -86 is an IAB with null scores, exam with id -88 is deleted
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 0, "id in (-86)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 2, "id in (-17, -15)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-16, -18)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 2, "exam_id in (-87, -85)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-86, -88)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 2, "exam_id in (-87, -85)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-86, -88)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 2, "exam_id in (-87, -85)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 0, "exam_id in (-86, -88)"));
+        // exam with id -88 is deleted
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 4, "id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 3, "id in (-17, -15, -16)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-18)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 3, "exam_id in (-87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-88)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 3, "exam_id in (-87, -86,  -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-88)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 3, "exam_id in (-87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 0, "exam_id in (-88)"));
 
         getStepExecutionContext().put("batch",
                 new MigrateBatch(

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.TableTestCountHelper.verifyTableCountsAfterTest;
 import static org.opentestsystem.rdw.ingest.migrate.reporting.step.WarehouseToStagingStepsConfig.StageExamStepName;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
@@ -48,31 +47,14 @@ public class StageExamIT extends SpringBatchStepIT {
     private static final long DefaultLastImportId = -1L;
 
     @Test
-    public void itShouldNotCopyPackagesIfBatchDoesNotHavePackageOrExamImportContent() {
+    public void itShouldNotCopyExamsIfBatchDoesNotHavePackageOrExamImportContent() {
         // Collect counts of rows in each staging table before the step call and the expected change.
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 0, "id in (-88, -87, -86)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-18, -17, -16)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-88, -87)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-88, -87)"));
-
-        getStepExecutionContext().put("batch", new MigrateBatch(mock(Migrate.class), newArrayList(ImportContent.GROUPS,
-                ImportContent.ORGANIZATION,
-                ImportContent.CODES)));
-
-        JobExecution jobExecution = launchStep(StageExamStepName);
-        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
-        //verifyTableCountsAfterTest(tableTestCounts);
-    }
-
-    @Test
-    public void itShouldCopyPackages() {
-        // Collect counts of rows in each staging table before the step call and the expected change.
-        final List<TableTestCountHelper> tableTestCounts = newArrayList();
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 3, "id in (-88, -87, -86)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 2, "id in (-18, -17, -16)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 1, "exam_id in (-88, -87)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 1, "exam_id in (-88, -87)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 0, "id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-18, -17, -16, -15)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 0, "exam_id in (-88, -87, -86, -85)"));
 
         getStepExecutionContext().put("batch",
                 new MigrateBatch(
@@ -81,7 +63,40 @@ public class StageExamIT extends SpringBatchStepIT {
                                 .firstImportId(DefaultFirstImportId)
                                 .lastImportId(DefaultLastImportId)
                                 .build(),
-                        newArrayList(ImportContent.EXAM, ImportContent.PACKAGE)));
+                        newArrayList(newArrayList(ImportContent.GROUPS,
+                                ImportContent.PACKAGE,
+                                ImportContent.ORGANIZATION,
+                                ImportContent.CODES))));
+
+        final JobExecution jobExecution = launchStep(StageExamStepName);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @Test
+    public void itShouldCopyExams() {
+        // Collect counts of rows in each staging table before the step call and the expected change.
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 3, "id in (-88, -87, -85)"));
+        // exam with id -86 is an IAB with null scores, exam with id -88 is deleted
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 0, "id in (-86)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 2, "id in (-17, -15)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-16, -18)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 2, "exam_id in (-87, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-86, -88)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 2, "exam_id in (-87, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-86, -88)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 2, "exam_id in (-87, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 0, "exam_id in (-86, -88)"));
+
+        getStepExecutionContext().put("batch",
+                new MigrateBatch(
+                        Migrate.builder().id(1L).jobId(1)
+                                .status(MigrateStatus.STARTED)
+                                .firstImportId(DefaultFirstImportId)
+                                .lastImportId(DefaultLastImportId)
+                                .build(),
+                        newArrayList(ImportContent.EXAM)));
 
         final JobExecution jobExecution = launchStep(StageExamStepName);
 
@@ -90,13 +105,14 @@ public class StageExamIT extends SpringBatchStepIT {
     }
 
     @Test
-    public void itShouldNotCopyPackagesIfNoImports() {
+    public void itShouldNotCopyExamsIfNoImports() {
         // Collect counts of rows in each staging table before the step call and the expected change.
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 0, "id in (-88, -87, -86)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-18, -17, -16)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-88, -87)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-88, -87)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 0, "id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-18, -17, -16, -15)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 0, "exam_id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_item", 0, "exam_id in (-88, -87, -86, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_claim_score", 0, "exam_id in (-88, -87, -86, -85)"));
 
         getStepExecutionContext().put("batch",
                 new MigrateBatch(
@@ -105,7 +121,7 @@ public class StageExamIT extends SpringBatchStepIT {
                                 .firstImportId(20000L)
                                 .lastImportId(20001L)
                                 .build(),
-                        newArrayList(ImportContent.EXAM, ImportContent.PACKAGE)));
+                        newArrayList(ImportContent.EXAM)));
 
         final JobExecution jobExecution = launchStep(StageExamStepName);
 

--- a/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
@@ -120,21 +120,32 @@ INSERT INTO warehouse_test.exam_student ( id, grade_id, student_id, school_id, i
                                                     migrant_status, eng_prof_lvl, t3_program_type, language_code, prim_disability_type) VALUES
   ( -18, -98, -89, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
   ( -17, -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  ( -16, -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null);
+  ( -16, -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  ( -15, -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null);
 
 INSERT INTO  warehouse_test.exam ( id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity, completeness_id,
                                       administration_condition_id, session_id, performance_level, scale_score, scale_score_std_err, completed_at, import_id, update_import_id, deleted) VALUES
   (-88, 1, -18, 2016, -99,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14', -5000, -88, 1),
-  (-87, 1, -17, 2016, -11,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14', -88, -88, 0),
-  (-86, 1, -16, 2016, -11,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14', -88, -88, 0);
+  (-87, 1, -17, 2016, -11,  null, 1, 1, 1, 'session', 1, null, null, '2016-08-14', -88, -88, 0),
+  (-86, 2, -16, 2016, -11,  null, 1, 1, 1, 'session', 1, null, null, '2016-08-14', -88, -88, 0),
+  (-85, 1, -15, 2016, -11,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14', -88, -88, 0);
 
 INSERT INTO warehouse_test.exam_available_accommodation (exam_id, accommodation_id) VALUES
   (-88, -98),
-  (-87, -98);
+  (-87, -98),
+  (-86, -98),
+  (-85, -98);
 
 INSERT INTO warehouse_test.exam_item (id, exam_id, item_id, score, score_status, response, position) VALUES
   (-1, -88,  -9, 1, 'SCORED', '<response><math xmlns="http://www.w3.org/1998/Math/MathML" title="10"><mstyle><mn>10</mn></mstyle></math></response>', 1),
   (-2, -88,  -8, 1, 'SCORED', 'D', 2),
   (-3, -88,  -7, 0, 'SCORED', 'C', 3),
   (-4, -88,  -6, -1, 'SCORED', null, 16),
-  (-5, -87,  -6, -1, 'SCORED', null, 16);
+  (-5, -87,  -6, -1, 'SCORED', null, 16),
+  (-6, -85,  -6, -1, 'SCORED', null, 16),
+  (-7, -86,  -6, -1, 'SCORED', null, 16);
+
+INSERT INTO warehouse_test.exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES
+   (-1, -88, 1, 2014, 0.19, 1),
+   (-2, -87, 1, 2014, 0.19, 1),
+   (-3, -85, 1, 2014, 0.19, 1);

--- a/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
@@ -148,4 +148,5 @@ INSERT INTO warehouse_test.exam_item (id, exam_id, item_id, score, score_status,
 INSERT INTO warehouse_test.exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES
    (-1, -88, 1, 2014, 0.19, 1),
    (-2, -87, 1, 2014, 0.19, 1),
-   (-3, -85, 1, 2014, 0.19, 1);
+   (-3, -86, 1, 2014, 0.19, 1),
+   (-4, -85, 1, 2014, 0.19, 1);

--- a/migrate-reporting/src/test/resources/WarehouseEntitiesTearDown.sql
+++ b/migrate-reporting/src/test/resources/WarehouseEntitiesTearDown.sql
@@ -7,7 +7,7 @@ DELETE FROM warehouse_test.exam_available_accommodation where exam_id in (-88, -
 DELETE FROM warehouse_test.exam_item where exam_id in (-88, -87, -86, -85, -84);
 DELETE FROM warehouse_test.exam_claim_score where exam_id in (-88, -87, -86, -85, -84);
 DELETE FROM warehouse_test.exam where id in (-88, -87, -86, -85, -84);
-DELETE FROM warehouse_test.exam_student where id in (-18, -17, -16);
+DELETE FROM warehouse_test.exam_student where id in (-18, -17, -16, -15);
 
 -- ------------------------------------------ Student and Groups  ------------------------------------------------------------------------------------------------
 DELETE FROM warehouse_test.student_group_membership where student_group_id in ( -91, -8, -7);


### PR DESCRIPTION
This fixes the issue for the newly loaded data.
I am not sure what to do with the already loaded data. 
Options I see:
1. write a SQL script to clean them up in the reporting. 
2. write a SQL script to mark them as 'deleted' in the warehouse and expect migrate to clean them up. This way we could also test the migrate/delete. The risk is that if it fails - we will have more issues to deal with.
3. do nothing. I think the 'data generator' data do not have unscored IABs( @malaffoon, please correct me if needed). ETS loaded data do have this problem. If this is the case, would it be easier to load ETS data?

Please let me know what you think. 