### PR TITLE
DWR-398 Set up tests to reproduce the errors.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
@@ -7,6 +7,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcCall;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 class JdbcSchoolRepository implements SchoolRepository {
@@ -20,6 +21,7 @@ class JdbcSchoolRepository implements SchoolRepository {
 
     @Override
     @Cacheable(value = "school", key = "#school")
+    @Transactional
     public int upsert(final School school, final long importId) {
         return (int) new SimpleJdbcCall(jdbcTemplate)
                 .withProcedureName("school_upsert").execute(new MapSqlParameterSource()

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedApplicationTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedApplicationTest.java
@@ -1,0 +1,56 @@
+package org.opentestsystem.rdw.ingest.processor.multithreaded;
+
+import org.opentestsystem.rdw.ingest.processor.configuration.DataSourceConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * A console application that runs all available {@link MultiThreadedTest}s
+ * The exist status 0 indicates a success.
+ * The exist status > 0 indicates a number of failed tests
+ */
+@ComponentScan({"rg.opentestsystem.rdw.ingest.processor.service",
+        "org.opentestsystem.rdw.ingest.processor.service.impl",
+        "org.opentestsystem.rdw.ingest.processor.repository",
+        "org.opentestsystem.rdw.ingest.processor.repository.impl",
+        "org.opentestsystem.rdw.ingest.processor.model",
+        "org.opentestsystem.rdw.ingest.processor.multithreaded"
+})
+@Import({YamlPropertiesConfigurator.class,
+        DataSourceAutoConfiguration.class,
+        JdbcTemplateAutoConfiguration.class,
+        DataSourceConfiguration.class})
+@Profile("test")
+public class MultiThreadedApplicationTest {
+    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedApplicationTest.class);
+
+    public static void main(final String[] args) throws Exception {
+        final ConfigurableApplicationContext ctx =
+                new SpringApplicationBuilder(MultiThreadedApplicationTest.class)
+                        .web(false)
+                        .run(args);
+
+        final List<Integer> failed = newArrayList();
+        for (final String test : ctx.getBeanNamesForType(MultiThreadedTest.class)) {
+            logger.info("Running test for [" + test + "]");
+            final boolean passed = ctx.getBean(test, MultiThreadedTest.class).run();
+            logger.info(test + " " + (passed ? "passed" : "failed"));
+
+            failed.add(passed ? 0 : 1);
+        }
+
+        System.exit(failed.stream().mapToInt(Integer::intValue).sum());
+    }
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedSchoolRepo.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedSchoolRepo.java
@@ -1,0 +1,49 @@
+package org.opentestsystem.rdw.ingest.processor.multithreaded;
+
+import org.opentestsystem.rdw.ingest.common.model.District;
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.repository.SchoolRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+
+@Component
+public class MultiThreadedSchoolRepo extends MultiThreadedTest {
+    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedSchoolRepo.class);
+
+    @Autowired
+    private SchoolRepository repository;
+
+    private School school;
+
+    @Override
+    protected void setUp() {
+        school = School.builder()
+                .name("New School To Test Cache")
+                .naturalId("cache123")
+                .district(District.builder().naturalId("cache123").name("New District to test Cache").build())
+                .build();
+    }
+
+    @Override
+    protected Runnable newRunnable(ExecutorService pool) {
+        return () -> {
+            try {
+                repository.upsert(school, 1);
+            } catch (final Exception ex) {
+                logger.info("Exception:" + ex.getMessage());
+                if (passed) passed = false;
+                try {
+                    repository.upsert(school, 1);
+                    logger.info("Second try success");
+                } catch (Exception e) {
+                    logger.info("Second try failed, exception:" + e.getMessage());
+                }
+            }
+            pool.shutdown();
+        };
+    }
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentExamWriter.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentExamWriter.java
@@ -1,0 +1,146 @@
+package org.opentestsystem.rdw.ingest.processor.multithreaded;
+
+import org.opentestsystem.rdw.common.model.AssessmentType;
+import org.opentestsystem.rdw.ingest.common.model.District;
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.repository.SchoolRepository;
+import org.opentestsystem.rdw.ingest.processor.model.Assessment;
+import org.opentestsystem.rdw.ingest.processor.model.Exam;
+import org.opentestsystem.rdw.ingest.processor.model.Student;
+import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
+import org.opentestsystem.rdw.ingest.processor.model.StudentGroup;
+import org.opentestsystem.rdw.ingest.processor.repository.StubbedOutAssessmentRepository;
+import org.opentestsystem.rdw.ingest.processor.repository.StudentGroupRepository;
+import org.opentestsystem.rdw.ingest.processor.repository.StudentRepository;
+import org.opentestsystem.rdw.ingest.processor.service.StudentExamWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+@Component
+public class MultiThreadedStudentExamWriter extends MultiThreadedTest {
+    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedStudentExamWriter.class);
+
+    @Autowired
+    private StudentExamWriter examWriter;
+
+    @Autowired
+    private SchoolRepository schoolRepository;
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @Autowired
+    private StubbedOutAssessmentRepository assessmentRepository;
+
+    @Autowired
+    private StudentGroupRepository studentGroupRepository;
+
+    private Exam exam;
+    private Student student;
+
+    @Override
+    protected void setUp() {
+        final int schoolId = schoolRepository.upsert(School.builder()
+                .name("New School To Test Cache")
+                .naturalId("cache123")
+                .district(District.builder().naturalId("cache123").name("New District to test Cache").build())
+                .build(), 1);
+        final int assmtId = assessmentRepository.create(Assessment.builder()
+                .naturalId("testId")
+                .name("test name")
+                .label("test label")
+                .schoolYear(2015)
+                .gradeId(3)
+                .subjectId(1)
+                .typeId(1).build(), 1).getId();
+
+        final StudentGroup group1 = newGroup("name1", schoolId);
+        final StudentGroup group2 = newGroup("name2", schoolId);
+        final StudentGroup group3 = newGroup("name3", schoolId);
+
+        studentGroupRepository.upsert(group1, 1);
+        studentGroupRepository.upsert(group2, 1);
+        studentGroupRepository.upsert(group3, 1);
+
+        student = Student.builder()
+                .ssid("6666666669")
+                .firstName("FirstName6")
+                .lastOrSurname("LastName6")
+                .middleName("MiddleName6")
+                .birthday(LocalDate.parse("2006-07-08"))
+                .firsEntryIntoUSSchoolAt(LocalDate.parse("2015-09-02"))
+                .lepEntryAt(null)
+                .lepExitAt(null)
+                .genderId(1)
+                .groups(newArrayList(group1, group2, group3))
+                .build();
+        studentRepository.upsert(student, 1);
+
+        exam = Exam.builder()
+                .typeId(AssessmentType.ICA.id())
+                .performanceLevel(5)
+                .administrationConditionId(1)
+                .asmtVersion("345")
+                .assessmentId(assmtId)
+                .completedAt(Instant.parse("2007-01-02T14:30:00Z"))
+                .schoolYear(2015L)
+                .completenessId(1)
+                .opportunity(7L)
+                .scaleScore(77.7)
+                .scaleScoreStdErr(6.6)
+                .sessionId("session")
+                .studentExamAttributes(StudentExamAttributes.builder()
+                        .economicDisadvantage(true)
+                        .engProfLvl("engl prof")
+                        .gradeId(1)
+                        .ideaIndicator(true)
+                        .languageCode("CDE")
+                        .lep(false)
+                        .migrantStatus(false)
+                        .primDisabilityType("PD")
+                        .responsibleSchoolId(schoolId)
+                        .section504(true)
+                        .t3ProgramType("t3")
+                        .build()).build();
+    }
+
+    @Override
+    protected Runnable newRunnable(ExecutorService pool) {
+
+        return () -> {
+            try {
+                examWriter.saveNewExam(student, exam, 1);
+            } catch (final Exception ex) {
+                logger.info("Exception:" + ex.getMessage());
+                if (passed) passed = false;
+                try {
+                    examWriter.saveNewExam(student, exam, 1);
+                    logger.info("Second try success");
+                } catch (Exception e) {
+                    logger.info("Second try failed, exception:" + e.getMessage());
+                }
+            }
+            pool.shutdown();
+        };
+    }
+
+    private StudentGroup newGroup(final String name, final int schoolId) {
+        return StudentGroup.builder()
+                .name(name)
+                .schoolId(schoolId)
+                .schoolYear(2017)
+                .subjectId(1)
+                .active(true)
+                .creator("test")
+                .created(Instant.now())
+                .build();
+    }
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentRepo.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentRepo.java
@@ -1,0 +1,55 @@
+package org.opentestsystem.rdw.ingest.processor.multithreaded;
+
+import org.opentestsystem.rdw.ingest.processor.model.Student;
+import org.opentestsystem.rdw.ingest.processor.repository.StudentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.concurrent.ExecutorService;
+
+@Component
+public class MultiThreadedStudentRepo extends MultiThreadedTest {
+    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedStudentRepo.class);
+
+    @Autowired
+    private StudentRepository repository;
+
+    private Student student;
+
+    @Override
+    protected void setUp() {
+        student = Student.builder()
+                .ssid("6666666669")
+                .firstName("FirstName6")
+                .lastOrSurname("LastName6")
+                .middleName("MiddleName6")
+                .birthday(LocalDate.parse("2006-07-08"))
+                .firsEntryIntoUSSchoolAt(LocalDate.parse("2015-09-02"))
+                .lepEntryAt(null)
+                .lepExitAt(null)
+                .genderId(1)
+                .build();
+    }
+
+    @Override
+    protected Runnable newRunnable(final ExecutorService pool) {
+        return () -> {
+            try {
+                repository.upsert(student, 1);
+            } catch (Exception ex) {
+                logger.info("Exception:" + ex.getMessage());
+                if (passed) passed = false;
+                try {
+                    repository.upsert(student, 1);
+                    logger.info("Second try success");
+                } catch (Exception e) {
+                    logger.info("Second try failed, exception:" + e.getMessage());
+                }
+            }
+            pool.shutdown();
+        };
+    }
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedTDSProcessor.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedTDSProcessor.java
@@ -1,0 +1,51 @@
+package org.opentestsystem.rdw.ingest.processor.multithreaded;
+
+import org.opentestsystem.rdw.common.model.trt.TDSReport;
+import org.opentestsystem.rdw.common.model.trt.XmlUtils;
+import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+
+@Component
+public class MultiThreadedTDSProcessor extends MultiThreadedTest {
+    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedTDSProcessor.class);
+
+    @Autowired
+    private TDSReportProcessor processor;
+
+    @Override
+    protected Runnable newRunnable(ExecutorService pool) {
+        return () -> {
+            for (final String sample : new String[]{
+                    "TDSReport.iab.sample.xml",
+                    "TDSReport.ica.sample.xml",
+                    "SBAC-IAB-FIXED-G4M-G-MATH-4.xml",
+                    "SBAC-IAB-FIXED-G6E-LangVocab-ELA-6.xml",
+                    "SBAC-IAB-FIXED-G6E-ReadLit-ELA-6.xml",
+                    "SBAC-IAB-FIXED-G6M-EE.xml",
+                    "SBAC-ICA-FIXED-G4M-COMBINED-2017.xml",
+                    "SBAC-ICA-FIXED-G6E-COMBINED-2017.xml",
+                    "SBAC-ICA-FIXED-G6M-COMBINED-2017.xml"
+            }) {
+                final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/" + sample));
+                try {
+                    processor.process(tdsReport, 1);
+                } catch (Exception ex) {
+                    logger.info("Exception:" + ex.getMessage());
+                    if (passed) passed = false;
+                    try {
+                        processor.process(tdsReport, 1);
+                        logger.info("Second try success");
+                    } catch (Exception e) {
+                        logger.info("Second try failed, exception:" + e.getMessage());
+                    }
+                }
+            }
+            pool.shutdown();
+        };
+    }
+}

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedTest.java
@@ -1,0 +1,88 @@
+package org.opentestsystem.rdw.ingest.processor.multithreaded;
+
+import com.google.common.collect.Lists;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * A base class for running multi-threaded testing involving jdbc
+ */
+public abstract class MultiThreadedTest {
+    private final static int TEST_THREAD_COUNT = 5;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    protected volatile Boolean passed = true;
+
+    /**
+     * The test itself. Each test must provide its own implementation
+     *
+     * @param pool the {@link ExecutorService}
+     * @return newly created {@link Runnable} to test
+     */
+    protected abstract Runnable newRunnable(ExecutorService pool);
+
+    /**
+     * A hook to prepare the test data if needed
+     */
+    protected void setUp() {
+        //override with anything that is needed for the test
+    }
+
+    /**
+     * A multithreaded test runner
+     *
+     * @return a flag indicating a pass or fail
+     */
+    public boolean run() {
+        cleanUp();
+        setUp();
+
+        final ExecutorService pool = Executors.newWorkStealingPool(TEST_THREAD_COUNT);
+        final Runnable r = newRunnable(pool);
+
+        for (int i = 0; i < TEST_THREAD_COUNT; i++) {
+            pool.submit(r);
+        }
+        while (!pool.isTerminated()) {
+            //stay alive
+        }
+
+        cleanUp();
+        return passed;
+    }
+
+    private void cleanUp() {
+        final List<String> sqls = newArrayList(
+                "TRUNCATE TABLE school",
+                "TRUNCATE TABLE district",
+                "TRUNCATE TABLE student",
+                "TRUNCATE TABLE student_ethnicity",
+                "TRUNCATE TABLE student_group",
+                "TRUNCATE TABLE student_group_membership",
+                "TRUNCATE TABLE user_student_group",
+                "TRUNCATE TABLE asmt",
+                "TRUNCATE TABLE asmt_score",
+                "TRUNCATE TABLE item",
+                "TRUNCATE TABLE item_common_core_standard",
+                "TRUNCATE TABLE item_other_target",
+                "TRUNCATE TABLE exam_student",
+                "TRUNCATE TABLE exam",
+                "TRUNCATE TABLE exam_item",
+                "TRUNCATE TABLE exam_available_accommodation",
+                "TRUNCATE TABLE exam_claim_score"
+        );
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        for (final String sql : Lists.reverse(sqls)) {
+            jdbcTemplate.execute(sql);
+        }
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+}


### PR DESCRIPTION
This does not solve anything. 
It sets up the test environment to reproduce the failures.

I was not able to use junit framework due to a difference in the transaction management.
This creates a console app that runs some Repos and Services in the multi-threaded set up.

I am able to reproduce two errors @malaffoon had seen while ingesting the data and two more:

1. "call school_upsert(?, ?, ?, ?, ?, ?)}]; Column 'district_id' cannot be null"
2. "UPDATE student_group SET update_import_id = ? WHERE id = ?]; Deadlock found when trying to get lock; try restarting transaction"
3. "INSERT IGNORE INTO student_group_membership (student_group_id, student_id) VALUES (?, ?)]; Deadlock found when trying to get lock;"
4. null student id returned for the student upsert.

Issues 1 and 4 are solved by the retry.
Issues 2 and 3 are not really solved by the retry - it depends on the number of the concurrent threads. At least one thread succeeds with the retry, but not all.

I am planning on trying to find a solution for these issues, but wanted to get the feedback on the testing set up.