### PR TITLE
DWR-401

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,30 +42,35 @@ mysql> GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
 mysql> exit
 ```
 
-Additionaly, you need to configure MySQL setting in my.cnf file. Locate the file and add the following lines:
+Additionally, you need to configure MySQL settings in `my.cnf` file. Locate the file (for a brew install it will be
+`/usr/local/Cellar/mysql@5.6/5.6.34/my.cnf` but if you can't find it try `sudo find -name my.cnf -print`) 
+and add the following lines:
 ```
 [mysqld]
 explicit_defaults_for_timestamp=1
+default-time-zone='UTC'
 ```
 
-If you do not know the location of my.cnf file, one way to check it is to run:
-```bash
-sudo fs_usage | grep my.cnf
-```
-This will report any filesystem activity in real-time related to that file.
-In another Terminal, restart your MySQL:
+Restart MySQL:
 ```bash
 brew services restart mysql@5.6
 ```
-On terminal with fs_usage, the proper location should be shown, e.g.
-```
-15:52:22  open            /usr/local/var/mysql/my.cnf
-```
 
-To verify that MySQL explicit_defaults_for_timestamp was set to 1:
+To verify the settings, run a mysql client:
 ```bash
-mysql 
 mysql> SELECT @@explicit_defaults_for_timestamp;
++-----------------------------------+
+| @@explicit_defaults_for_timestamp |
++-----------------------------------+
+|                                 1 |
++-----------------------------------+
+
+mysql> SELECT @@system_time_zone, @@global.time_zone, @@session.time_zone;
++--------------------+--------------------+---------------------+
+| @@system_time_zone | @@global.time_zone | @@session.time_zone |
++--------------------+--------------------+---------------------+
+| PDT                | UTC                | UTC                 |
++--------------------+--------------------+---------------------+
 ```
 
 The applications depend on the database being configured properly. See instructions below under [Running](#running)

--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
           group: default
 
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
     username: root
     password:
     testWhileIdle: true

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
@@ -12,7 +12,6 @@ import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
 import org.opentestsystem.rdw.ingest.processor.repository.ExamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -79,8 +78,7 @@ public class ExamRepositoryIT {
             "administration_condition_id = 1 and " +
             "asmt_version = '345' and " +
             "asmt_id = -1 and " +
-//            TODO: Mark will fix it
-//            "completed_at = convert_tz(timestamp('2007-01-02T14:30:00Z'), '+00:00', @@session.time_zone) and " +
+            "completed_at = convert_tz(timestamp('2007-01-02T14:30:00Z'), '+00:00', @@session.time_zone) and " +
             "completeness_id = 1 and " +
             "opportunity = 7 and " +
             "cast(scale_score as decimal(5,2)) =  77.7 and " +

--- a/exam-processor/src/test/resources/application-test.yml
+++ b/exam-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -46,7 +46,7 @@ spring:
             requiredGroups: default
 
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
     username: root
     password:
     testWhileIdle: true

--- a/import-service/src/test/resources/application-test.yml
+++ b/import-service/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -13,7 +13,7 @@ migrate:
 
 spring:
   batch_datasource:
-    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false&useLegacyDatetimeCode=false
     username: root
     password:
     testWhileIdle: true
@@ -22,7 +22,7 @@ spring:
     initialize: false
 
   warehouse_datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
     username: root
     password:
     testWhileIdle: true

--- a/migrate-reporting/src/test/resources/application-test.yml
+++ b/migrate-reporting/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   batch_datasource:
-    url: jdbc:mysql://localhost:3306/spring_batch_reporting_test?useSSL=false
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting_test?useSSL=false&useLegacyDatetimeCode=false

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
           group: default
 
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
     username: root
     password:
     testWhileIdle: true

--- a/package-processor/src/test/resources/application-test.yml
+++ b/package-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   mail:
     host: local
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
     username: root
     password:
     testWhileIdle: true

--- a/task-service/src/test/resources/application-test.yml
+++ b/task-service/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false


### PR DESCRIPTION
Some explanation and solicitation for feedback (sorry about the rambling) ...

The fundamental fix is to set `useLegacyDatetimeCode=false`. This works great, enabling the new version of timezone handling. With that flag it does what you'd think it would converting properly between the client and server time offsets. I will have to make similar changes in RDW_Reporting (https://github.com/SmarterApp/RDW_Reporting/pull/164), and all the sbac-config-repo files (https://gitlab.com/fairwaytech/sbac-config-repo/merge_requests/47).

A problem arises because, with this change, the mysql server *must* have a valid timezone set (see digression 1 below). For our Aurora instances, this isn't a problem: they are all UTC, awesome possum. For our local systems, we need to change them because PDT (the default for most of us) is an ambiguous timezone. We could load all the timezone info and set it to 'America/Los Angeles'; we could use '-07:00'; or we could use UTC -- the latter is my recommendation (see digression 2 below). We'll have to see how the CI MySQL's are set up.

So, whatcha all think about this? ~~@rcordeau i will need your help tweaking the CI MySQL instances if necessary and i'd like to do that *before* committing these changes.~~ I verified that mysql on the build agent is set to 'UTC'.

---

Digression 1: okay, before any timezone junkies jump all over me: yes, mysql is messed up and the documentation and verbiage is very misleading. Strictly speaking what mysql calls a timezone is really a zone offset. That is why PDT is ambiguous and UTC (which isn't actually a timezone) is okay. It basically loads a map of timezone -> zone offsets and tries to smooth over the inconsistencies.

---

Digression 2: setting to UTC makes things a little odd with a mysql client because you'll have to remember that the values you are setting are in UTC, not local timezone. And, because mysql doesn't accept timezone indicators in SQL you have to use convert_ts. So, to save a value that is 7:30am (PDT) you should do something like `SET created=convert_tz(timestamp('2017-06-24 07:30:00'), '-07:00', @@session.time_zone)`. Alternatively you could set your session.time_zone to 'PDT' in the client. OTOH it will make interacting with your local database more similar to interacting with the aurora instances. I think.


