### PR TITLE
add CALPADS schools CSV parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=0.0.1-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "0.0.1-21"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "0.0.1-95"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "0.0.1-106"
 
 
 allprojects {

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
@@ -5,10 +5,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcCall;
 import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 @Repository
 class JdbcSchoolRepository implements SchoolRepository {
@@ -16,7 +23,10 @@ class JdbcSchoolRepository implements SchoolRepository {
     private final JdbcTemplate jdbcTemplate;
 
     @Value("${sql.school.findIdByNaturalId}")
-    private String findIdByNaturalIdSql;
+    private String sqlFindIdByNaturalId;
+
+    @Value("${sql.school.upsert}")
+    private String sqlUpsertSchool;
 
     @Autowired
     JdbcSchoolRepository(final JdbcTemplate jdbcTemplate) {
@@ -36,10 +46,31 @@ class JdbcSchoolRepository implements SchoolRepository {
     }
 
     @Override
+    public void upsert(final Iterable<School> schools, final long importId) {
+        final List<School> toUpsert = newArrayList(schools);
+        jdbcTemplate.batchUpdate(sqlUpsertSchool, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(final PreparedStatement ps, final int i) throws SQLException {
+                final School school = toUpsert.get(i);
+                ps.setString(1, school.getDistrict().getName());
+                ps.setString(2, school.getDistrict().getNaturalId());
+                ps.setString(3, school.getName());
+                ps.setString(4, school.getNaturalId());
+                ps.setLong(5, importId);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return toUpsert.size();
+            }
+        });
+    }
+
+    @Override
     @Cacheable(value = "schoolId")
     public Integer findIdByNaturalId(final String naturalId) {
         try {
-            return jdbcTemplate.queryForObject(findIdByNaturalIdSql, new Object[]{naturalId}, Integer.class);
+            return jdbcTemplate.queryForObject(sqlFindIdByNaturalId, new Object[]{naturalId}, Integer.class);
         } catch (final EmptyResultDataAccessException ignore) {
             return null;
         }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/SchoolRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/SchoolRepository.java
@@ -18,6 +18,17 @@ public interface SchoolRepository {
     int upsert(School school, long importId);
 
     /**
+     * Upsert a collection of schools.<br/>
+     * Based on natural id it will insert a new school or update an existing one.
+     * If the school already exists with the same data no writes will occur.
+     * The same logic is applied to the embedded district.
+     *
+     * @param schools schools to upsert
+     * @param importId import id to associate with any change.
+     */
+    void upsert(Iterable<School> schools, long importId);
+
+    /**
      * Find id of the school by the given natural id
      * @param naturalId the natural id
      * @return the dbid, null if not found

--- a/common/src/main/resources/application.sql.yml
+++ b/common/src/main/resources/application.sql.yml
@@ -12,3 +12,6 @@ sql:
   school:
     findIdByNaturalId: >-
       SELECT id FROM school WHERE natural_id = ?
+
+    upsert: >-
+      CALL school_upsert(?, ?, ?, ?, ?, @p_id)

--- a/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
@@ -832,6 +832,7 @@ sql:
                 JOIN staging.staging_student ss ON ss.id = rs.id
                 JOIN reporting.gender rg ON ss.gender_id = rg.id
               SET
+                rs.ssid = ss.ssid,
                 rs.last_or_surname = ss.last_or_surname,
                 rs.first_name = ss.first_name,
                 rs.middle_name = ss.middle_name,

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
@@ -1,0 +1,74 @@
+package org.opentestsystem.rdw.ingest.processor.service.impl;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.opentestsystem.rdw.ingest.common.model.District;
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+/**
+ * Parses CALPADS schools CSV format. This is a caret-delimited file, see samples in tests.
+ */
+class CalpadsSchoolsParser implements OrganizationParser {
+    private static final Logger logger = LoggerFactory.getLogger(CalpadsSchoolsParser.class);
+
+    // Columns in CALPADS schools CSV
+    private static final String DistrictCode = "County-District Code";
+//    private static final String SchoolCode = "SchoolCode";
+    private static final String AuthCdsCode = "Auth CDS Code";
+//    private static final String CountyName = "County Name";
+    private static final String DistrictName = "District Name";
+    private static final String SchoolName = "School Name";
+//    private static final String CharterSchool = "Charter School";
+//    private static final String CharterStatus = "Charter Status";
+//    private static final String NpsSchool = "NPS School";
+
+    private static final CSVFormat CalpadsCSVFormat = CSVFormat.RFC4180.withDelimiter('^').withFirstRecordAsHeader();
+
+    private final Map<String, District> districts = newHashMap();
+    private final Map<String, School> schools = newHashMap();
+
+    public Map<String, School> getSchools() {
+        return schools;
+    }
+
+    public void parse(final byte[] payload, final ParserHelper parserHelper) {
+        try (final Reader reader = new InputStreamReader(new ByteArrayInputStream(payload), Charset.forName("utf8"))) {
+            final District.Builder districtBuilder = District.builder();
+            final School.Builder schoolBuilder = School.builder();
+
+            int count = 0;
+            for (final CSVRecord record : CalpadsCSVFormat.parse(reader)) {
+                final String districtId = parserHelper.validate(DistrictCode, record.get(DistrictCode), 33, true) + "0000000";
+                final District district = districts.computeIfAbsent(districtId, id -> districtBuilder
+                        .naturalId(id)
+                        .name(parserHelper.validate(DistrictName, record.get(DistrictName), 100, true))
+                        .build());
+
+                final String schoolId = parserHelper.validate(AuthCdsCode, record.get(AuthCdsCode), 40, true);
+                schools.computeIfAbsent(schoolId, id -> schoolBuilder
+                        .naturalId(id)
+                        .name(parserHelper.validate(SchoolName, record.get(SchoolName), 100, true))
+                        .district(district)
+                        .build());
+
+                ++count;
+            }
+            logger.info("parsed {} rows", count);
+
+        } catch (final IOException ioe) {
+            throw new IllegalArgumentException("invalid CALPADS schools payload", ioe);
+        }
+    }
+}

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
@@ -35,7 +35,7 @@ class CalpadsSchoolsParser implements OrganizationParser {
 //    private static final String CharterStatus = "Charter Status";
 //    private static final String NpsSchool = "NPS School";
 
-    private static final CSVFormat CalpadsCSVFormat = CSVFormat.RFC4180.withDelimiter('^').withFirstRecordAsHeader();
+    private static final CSVFormat CalpadsCSVFormat = CSVFormat.DEFAULT.withDelimiter('^').withFirstRecordAsHeader();
 
     @Override
     public Collection<School> parse(final byte[] payload, final ParserHelper parserHelper) {

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.util.Collection;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -36,14 +37,11 @@ class CalpadsSchoolsParser implements OrganizationParser {
 
     private static final CSVFormat CalpadsCSVFormat = CSVFormat.RFC4180.withDelimiter('^').withFirstRecordAsHeader();
 
-    private final Map<String, District> districts = newHashMap();
-    private final Map<String, School> schools = newHashMap();
+    @Override
+    public Collection<School> parse(final byte[] payload, final ParserHelper parserHelper) {
+        final Map<String, District> districts = newHashMap();
+        final Map<String, School> schools = newHashMap();
 
-    public Map<String, School> getSchools() {
-        return schools;
-    }
-
-    public void parse(final byte[] payload, final ParserHelper parserHelper) {
         try (final Reader reader = new InputStreamReader(new ByteArrayInputStream(payload), Charset.forName("utf8"))) {
             final District.Builder districtBuilder = District.builder();
             final School.Builder schoolBuilder = School.builder();
@@ -66,6 +64,7 @@ class CalpadsSchoolsParser implements OrganizationParser {
                 ++count;
             }
             logger.info("parsed {} rows", count);
+            return schools.values();
 
         } catch (final IOException ioe) {
             throw new IllegalArgumentException("invalid CALPADS schools payload", ioe);

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
@@ -40,16 +40,14 @@ class DefaultOrganizationProcessor implements OrganizationProcessor {
     @Override
     public void process(final byte[] payload, final long importId) throws ImportException {
         for (final OrganizationParser parser : parsers) {
-            final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
             try {
+                final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
                 final Collection<School> schools = parser.parse(payload, new ParserHelper(errorCollector));
                 if (!errorCollector.isEmpty()) {
                     throw new ImportException(BAD_DATA, errorCollector.toJson());
                 }
-                for (final School school : schools) {
-                    schoolRepository.upsert(school, importId);
-                }
-                logger.info("{} schools upserted", schools.size());
+                schoolRepository.upsert(schools, importId);
+                logger.info("upsert called for {} schools", schools.size());
                 return;
             } catch (final IllegalArgumentException iae) {
                 // expected, just loop

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
@@ -1,9 +1,5 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.opentestsystem.rdw.ingest.common.model.District;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.School;
 import org.opentestsystem.rdw.ingest.common.repository.SchoolRepository;
@@ -13,173 +9,53 @@ import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 
-import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Lists.newArrayList;
 import static org.opentestsystem.rdw.ingest.common.model.ImportStatus.BAD_DATA;
-import static org.springframework.util.StringUtils.hasText;
+import static org.opentestsystem.rdw.ingest.common.model.ImportStatus.BAD_FORMAT;
 
 /**
- * Process a payload with organization information.
- * <p>
- * The payload is expected to be concatenated json response from ART. The required data fields are:<ul>
- *     <li>entityType</li>
- *     <li>entityId</li>
- *     <li>entityName</li>
- *     <li>parentEntityId</li>
+ * Process a payload with organization information. It uses multiple parsers to handle different formats:<ul>
+ *     <li>JSON format similar to ART output</li>
+ *     <li>CALPADS schools CSV</li>
  * </ul>
- * The precise structure of the payload isn't critical but might look like this:<pre>
- * { "districts": PAYLOAD-FROM-ART,
- *   "groupsofschools": PAYLOAD-FROM-ART,
- *   "schools": PAYLOAD-FROM-ART
- * }
- * </pre>
- * Where each ART payload is a collection of entities, optionally in a search results wrapper.
- * For example, simple collection of districts:<pre>
-[
-    {
-        "id": "572d7630e4b0ed2c55c37e34",
-        "entityId": "DISTRICT9",
-        "entityName": "District 9 - Prawn Town",
-        "parentEntityId": "CA",
-        "nationwideIdentifier": null,
-        "entityType": "DISTRICT",
-    }, ...
-]
- * </pre>
- * And a list of schools wrapped in search results:<pre>
-{
-    "searchResults": [
-        {
-            "id": "57325fc6e4b0ed2c55c37e40",
-            "entityId": "DS9001",
-            "entityName": "District 9 Institution 1",
-            "parentEntityId": "DISTRICT9",
-            "stateAbbreviation": "CA",
-            "nationwideIdentifier": "NCESID001",
-            "entityType": "INSTITUTION",
-        }, ...
-    ],
-    "currentPage": 0,
-    "returnCount": 1000,
-    "pageSize": 1000,
-    "totalCount": 1800,
-    "nextPageUrl": "?pageSize=1000&currentPage=1"
-}
- * </pre>
- * </p>
  */
 @Service
 class DefaultOrganizationProcessor implements OrganizationProcessor {
     private static final Logger logger = LoggerFactory.getLogger(DefaultOrganizationProcessor.class);
 
     private final SchoolRepository schoolRepository;
+    private final List<OrganizationParser> parsers;
 
     @Autowired
     public DefaultOrganizationProcessor(final SchoolRepository schoolRepository) {
         this.schoolRepository = schoolRepository;
+        parsers = newArrayList(new JsonOrganizationParser(), new CalpadsSchoolsParser());
     }
 
     @Override
     public void process(final byte[] payload, final long importId) throws ImportException {
-        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
-
-        final OrgTreeParser parser = new OrgTreeParser(new ParserHelper(errorCollector));
-        parser.extractDistrictsAndSchools(payload);
-
-        if (!errorCollector.isEmpty()) {
-            throw new ImportException(BAD_DATA, errorCollector.toJson());
-        }
-
-        for (final School school : parser.getSchools().values()) {
-            schoolRepository.upsert(school, importId);
-        }
-        logger.info("{} schools upserted", parser.getSchools().size());
-    }
-
-    /**
-     * This parses the json document, extracting pertinent district, group, and institution info.
-     * It is as forgiving as possible wrt to the structure: it looks for json objects that have
-     * the required type, id, name, and parent id fields. It allows the order of the objects to
-     * be flexible (e.g. districts can come after schools).
-     */
-    static class OrgTreeParser {
-
-        private final ParserHelper parserHelper;
-        private final Map<String, District> districts = newHashMap();
-        private final Map<String, School> schools = newHashMap();
-        private final Map<String, String> groupToDistrict = newHashMap();
-        private final Map<String, String> schoolToParent = newHashMap();
-
-        OrgTreeParser(final ParserHelper parserHelper) {
-            this.parserHelper = parserHelper;
-        }
-
-        Map<String, School> getSchools() {
-            return schools;
-        }
-
-        void extractDistrictsAndSchools(final byte[] payload) {
-            districts.clear();
-            schools.clear();
-            groupToDistrict.clear();
-            schoolToParent.clear();
-
-            final JsonFactory factory = new JsonFactory();
-            final ObjectMapper mapper = new ObjectMapper(factory);
+        for (final OrganizationParser parser : parsers) {
+            final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
             try {
-                processNode(mapper.readTree(payload));
-                resolveSchoolParents();
-                logger.info("parsed {} schools, {} districts", schools.size(), districts.size());
-            } catch (final IOException e) {
-                throw new IllegalArgumentException("invalid organization payload", e);
-            }
-        }
-
-        private void processNode(final JsonNode node) {
-            if (node.isArray() || (node.isContainerNode() && !node.has("entityType"))) {
-                node.forEach(this::processNode);
-            } else if (node.isContainerNode() && node.has("entityType")) {
-                final String entityId = validateNodeText("entityId", node.get("entityId"), 40);
-                final String entityName = validateNodeText("entityName", node.get("entityName"), 100);
-                final String parentId = validateNodeText("parentEntityId", node.get("parentEntityId"), 40);
-                if (hasText(entityId) && hasText(entityName) && hasText(parentId)) {
-                    switch (node.get("entityType").asText().toUpperCase()) {
-                        case "DISTRICT":
-                            districts.put(entityId, District.builder().naturalId(entityId).name(entityName).stateCode(parentId).build());
-                            break;
-                        case "GROUPOFINSTITUTIONS":
-                            groupToDistrict.put(entityId, parentId);
-                            break;
-                        case "INSTITUTION":
-                            schools.put(entityId, School.builder().naturalId(entityId).name(entityName).build());
-                            schoolToParent.put(entityId, parentId);
-                            break;
-                        default:
-                            break;
-                    }
+                parser.parse(payload, new ParserHelper(errorCollector));
+                if (!errorCollector.isEmpty()) {
+                    throw new ImportException(BAD_DATA, errorCollector.toJson());
                 }
-            }
-        }
-
-        private String validateNodeText(final String name, final JsonNode node, final int maxLength) {
-            return parserHelper.validate(name, parserHelper.validate(name, node, JsonNode::asText), maxLength, true);
-        }
-
-        private void resolveSchoolParents() {
-            for (final School school : schools.values()) {
-                String parentId = schoolToParent.get(school.getNaturalId());
-                if (groupToDistrict.containsKey(parentId)) {
-                    parentId = groupToDistrict.get(parentId);
+                for (final School school : parser.getSchools().values()) {
+                    schoolRepository.upsert(school, importId);
                 }
-                school.setDistrict(parserHelper.validate(school.getNaturalId() + " district", parentId, value -> {
-                    if (!districts.containsKey(value)) throw new IllegalArgumentException("unknown district [" + value + "]");
-                    return districts.get(value);
-                }));
+                logger.info("{} schools upserted", parser.getSchools().size());
+                return;
+            } catch (final IllegalArgumentException iae) {
+                // expected, just loop
             }
         }
+        // if we get here, no parser could deal with the payload
+        throw new ImportException(BAD_FORMAT, "invalid organization payload format");
     }
 }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
@@ -9,9 +9,9 @@ import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -42,14 +42,14 @@ class DefaultOrganizationProcessor implements OrganizationProcessor {
         for (final OrganizationParser parser : parsers) {
             final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
             try {
-                parser.parse(payload, new ParserHelper(errorCollector));
+                final Collection<School> schools = parser.parse(payload, new ParserHelper(errorCollector));
                 if (!errorCollector.isEmpty()) {
                     throw new ImportException(BAD_DATA, errorCollector.toJson());
                 }
-                for (final School school : parser.getSchools().values()) {
+                for (final School school : schools) {
                     schoolRepository.upsert(school, importId);
                 }
-                logger.info("{} schools upserted", parser.getSchools().size());
+                logger.info("{} schools upserted", schools.size());
                 return;
             } catch (final IllegalArgumentException iae) {
                 // expected, just loop

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParser.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -20,6 +21,9 @@ import static org.springframework.util.StringUtils.hasText;
  * It is as forgiving as possible wrt to the structure: it looks for json objects that have
  * the required type, id, name, and parent id fields. It allows the order of the objects to
  * be flexible (e.g. districts can come after schools).
+ * <p>
+ * NOTE: this parse is not multi-thread safe!
+ * </p>
  * <p>
  * The payload is expected to be concatenated json response from ART. The required data fields are:<ul>
  *     <li>entityType</li>
@@ -71,17 +75,15 @@ import static org.springframework.util.StringUtils.hasText;
 class JsonOrganizationParser implements OrganizationParser {
     private static final Logger logger = LoggerFactory.getLogger(JsonOrganizationParser.class);
 
+    // NOTE: this state makes parse() completely NOT thread-safe
     private ParserHelper parserHelper;
     private final Map<String, District> districts = newHashMap();
     private final Map<String, School> schools = newHashMap();
     private final Map<String, String> groupToDistrict = newHashMap();
     private final Map<String, String> schoolToParent = newHashMap();
 
-    public Map<String, School> getSchools() {
-        return schools;
-    }
-
-    public void parse(final byte[] payload, final ParserHelper parserHelper) {
+    @Override
+    public Collection<School> parse(final byte[] payload, final ParserHelper parserHelper) {
         this.parserHelper = parserHelper;
         districts.clear();
         schools.clear();
@@ -94,6 +96,7 @@ class JsonOrganizationParser implements OrganizationParser {
             processNode(mapper.readTree(payload));
             resolveSchoolParents();
             logger.info("parsed {} schools, {} districts", schools.size(), districts.size());
+            return schools.values();
         } catch (final IOException e) {
             throw new IllegalArgumentException("invalid organization payload", e);
         }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParser.java
@@ -1,0 +1,144 @@
+package org.opentestsystem.rdw.ingest.processor.service.impl;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opentestsystem.rdw.ingest.common.model.District;
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * This parses the json document, extracting pertinent district, group, and institution info.
+ * It is as forgiving as possible wrt to the structure: it looks for json objects that have
+ * the required type, id, name, and parent id fields. It allows the order of the objects to
+ * be flexible (e.g. districts can come after schools).
+ * <p>
+ * The payload is expected to be concatenated json response from ART. The required data fields are:<ul>
+ *     <li>entityType</li>
+ *     <li>entityId</li>
+ *     <li>entityName</li>
+ *     <li>parentEntityId</li>
+ * </ul>
+ * The precise structure of the payload isn't critical but might look like this:<pre>
+ * { "districts": PAYLOAD-FROM-ART,
+ *   "groupsofschools": PAYLOAD-FROM-ART,
+ *   "schools": PAYLOAD-FROM-ART
+ * }
+ * </pre>
+ * Where each ART payload is a collection of entities, optionally in a search results wrapper.
+ * For example, simple collection of districts:<pre>
+ [
+ {
+ "id": "572d7630e4b0ed2c55c37e34",
+ "entityId": "DISTRICT9",
+ "entityName": "District 9 - Prawn Town",
+ "parentEntityId": "CA",
+ "nationwideIdentifier": null,
+ "entityType": "DISTRICT",
+ }, ...
+ ]
+ * </pre>
+ * And a list of schools wrapped in search results:<pre>
+ {
+ "searchResults": [
+ {
+ "id": "57325fc6e4b0ed2c55c37e40",
+ "entityId": "DS9001",
+ "entityName": "District 9 Institution 1",
+ "parentEntityId": "DISTRICT9",
+ "stateAbbreviation": "CA",
+ "nationwideIdentifier": "NCESID001",
+ "entityType": "INSTITUTION",
+ }, ...
+ ],
+ "currentPage": 0,
+ "returnCount": 1000,
+ "pageSize": 1000,
+ "totalCount": 1800,
+ "nextPageUrl": "?pageSize=1000&currentPage=1"
+ }
+ * </pre>
+ * </p>
+ */
+class JsonOrganizationParser implements OrganizationParser {
+    private static final Logger logger = LoggerFactory.getLogger(JsonOrganizationParser.class);
+
+    private ParserHelper parserHelper;
+    private final Map<String, District> districts = newHashMap();
+    private final Map<String, School> schools = newHashMap();
+    private final Map<String, String> groupToDistrict = newHashMap();
+    private final Map<String, String> schoolToParent = newHashMap();
+
+    public Map<String, School> getSchools() {
+        return schools;
+    }
+
+    public void parse(final byte[] payload, final ParserHelper parserHelper) {
+        this.parserHelper = parserHelper;
+        districts.clear();
+        schools.clear();
+        groupToDistrict.clear();
+        schoolToParent.clear();
+
+        final JsonFactory factory = new JsonFactory();
+        final ObjectMapper mapper = new ObjectMapper(factory);
+        try {
+            processNode(mapper.readTree(payload));
+            resolveSchoolParents();
+            logger.info("parsed {} schools, {} districts", schools.size(), districts.size());
+        } catch (final IOException e) {
+            throw new IllegalArgumentException("invalid organization payload", e);
+        }
+    }
+
+    private void processNode(final JsonNode node) {
+        if (node.isArray() || (node.isContainerNode() && !node.has("entityType"))) {
+            node.forEach(this::processNode);
+        } else if (node.isContainerNode() && node.has("entityType")) {
+            final String entityId = validateNodeText("entityId", node.get("entityId"), 40);
+            final String entityName = validateNodeText("entityName", node.get("entityName"), 100);
+            final String parentId = validateNodeText("parentEntityId", node.get("parentEntityId"), 40);
+            if (hasText(entityId) && hasText(entityName) && hasText(parentId)) {
+                switch (node.get("entityType").asText().toUpperCase()) {
+                    case "DISTRICT":
+                        districts.put(entityId, District.builder().naturalId(entityId).name(entityName).stateCode(parentId).build());
+                        break;
+                    case "GROUPOFINSTITUTIONS":
+                        groupToDistrict.put(entityId, parentId);
+                        break;
+                    case "INSTITUTION":
+                        schools.put(entityId, School.builder().naturalId(entityId).name(entityName).build());
+                        schoolToParent.put(entityId, parentId);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+
+    private String validateNodeText(final String name, final JsonNode node, final int maxLength) {
+        return parserHelper.validate(name, parserHelper.validate(name, node, JsonNode::asText), maxLength, true);
+    }
+
+    private void resolveSchoolParents() {
+        for (final School school : schools.values()) {
+            String parentId = schoolToParent.get(school.getNaturalId());
+            if (groupToDistrict.containsKey(parentId)) {
+                parentId = groupToDistrict.get(parentId);
+            }
+            school.setDistrict(parserHelper.validate(school.getNaturalId() + " district", parentId, value -> {
+                if (!districts.containsKey(value)) throw new IllegalArgumentException("unknown district [" + value + "]");
+                return districts.get(value);
+            }));
+        }
+    }
+}

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParser.java
@@ -1,10 +1,9 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 import org.opentestsystem.rdw.ingest.common.model.School;
-import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * Parses organization payloads; helper for DefaultOrganizationProcessor
@@ -19,9 +18,8 @@ public interface OrganizationParser {
      *
      * @param payload payload to parse
      * @param parserHelper parser helper
+     * @return extracted schools (with district refs set)
      * @throws IllegalArgumentException if payload is not parseable
      */
-    void parse(byte[] payload, ParserHelper parserHelper);
-
-    Map<String, School> getSchools();
+    Collection<School> parse(byte[] payload, ParserHelper parserHelper);
 }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParser.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.ingest.processor.service.impl;
+
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
+import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
+
+import java.util.Map;
+
+/**
+ * Parses organization payloads; helper for DefaultOrganizationProcessor
+ */
+public interface OrganizationParser {
+
+    /**
+     * Parse payload and extract schools and districts.<br/>
+     * This method should throw if the payload is unparseable. If the payload is parseable but has errors,
+     * let the parser helper populate the error collector and return without throwing. If the payload is
+     * parseable and good, return with throwing or populating the error collector.
+     *
+     * @param payload payload to parse
+     * @param parserHelper parser helper
+     * @throws IllegalArgumentException if payload is not parseable
+     */
+    void parse(byte[] payload, ParserHelper parserHelper);
+
+    Map<String, School> getSchools();
+}

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParserTest.java
@@ -7,7 +7,7 @@ import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,14 +18,12 @@ public class CalpadsSchoolsParserTest {
         final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/CA_schools.baddata.csv"));
         final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
         final CalpadsSchoolsParser parser = new CalpadsSchoolsParser();
-        parser.parse(payload, new ParserHelper(errorCollector));
+        final Collection<School> schools = parser.parse(payload, new ParserHelper(errorCollector));
 
+        assertThat(schools).hasSize(23);
         assertThat(errorCollector.size()).isEqualTo(3);
 
-        final Map<String, School> schools = parser.getSchools();
-        assertThat(schools).hasSize(23);
-
-        final School arcata = schools.get("12626796007678");
+        final School arcata = schools.stream().filter(school -> "12626796007678".equals(school.getNaturalId())).findFirst().get();
         assertThat(arcata.getName()).isEqualTo("Arcata Elementary");
         assertThat(arcata.getDistrict().getNaturalId()).isEqualTo("12626790000000");
         assertThat(arcata.getDistrict().getName()).isEqualTo("Arcata Elementary");

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParserTest.java
@@ -1,0 +1,49 @@
+package org.opentestsystem.rdw.ingest.processor.service.impl;
+
+import com.google.common.io.ByteStreams;
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
+import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CalpadsSchoolsParserTest {
+
+    @Test
+    public void testParser() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/CA_schools.baddata.csv"));
+        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+        final CalpadsSchoolsParser parser = new CalpadsSchoolsParser();
+        parser.parse(payload, new ParserHelper(errorCollector));
+
+        assertThat(errorCollector.size()).isEqualTo(3);
+
+        final Map<String, School> schools = parser.getSchools();
+        assertThat(schools).hasSize(23);
+
+        final School arcata = schools.get("12626796007678");
+        assertThat(arcata.getName()).isEqualTo("Arcata Elementary");
+        assertThat(arcata.getDistrict().getNaturalId()).isEqualTo("12626790000000");
+        assertThat(arcata.getDistrict().getName()).isEqualTo("Arcata Elementary");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowForUnknownFormatJson() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.json"));
+        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+        final CalpadsSchoolsParser parser = new CalpadsSchoolsParser();
+        parser.parse(payload, new ParserHelper(errorCollector));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowForUnknownFormatXml() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.xml"));
+        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+        final CalpadsSchoolsParser parser = new CalpadsSchoolsParser();
+        parser.parse(payload, new ParserHelper(errorCollector));
+    }
+}

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParserTest.java
@@ -8,7 +8,7 @@ import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,22 +19,18 @@ public class JsonOrganizationParserTest {
         final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.noparent.json"));
         final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
         final JsonOrganizationParser parser = new JsonOrganizationParser();
-        parser.parse(payload, new ParserHelper(errorCollector));
+        final Collection<School> schools = parser.parse(payload, new ParserHelper(errorCollector));
 
+        assertThat(schools).hasSize(5);
         assertThat(errorCollector.size()).isEqualTo(1);
 
-        final Map<String, School> schools = parser.getSchools();
-        assertThat(schools).hasSize(5);
-
-        final School ds9001 = schools.get("DS9001");
+        final School ds9001 = schools.stream().filter(school -> "DS9001".equals(school.getNaturalId())).findFirst().get();
         assertThat(ds9001.getName()).isEqualTo("District 9 Institution 1");
 
         final District district9 = ds9001.getDistrict();
         assertThat(district9.getNaturalId()).isEqualTo("DISTRICT9");
         assertThat(district9.getName()).isEqualTo("District 9 - Prawn Town");
         assertThat(district9.getStateCode()).isEqualTo("CA");
-
-        assertThat(schools.get("DS1111").getDistrict()).isNull();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParserTest.java
@@ -1,0 +1,56 @@
+package org.opentestsystem.rdw.ingest.processor.service.impl;
+
+import com.google.common.io.ByteStreams;
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.common.model.District;
+import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
+import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonOrganizationParserTest {
+
+    @Test
+    public void testOrgParser() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.noparent.json"));
+        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+        final JsonOrganizationParser parser = new JsonOrganizationParser();
+        parser.parse(payload, new ParserHelper(errorCollector));
+
+        assertThat(errorCollector.size()).isEqualTo(1);
+
+        final Map<String, School> schools = parser.getSchools();
+        assertThat(schools).hasSize(5);
+
+        final School ds9001 = schools.get("DS9001");
+        assertThat(ds9001.getName()).isEqualTo("District 9 Institution 1");
+
+        final District district9 = ds9001.getDistrict();
+        assertThat(district9.getNaturalId()).isEqualTo("DISTRICT9");
+        assertThat(district9.getName()).isEqualTo("District 9 - Prawn Town");
+        assertThat(district9.getStateCode()).isEqualTo("CA");
+
+        assertThat(schools.get("DS1111").getDistrict()).isNull();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowForUnknownFormatCsv() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/CA_schools.csv"));
+        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+        final JsonOrganizationParser parser = new JsonOrganizationParser();
+        parser.parse(payload, new ParserHelper(errorCollector));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldThrowForUnknownFormatXml() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.xml"));
+        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+        final JsonOrganizationParser parser = new JsonOrganizationParser();
+        parser.parse(payload, new ParserHelper(errorCollector));
+    }
+
+}

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParserTest.java
@@ -1,23 +1,34 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 import com.google.common.io.ByteStreams;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.School;
 import org.opentestsystem.rdw.ingest.common.repository.SchoolRepository;
 import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class OrganizationParserTest {
+
+    @Captor
+    private ArgumentCaptor<Collection<School>> schoolsCaptor;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     public void itShouldProcessJson() throws IOException {
@@ -27,7 +38,8 @@ public class OrganizationParserTest {
         final OrganizationProcessor processor = new DefaultOrganizationProcessor(schoolRepository);
 
         processor.process(payload, 1L);
-        verify(schoolRepository, times(5)).upsert(any(School.class), eq(1L));
+        verify(schoolRepository).upsert(schoolsCaptor.capture(), eq(1L));
+        assertThat(schoolsCaptor.getValue()).hasSize(5);
     }
 
     @Test
@@ -38,7 +50,8 @@ public class OrganizationParserTest {
         final OrganizationProcessor processor = new DefaultOrganizationProcessor(schoolRepository);
 
         processor.process(payload, 1L);
-        verify(schoolRepository, times(23)).upsert(any(School.class), eq(1L));
+        verify(schoolRepository).upsert(schoolsCaptor.capture(), eq(1L));
+        assertThat(schoolsCaptor.getValue()).hasSize(23);
     }
 
     @Test

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParserTest.java
@@ -2,17 +2,12 @@ package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 import com.google.common.io.ByteStreams;
 import org.junit.Test;
-import org.opentestsystem.rdw.ingest.common.model.District;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.School;
 import org.opentestsystem.rdw.ingest.common.repository.SchoolRepository;
-import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
-import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
-import org.opentestsystem.rdw.ingest.processor.service.impl.DefaultOrganizationProcessor.OrgTreeParser;
 
 import java.io.IOException;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -25,7 +20,7 @@ import static org.mockito.Mockito.verify;
 public class OrganizationParserTest {
 
     @Test
-    public void itShouldUpsertSchools() throws IOException {
+    public void itShouldProcessJson() throws IOException {
         final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.json"));
 
         final SchoolRepository schoolRepository = mock(SchoolRepository.class);
@@ -36,50 +31,53 @@ public class OrganizationParserTest {
     }
 
     @Test
-    public void itShouldFailForMissingParent() throws IOException {
+    public void itShouldProcessCalpads() throws IOException {
+        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/CA_schools.csv"));
+
+        final SchoolRepository schoolRepository = mock(SchoolRepository.class);
+        final OrganizationProcessor processor = new DefaultOrganizationProcessor(schoolRepository);
+
+        processor.process(payload, 1L);
+        verify(schoolRepository, times(23)).upsert(any(School.class), eq(1L));
+    }
+
+    @Test
+    public void itShouldFailToProcessUnknownFormat() throws IOException {
+        assertThat(processForImportException("/organization.xml"))
+                .isEqualTo("invalid organization payload format");
+    }
+
+    @Test
+    public void itShouldFailJsonForMissingParent() throws IOException {
         assertThat(processForImportException("/organization.noparent.json"))
                 .isEqualTo("{\"messages\":[{\"elementName\":\"DS1111 district\",\"value\":\"DoesNotExist\",\"error\":\"unknown district [DoesNotExist]\"}]}");
     }
 
     @Test
-    public void itShouldFailForLongId() throws IOException {
+    public void itShouldFailJsonForLongId() throws IOException {
         assertThat(processForImportException("/organization.idtoolong.json"))
                 .isEqualTo("{\"messages\":[{\"elementName\":\"entityId\",\"value\":\"AnIdThatIsMoreThan40CharactersWhichIsTheLimit\",\"error\":\"string is too long, max length is 40\"}]}");
     }
 
     @Test
-    public void itShouldFailForLongName() throws IOException {
+    public void itShouldFailJsonForLongName() throws IOException {
         assertThat(processForImportException("/organization.nametoolong.json"))
                 .isEqualTo("{\"messages\":[{\"elementName\":\"entityName\",\"value\":\"District 9 - Prawn Town - With A Suffix That Makes The Name At Least A Little Longer Than 100 Characters\",\"error\":\"string is too long, max length is 100\"}]}");
     }
 
     @Test
-    public void itShouldFailForMissingName() throws IOException {
+    public void itShouldFailJsonForMissingName() throws IOException {
         assertThat(processForImportException("/organization.noname.json"))
                 .isEqualTo("{\"messages\":[{\"elementName\":\"entityName\"},{\"elementName\":\"entityName\",\"error\":\"value may not be blank\"}]}");
     }
 
     @Test
-    public void testOrgParser() throws IOException {
-        final byte[] payload = ByteStreams.toByteArray(this.getClass().getResourceAsStream("/organization.noparent.json"));
-        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
-        final OrgTreeParser parser = new OrgTreeParser(new ParserHelper(errorCollector));
-        parser.extractDistrictsAndSchools(payload);
-
-        assertThat(errorCollector.size()).isEqualTo(1);
-
-        final Map<String, School> schools = parser.getSchools();
-        assertThat(schools).hasSize(5);
-
-        final School ds9001 = schools.get("DS9001");
-        assertThat(ds9001.getName()).isEqualTo("District 9 Institution 1");
-
-        final District district9 = ds9001.getDistrict();
-        assertThat(district9.getNaturalId()).isEqualTo("DISTRICT9");
-        assertThat(district9.getName()).isEqualTo("District 9 - Prawn Town");
-        assertThat(district9.getStateCode()).isEqualTo("CA");
-
-        assertThat(schools.get("DS1111").getDistrict()).isNull();
+    public void itShouldFailCalpadsWithErrors() throws IOException {
+        assertThat(processForImportException("/CA_schools.baddata.csv")).isEqualTo("{\"messages\":["+
+            "{\"elementName\":\"County-District Code\",\"value\":\"01000168901234567890123456789012345\",\"error\":\"string is too long, max length is 33\"},"+
+            "{\"elementName\":\"Auth CDS Code\",\"value\":\"0161259010006556789012345678901234567890123\",\"error\":\"string is too long, max length is 40\"},"+
+            "{\"elementName\":\"School Name\",\"value\":\"Lodge Pole Elementary (Alternative) with trailing text that makes the name much too long to be handled by our system\",\"error\":\"string is too long, max length is 100\"}"+
+            "]}");
     }
 
     private String processForImportException(final String resource) throws IOException {

--- a/package-processor/src/test/resources/CA_schools.baddata.csv
+++ b/package-processor/src/test/resources/CA_schools.baddata.csv
@@ -5,10 +5,13 @@ County-District Code^School Code^Auth CDS Code^County Name^District Name^School 
 0100123^0100123^01612590100123^Alameda^East Oakland Leadership Academy^East Oakland Leadership Academy^Y^DF^N
 0561580^6111884^05615806111884^Calaveras^Vallecito Union District modified to have a name that is so long it is considered to be bad data^Avery Middle^N^^N
 0610066^0610066^06100660610066^Colusa^Colusa County Office of Education School District^Colusa County Office of Education District Level Program^N^^N
+
 1075275^6112544^10752756112544^Fresno^Sierra Unified^Lodge Pole Elementary (Alternative) with trailing text that makes the name much too long to be handled by our system^N^^N
 1075408^1030253^10754081030253^Fresno^Riverdale Joint Unified^Horizon High^N^^N
+
 1262679^6007678^12626796007678^Humboldt^Arcata Elementary^Arcata Elementary^N^^N
 1262687^0107110^12626870107110^Humboldt^Northern Humboldt Union High^Six Rivers Charter High^Y^LF^N
+
 1964733^6061568^19647336061568^Los Angeles^Los Angeles Unified^Woodland Hills Academy^N^^N
 1964733^6061576^19647336061576^Los Angeles^Los Angeles Unified^Robert E. Peary Middle^N^^N
 1964733^6061584^19647336061584^Los Angeles^Los Angeles Unified^Gaspar De Portola Middle^N^^N

--- a/package-processor/src/test/resources/CA_schools.baddata.csv
+++ b/package-processor/src/test/resources/CA_schools.baddata.csv
@@ -1,0 +1,24 @@
+County-District Code^School Code^Auth CDS Code^County Name^District Name^School Name^Charter School^Charter Status^NPS School
+01000168901234567890123456789012345^0100016^20652430100016^Madera^Sherman Thomas Charter^Sherman Thomas Charter^Y^DF^N
+0100065^0100065^0161259010006556789012345678901234567890123^Alameda^Oakland Unity High^Oakland Unity High^Y^DF^N
+0100099^0100099^55723630100099^Tuolumne^California Virtual Academy @ Jamestown^California Virtual Academy @ Jamestown^Y^DF^N
+0100123^0100123^01612590100123^Alameda^East Oakland Leadership Academy^East Oakland Leadership Academy^Y^DF^N
+0561580^6111884^05615806111884^Calaveras^Vallecito Union District modified to have a name that is so long it is considered to be bad data^Avery Middle^N^^N
+0610066^0610066^06100660610066^Colusa^Colusa County Office of Education School District^Colusa County Office of Education District Level Program^N^^N
+1075275^6112544^10752756112544^Fresno^Sierra Unified^Lodge Pole Elementary (Alternative) with trailing text that makes the name much too long to be handled by our system^N^^N
+1075408^1030253^10754081030253^Fresno^Riverdale Joint Unified^Horizon High^N^^N
+1262679^6007678^12626796007678^Humboldt^Arcata Elementary^Arcata Elementary^N^^N
+1262687^0107110^12626870107110^Humboldt^Northern Humboldt Union High^Six Rivers Charter High^Y^LF^N
+1964733^6061568^19647336061568^Los Angeles^Los Angeles Unified^Woodland Hills Academy^N^^N
+1964733^6061576^19647336061576^Los Angeles^Los Angeles Unified^Robert E. Peary Middle^N^^N
+1964733^6061584^19647336061584^Los Angeles^Los Angeles Unified^Gaspar De Portola Middle^N^^N
+3768056^6120596^37680566120596^San Diego^Del Mar Union Elementary^Torrey Hills^N^^N
+3768056^6987960^37680566987960^San Diego^Del Mar Union Elementary^T.I.E.E. Site 1 - Children's Workshop (The Institute for Effective Education)^N^^Y
+3768080^3768080^37680803768080^San Diego^Encinitas Union Elementary School District^Encinitas Union Elementary District Level Program^N^^N
+3768080^6038145^37680806038145^San Diego^Encinitas Union Elementary^Paul Ecke-Central Elementary^N^^N
+3768080^6038152^37680806038152^San Diego^Encinitas Union Elementary^Ocean Knoll Elementary^N^^N
+6120893^6120893^37684036120893^San Diego^California Virtual Academy @ San Diego^California Virtual Academy @ San Diego^Y^DF^N
+6120901^6120901^37681896120901^San Diego^Barona Indian Charter^Barona Indian Charter^Y^DF^N
+6120935^6120935^37683386120935^San Diego^Albert Einstein Academy Charter Elementary^Albert Einstein Academy Charter Elementary^Y^DF^N
+6121081^6121081^19647336121081^Los Angeles^View Park Preparatory Accelerated Charter Middle^View Park Preparatory Accelerated Charter Middle^Y^DF^N
+7776422^7776422^77764227776422^^Out-of-State, Non-Public, Non-Sectarian School District^Out-of-State, Non-Public, Non-Sectarian District Level Program^N^^N

--- a/package-processor/src/test/resources/CA_schools.csv
+++ b/package-processor/src/test/resources/CA_schools.csv
@@ -1,0 +1,24 @@
+County-District Code^School Code^Auth CDS Code^County Name^District Name^School Name^Charter School^Charter Status^NPS School
+0100016^0100016^20652430100016^Madera^Sherman Thomas Charter^Sherman Thomas Charter^Y^DF^N
+0100065^0100065^01612590100065^Alameda^Oakland Unity High^Oakland Unity High^Y^DF^N
+0100099^0100099^55723630100099^Tuolumne^California Virtual Academy @ Jamestown^California Virtual Academy @ Jamestown^Y^DF^N
+0100123^0100123^01612590100123^Alameda^East Oakland Leadership Academy^East Oakland Leadership Academy^Y^DF^N
+0561580^6111884^05615806111884^Calaveras^Vallecito Union^Avery Middle^N^^N
+0610066^0610066^06100660610066^Colusa^Colusa County Office of Education School District^Colusa County Office of Education District Level Program^N^^N
+1075275^6112544^10752756112544^Fresno^Sierra Unified^Lodge Pole Elementary (Alternative)^N^^N
+1075408^1030253^10754081030253^Fresno^Riverdale Joint Unified^Horizon High^N^^N
+1262679^6007678^12626796007678^Humboldt^Arcata Elementary^Arcata Elementary^N^^N
+1262687^0107110^12626870107110^Humboldt^Northern Humboldt Union High^Six Rivers Charter High^Y^LF^N
+1964733^6061568^19647336061568^Los Angeles^Los Angeles Unified^Woodland Hills Academy^N^^N
+1964733^6061576^19647336061576^Los Angeles^Los Angeles Unified^Robert E. Peary Middle^N^^N
+1964733^6061584^19647336061584^Los Angeles^Los Angeles Unified^Gaspar De Portola Middle^N^^N
+3768056^6120596^37680566120596^San Diego^Del Mar Union Elementary^Torrey Hills^N^^N
+3768056^6987960^37680566987960^San Diego^Del Mar Union Elementary^T.I.E.E. Site 1 - Children's Workshop (The Institute for Effective Education)^N^^Y
+3768080^3768080^37680803768080^San Diego^Encinitas Union Elementary School District^Encinitas Union Elementary District Level Program^N^^N
+3768080^6038145^37680806038145^San Diego^Encinitas Union Elementary^Paul Ecke-Central Elementary^N^^N
+3768080^6038152^37680806038152^San Diego^Encinitas Union Elementary^Ocean Knoll Elementary^N^^N
+6120893^6120893^37684036120893^San Diego^California Virtual Academy @ San Diego^California Virtual Academy @ San Diego^Y^DF^N
+6120901^6120901^37681896120901^San Diego^Barona Indian Charter^Barona Indian Charter^Y^DF^N
+6120935^6120935^37683386120935^San Diego^Albert Einstein Academy Charter Elementary^Albert Einstein Academy Charter Elementary^Y^DF^N
+6121081^6121081^19647336121081^Los Angeles^View Park Preparatory Accelerated Charter Middle^View Park Preparatory Accelerated Charter Middle^Y^DF^N
+7776422^7776422^77764227776422^^Out-of-State, Non-Public, Non-Sectarian School District^Out-of-State, Non-Public, Non-Sectarian District Level Program^N^^N

--- a/package-processor/src/test/resources/organization.xml
+++ b/package-processor/src/test/resources/organization.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+  <!-- this is a test file that is in an unsupported format -->
+</root>


### PR DESCRIPTION
DWR-542 isn't actually the correct ticket for this but that one was under-estimated and we didn't know about this work ...

Since we no longer create stub school/district on TRT import, we needed to get the CA schools into the system. Otherwise all the ETS samples would be rejected as UNKNOWN_SCHOOL. ETS provided us a CALPADS drop so i added a parser for that.

I've updated the PR with performance improvements; they require the latest schema so i'll have another patch to bump the dependency once that is available.