### PR TITLE
add multiple senders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=0.0.1-SNAPSHOT`
 
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "0.0.1-21"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "0.0.1-25"
 String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "0.0.1-107"
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -86,6 +86,8 @@ services:
     image: fwsbac/rdw-ingest-task-service
     ports:
       - 8084:8008
+    volumes:
+      - /tmp:/tmp
     links:
       - config-server
       - import-service

--- a/task-service/build.gradle
+++ b/task-service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
     compile 'mysql:mysql-connector-java'
 
+    compile 'org.opentestsystem.rdw.common:rdw-common-archive'
     compile 'org.opentestsystem.rdw.common:rdw-common-status'
     compile project(':rdw-ingest-common')
 

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/ReconciliationReportConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/ReconciliationReportConfiguration.java
@@ -1,9 +1,13 @@
-package org.opentestsystem.rdw.ingest.tasking.task;
+package org.opentestsystem.rdw.ingest.tasking;
 
+import org.opentestsystem.rdw.archive.ArchiveServiceFactory;
+import org.opentestsystem.rdw.archive.LocalArchiveService;
+import org.opentestsystem.rdw.archive.S3ArchiveService;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.tasking.repository.ReportRepository;
 import org.opentestsystem.rdw.ingest.tasking.service.ReconciliationService;
 import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
+import org.opentestsystem.rdw.ingest.tasking.service.impl.ArchiveReportSender;
 import org.opentestsystem.rdw.ingest.tasking.service.impl.DefaultReconciliationService;
 import org.opentestsystem.rdw.ingest.tasking.service.impl.FtpReportSender;
 import org.opentestsystem.rdw.ingest.tasking.service.impl.LoggingReportSender;
@@ -17,6 +21,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
 /**
  * Configuration and implementation for reconciliation report task.<br/>
  * The goal is to avoid creating the scheduled bean and any of its helpers if the system
@@ -25,23 +33,26 @@ import org.springframework.scheduling.annotation.Scheduled;
  *     <li>task.send-reconciliation-report.cron</li>
  *     <li>task.send-reconciliation-report.query</li>
  * </ul>
- * To enable FTP, the following properties must be defined:<ul>
- *     <li>task.send-reconciliation-report.ftp-sender.server</li>
- *     <li>task.send-reconciliation-report.ftp-sender.username</li>
- *     <li>task.send-reconciliation-report.ftp-sender.password</li>
+ * One or more senders should be configured under task.send-reconciliation-report.senders.
+ * For example, to enable FTP, the following properties must be defined:<ul>
+ *     <li>type:ftp</li>
+ *     <li>server</li>
+ *     <li>username</li>
+ *     <li>password</li>
  * </ul>
  * To properly disable this task, remove task.send-reconciliation-report.
  */
 @Configuration
 @ConditionalOnProperty(prefix = "task.send-reconciliation-report", name = { "cron", "query" })
 public class ReconciliationReportConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(ReconciliationReportConfiguration.class);
 
     @Bean
     public ReconciliationReportTask reconciliationReportTask(
             final ReconciliationService reconciliationService,
-            final ReportSender reportSender,
+            final List<ReportSender> reportSenders,
             @Value("${task.send-reconciliation-report.query}") final String query) {
-        return new ReconciliationReportTask(reconciliationService, reportSender, RdwImportQuery.builder().params(query).build());
+        return new ReconciliationReportTask(reconciliationService, reportSenders, RdwImportQuery.builder().params(query).build());
     }
 
     @Bean
@@ -50,30 +61,59 @@ public class ReconciliationReportConfiguration {
     }
 
     /**
-     * There needs to be exactly one {@link ReportSender} depending on the configuration.
-     * Instead of mucking about with @ConditionalXxx annotations, just get the properties
-     * directly, and instantiate the appropriate sender.
+     * This configuration can have multiple {@link ReportSender}'s. To support the polymorphism of
+     * report senders while keeping the yml readable, this factory parses the senders' properties
+     * and instantiates the appropriate objects.
      *
      * @param env environment
-     * @return report sender
+     * @return list of report senders
      */
     @Bean
-    public ReportSender reportSender(final Environment env) {
-        if (env.containsProperty("task.send-reconciliation-report.ftp-sender.server")) {
-            return new FtpReportSender(
-                    env.getRequiredProperty("task.send-reconciliation-report.ftp-sender.server"),
-                    env.getRequiredProperty("task.send-reconciliation-report.ftp-sender.username"),
-                    env.getRequiredProperty("task.send-reconciliation-report.ftp-sender.password")
-            );
-        } else {
-            return new LoggingReportSender();
+    public List<ReportSender> reportSender(final Environment env) {
+        final List<ReportSender> senders = newArrayList();
+        for (int i = 0; ; ++i) {
+            final String senderPrefix = "task.send-reconciliation-report.senders["+i+"].";
+            final String type = env.getProperty(senderPrefix + "type");
+            if (type == null) break;
+
+            switch (type.toLowerCase()) {
+                case "archive": {
+                    final String root = env.getRequiredProperty(senderPrefix + "root");
+                    try {
+                        senders.add(new ArchiveReportSender(ArchiveServiceFactory.newInstance(root)));
+                    } catch (final IllegalArgumentException e) {
+                        logger.info("Ignoring archive report sender with unknown root [{}]", root);
+                    }
+                    break;
+                }
+
+                case "ftp": {
+                    senders.add(new FtpReportSender(env.getRequiredProperty(senderPrefix + "server"),
+                            env.getRequiredProperty(senderPrefix + "username"),
+                            env.getRequiredProperty(senderPrefix + "password")));
+                    break;
+                }
+
+                case "log":
+                case "logging": {
+                    senders.add(new LoggingReportSender());
+                    break;
+                }
+
+                default: {
+                    logger.info("Ignoring unknown report sender type [{}]", type);
+                    break;
+                }
+
+            }
         }
+        return senders;
     }
 
     @Bean
     public ReconciliationReportStatusIndicator reconciliationReportStatusIndicator(final ReportRepository reportRepository,
-                                                                                   final ReportSender reportSender) {
-        return new ReconciliationReportStatusIndicator(reportRepository, reportSender);
+                                                                                   final List<ReportSender> reportSenders) {
+        return new ReconciliationReportStatusIndicator(reportRepository, reportSenders);
     }
 
 
@@ -81,14 +121,14 @@ public class ReconciliationReportConfiguration {
         private static final Logger logger = LoggerFactory.getLogger(ReconciliationReportTask.class);
 
         private final ReconciliationService reconciliationService;
-        private final ReportSender sender;
+        private final List<ReportSender> senders;
         private final RdwImportQuery query;
 
         ReconciliationReportTask(final ReconciliationService reconciliationService,
-                                 final ReportSender sender,
+                                 final List<ReportSender> senders,
                                  final RdwImportQuery query) {
             this.reconciliationService = reconciliationService;
-            this.sender = sender;
+            this.senders = senders;
             this.query = query;
         }
 
@@ -96,7 +136,7 @@ public class ReconciliationReportConfiguration {
         public void sendReconciliationReport() {
             logger.info("Scheduled task triggered: Send Reconciliation Report");
             try {
-                reconciliationService.sendReport(query, sender);
+                reconciliationService.sendReport(query, senders);
                 logger.debug("Scheduled task completed: Send Reconciliation Report");
             } catch (final Exception e) {
                 logger.warn("Error sending reconciliation report", e);

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/UpdateOrganizationsConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/UpdateOrganizationsConfiguration.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.ingest.tasking.task;
+package org.opentestsystem.rdw.ingest.tasking;
 
 import org.opentestsystem.rdw.ingest.tasking.repository.ArtClient;
 import org.opentestsystem.rdw.ingest.tasking.repository.ArtClientProperties;

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/ArtClient.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/ArtClient.java
@@ -2,7 +2,7 @@ package org.opentestsystem.rdw.ingest.tasking.repository;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.opentestsystem.rdw.ingest.tasking.task.UpdateOrganizationsConfiguration;
+import org.opentestsystem.rdw.ingest.tasking.UpdateOrganizationsConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/ReconciliationService.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/ReconciliationService.java
@@ -8,8 +8,8 @@ public interface ReconciliationService {
      * Generate a reconciliation report for the given query and send it using the sender.
      *
      * @param query non-empty query for imports
-     * @param sender report sender
+     * @param senders report senders
      * @throws RuntimeException if any problems
      */
-    void sendReport(RdwImportQuery query, ReportSender sender);
+    void sendReport(RdwImportQuery query, Iterable<ReportSender> senders);
 }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/ReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/ReportSender.java
@@ -16,6 +16,11 @@ public interface ReportSender {
     void sendReport(InputStream is, String filename);
 
     /**
+     * @return report sender label
+     */
+    String getLabel();
+
+    /**
      * @return true if sender is available, false otherwise
      */
     boolean isAvailable();

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/ReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/ReportSender.java
@@ -16,11 +16,6 @@ public interface ReportSender {
     void sendReport(InputStream is, String filename);
 
     /**
-     * @return report sender label
-     */
-    String getLabel();
-
-    /**
      * @return true if sender is available, false otherwise
      */
     boolean isAvailable();

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ArchiveReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ArchiveReportSender.java
@@ -1,0 +1,44 @@
+package org.opentestsystem.rdw.ingest.tasking.service.impl;
+
+import org.opentestsystem.rdw.archive.ArchiveService;
+import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * A ReportSender that uses the common archive service.
+ */
+public class ArchiveReportSender implements ReportSender {
+    private static final Logger logger = LoggerFactory.getLogger(ArchiveReportSender.class);
+
+    private static final String LocationPrefix = "REPORT" + File.pathSeparator;
+    private final ArchiveService archiveService;
+
+    public ArchiveReportSender(final ArchiveService archiveService) {
+        this.archiveService = archiveService;
+    }
+
+    @Override
+    public void sendReport(final InputStream is, final String filename) {
+        archiveService.writeResource(LocationPrefix + filename, is, null);
+    }
+
+    @Override
+    public String getLabel() {
+        return "archive";
+    }
+
+    @Override
+    public boolean isAvailable() {
+        try {
+            archiveService.writeResource(LocationPrefix + "status", "status check".getBytes(), null);
+            return true;
+        } catch (final Exception e) {
+            logger.warn("failed status check", e);
+            return false;
+        }
+    }
+}

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ArchiveReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ArchiveReportSender.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.tasking.service.impl;
 
 import org.opentestsystem.rdw.archive.ArchiveService;
+import org.opentestsystem.rdw.archive.S3ArchiveService;
 import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,11 +28,6 @@ public class ArchiveReportSender implements ReportSender {
     }
 
     @Override
-    public String getLabel() {
-        return "archive";
-    }
-
-    @Override
     public boolean isAvailable() {
         try {
             archiveService.writeResource(LocationPrefix + "status", "status check".getBytes(), null);
@@ -40,5 +36,12 @@ public class ArchiveReportSender implements ReportSender {
             logger.warn("failed status check", e);
             return false;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ArchiveReportSender{" +
+                "archiveService=" + (archiveService instanceof S3ArchiveService ? "S3" : "local") +
+                '}';
     }
 }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ArchiveReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ArchiveReportSender.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 public class ArchiveReportSender implements ReportSender {
     private static final Logger logger = LoggerFactory.getLogger(ArchiveReportSender.class);
 
-    private static final String LocationPrefix = "REPORT" + File.pathSeparator;
+    private static final String LocationPrefix = "REPORT" + File.separator;
     private final ArchiveService archiveService;
 
     public ArchiveReportSender(final ArchiveService archiveService) {

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
@@ -4,7 +4,7 @@ import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.tasking.repository.ReportRepository;
 import org.opentestsystem.rdw.ingest.tasking.service.ReconciliationService;
 import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
-import org.opentestsystem.rdw.ingest.tasking.task.ReconciliationReportConfiguration;
+import org.opentestsystem.rdw.ingest.tasking.ReconciliationReportConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ public class DefaultReconciliationService implements ReconciliationService {
     }
 
     @Override
-    public void sendReport(final RdwImportQuery query, final ReportSender sender) {
+    public void sendReport(final RdwImportQuery query, final Iterable<ReportSender> senders) {
         // because it is a configuration option (and not user input), assume query is set properly
         checkArgument(!query.isEmpty(), "Report query must not be empty");
 
@@ -61,13 +61,14 @@ public class DefaultReconciliationService implements ReconciliationService {
         }
 
         // send the report file
-        try (final FileInputStream fis = new FileInputStream(file.toFile())) {
-            sender.sendReport(fis, file.getFileName().toString());
-        } catch (final IOException e) {
-            throw new RuntimeException("Failed to send reconciliation report", e);
-        } finally {
-            cleanupReportFile(file);
+        for (final ReportSender sender : senders) {
+            try (final FileInputStream fis = new FileInputStream(file.toFile())) {
+                sender.sendReport(fis, file.getFileName().toString());
+            } catch (final Exception e) {
+                logger.warn("Failed to send reconciliation report to {}: {}", sender.getLabel(), e.getMessage());
+            }
         }
+        cleanupReportFile(file);
     }
 
     /**

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
@@ -65,7 +65,7 @@ public class DefaultReconciliationService implements ReconciliationService {
             try (final FileInputStream fis = new FileInputStream(file.toFile())) {
                 sender.sendReport(fis, file.getFileName().toString());
             } catch (final Exception e) {
-                logger.warn("Failed to send reconciliation report to {}: {}", sender.getLabel(), e.getMessage());
+                logger.warn("Failed to send reconciliation report to {}: {}", sender.toString(), e.getMessage());
             }
         }
         cleanupReportFile(file);

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultUpdateOrganizationsService.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultUpdateOrganizationsService.java
@@ -4,7 +4,7 @@ import com.google.common.primitives.Bytes;
 import org.opentestsystem.rdw.ingest.tasking.repository.OrganizationRepository;
 import org.opentestsystem.rdw.ingest.tasking.service.ImportServiceClient;
 import org.opentestsystem.rdw.ingest.tasking.service.UpdateOrganizationsService;
-import org.opentestsystem.rdw.ingest.tasking.task.UpdateOrganizationsConfiguration;
+import org.opentestsystem.rdw.ingest.tasking.UpdateOrganizationsConfiguration;
 
 import java.nio.charset.Charset;
 

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/FtpReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/FtpReportSender.java
@@ -46,11 +46,6 @@ public class FtpReportSender implements ReportSender {
     }
 
     @Override
-    public String getLabel() {
-        return "ftp " + server;
-    }
-
-    @Override
     public boolean isAvailable() {
         try {
             ftpClient.connect(server);
@@ -63,5 +58,12 @@ public class FtpReportSender implements ReportSender {
             logger.warn("Error checking connection", e);
             return false;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "FtpReportSender{" +
+                "server='" + server + '\'' +
+                '}';
     }
 }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/FtpReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/FtpReportSender.java
@@ -46,6 +46,11 @@ public class FtpReportSender implements ReportSender {
     }
 
     @Override
+    public String getLabel() {
+        return "ftp " + server;
+    }
+
+    @Override
     public boolean isAvailable() {
         try {
             ftpClient.connect(server);

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/LoggingReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/LoggingReportSender.java
@@ -21,7 +21,7 @@ public class LoggingReportSender implements ReportSender {
         try (final CountingInputStream cis = new CountingInputStream(is)) {
             final byte[] buffer = new byte[4096];
             while (-1 != cis.read(buffer)) ;
-            logger.info("**** DEV ONLY Fake Report Sender **** >> sent report {} ({} bytes)", filename, cis.getCount());
+            logger.info("Report {} ({} bytes)", filename, cis.getCount());
         } catch (final IOException e) {
             logger.warn("Error reading report", e);
         }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/LoggingReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/LoggingReportSender.java
@@ -28,6 +28,11 @@ public class LoggingReportSender implements ReportSender {
     }
 
     @Override
+    public String getLabel() {
+        return "log";
+    }
+
+    @Override
     public boolean isAvailable() {
         return true;
     }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/LoggingReportSender.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/LoggingReportSender.java
@@ -28,12 +28,12 @@ public class LoggingReportSender implements ReportSender {
     }
 
     @Override
-    public String getLabel() {
-        return "log";
+    public boolean isAvailable() {
+        return true;
     }
 
     @Override
-    public boolean isAvailable() {
-        return true;
+    public String toString() {
+        return "LoggingReportSender{}";
     }
 }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/RestImportServiceClient.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/RestImportServiceClient.java
@@ -4,7 +4,7 @@ import org.opentestsystem.rdw.common.status.Rating;
 import org.opentestsystem.rdw.common.status.UnitStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.tasking.service.ImportServiceClient;
-import org.opentestsystem.rdw.ingest.tasking.task.UpdateOrganizationsConfiguration;
+import org.opentestsystem.rdw.ingest.tasking.UpdateOrganizationsConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/status/ReconciliationReportStatusIndicator.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/status/ReconciliationReportStatusIndicator.java
@@ -9,7 +9,7 @@ import org.opentestsystem.rdw.common.status.UnitStatus;
 import org.opentestsystem.rdw.ingest.tasking.repository.ReportRepository;
 import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 
@@ -22,12 +22,12 @@ import static com.google.common.collect.Lists.newArrayList;
 public class ReconciliationReportStatusIndicator extends AbstractStatusIndicator {
 
     private final ReportRepository reportRepository;
-    private final ReportSender reportSender;
+    private final List<ReportSender> reportSenders;
 
     public ReconciliationReportStatusIndicator(final ReportRepository reportRepository,
-                                               final ReportSender reportSender) {
+                                               final List<ReportSender> reportSenders) {
         this.reportRepository = reportRepository;
-        this.reportSender = reportSender;
+        this.reportSenders = reportSenders;
     }
 
     @Override
@@ -42,15 +42,16 @@ public class ReconciliationReportStatusIndicator extends AbstractStatusIndicator
 
     @Override
     protected void doStatusCheck(final Status.Builder builder, final int level) {
-        final ArrayList<UnitStatus> unitStatuses = newArrayList(
-                getMailSenderStatus(),
-                getReportRepositoryStatus());
+        final List<UnitStatus> unitStatuses = newArrayList(getReportRepositoryStatus());
+        for (final ReportSender reportSender : reportSenders) {
+            unitStatuses.add(getMailSenderStatus(reportSender));
+        }
         builder.detail("providers", unitStatuses);
         builder.worstRating(unitStatuses);
     }
 
-    private UnitStatus getMailSenderStatus() {
-        return UnitStatus.builder().unit("report-sender")
+    private UnitStatus getMailSenderStatus(final ReportSender reportSender) {
+        return UnitStatus.builder().unit("report-sender " + reportSender.getLabel())
                 .rating(reportSender.isAvailable() ? Rating.Ideal : Rating.Failed)
                 .build();
     }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/status/ReconciliationReportStatusIndicator.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/status/ReconciliationReportStatusIndicator.java
@@ -51,7 +51,7 @@ public class ReconciliationReportStatusIndicator extends AbstractStatusIndicator
     }
 
     private UnitStatus getMailSenderStatus(final ReportSender reportSender) {
-        return UnitStatus.builder().unit("report-sender " + reportSender.getLabel())
+        return UnitStatus.builder().unit("report-sender " + reportSender.toString())
                 .rating(reportSender.isAvailable() ? Rating.Ideal : Rating.Failed)
                 .build();
     }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/status/UpdateOrganizationsStatusIndicator.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/status/UpdateOrganizationsStatusIndicator.java
@@ -8,7 +8,7 @@ import org.opentestsystem.rdw.common.status.StatusIndicator;
 import org.opentestsystem.rdw.common.status.UnitStatus;
 import org.opentestsystem.rdw.ingest.tasking.repository.OrganizationRepository;
 import org.opentestsystem.rdw.ingest.tasking.service.ImportServiceClient;
-import org.opentestsystem.rdw.ingest.tasking.task.UpdateOrganizationsConfiguration;
+import org.opentestsystem.rdw.ingest.tasking.UpdateOrganizationsConfiguration;
 
 import java.util.ArrayList;
 

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -6,9 +6,19 @@ management:
 server:
   port: 8008
 
+# there needs to be a default aws region configured
+cloud:
+  aws:
+    region:
+      auto: false
+      static: us-west-2
+    # disable CloudFormation stuff
+    stack:
+      auto: false
+    credentials:
+      instance-profile: false
+
 spring:
-  mail:
-    host: local
   datasource:
     url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
     username: root
@@ -26,10 +36,14 @@ task:
 #  send-reconciliation-report:
 #    cron: 0 0 14 * * *
 #    query: status=PROCESSED&after=-PT24H
-#    ftp-sender:
-#      server:
-#      username:
-#      password:
+#    senders:
+#      - type: ftp
+#        server:
+#        username:
+#        password:
+#      - type: log
+#      - type: archive
+#        root: file:///tmp/
   # by default, this task is disabled for local dev environment; uncomment and set secrets/hosts to test
 #  update-organizations:
 #    cron: 0 0 4 * * *

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/ReconciliationReportConfigurationIT.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/ReconciliationReportConfigurationIT.java
@@ -1,0 +1,43 @@
+package org.opentestsystem.rdw.ingest.tasking;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
+import org.opentestsystem.rdw.ingest.tasking.service.impl.ArchiveReportSender;
+import org.opentestsystem.rdw.ingest.tasking.service.impl.FtpReportSender;
+import org.opentestsystem.rdw.ingest.tasking.service.impl.LoggingReportSender;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Import(ReconciliationReportConfiguration.class)
+@ActiveProfiles("report")
+public class ReconciliationReportConfigurationIT {
+
+    @Autowired
+    private ReconciliationReportConfiguration.ReconciliationReportTask task;
+
+    @Autowired
+    private List<ReportSender> reportSenders;
+
+    @Test
+    public void itShouldInstantiateAReconciliationReportTask() {
+        assertThat(task).isNotNull();
+    }
+
+    @Test
+    public void itShouldInstantiateReportSenders() {
+        assertThat(reportSenders).hasSize(3);
+        assertThat(reportSenders.get(0)).isInstanceOf(LoggingReportSender.class);
+        assertThat(reportSenders.get(1)).isInstanceOf(FtpReportSender.class);
+        assertThat(reportSenders.get(2)).isInstanceOf(ArchiveReportSender.class);
+    }
+}

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ReconciliationServiceTest.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ReconciliationServiceTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -51,7 +52,7 @@ public class ReconciliationServiceTest {
             return null;
         }).when(sender).sendReport(any(InputStream.class), anyString());
 
-        reconciliationService.sendReport(query, sender);
+        reconciliationService.sendReport(query, newArrayList(sender));
         verify(sender).sendReport(any(InputStream.class), anyString());
     }
 
@@ -60,28 +61,30 @@ public class ReconciliationServiceTest {
         when(reportRepository.countExamImports(any(RdwImportQuery.class))).thenReturn(0L);
         final ReportSender sender = mock(ReportSender.class);
 
-        reconciliationService.sendReport(query, sender);
+        reconciliationService.sendReport(query, newArrayList(sender));
         verify(reportRepository).countExamImports(any(RdwImportQuery.class));
         verifyZeroInteractions(sender);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void itRequiresANonEmptyQuery() {
-        reconciliationService.sendReport(RdwImportQuery.builder().build(), mock(ReportSender.class));
+        reconciliationService.sendReport(RdwImportQuery.builder().build(), newArrayList(mock(ReportSender.class)));
     }
 
     @Test(expected = RuntimeException.class)
     public void itShouldPropagateRepositoryIOException() {
         doThrow(IOException.class).when(reportRepository).writeReconciliationReport(any(RdwImportQuery.class), any(OutputStream.class));
         final ReportSender sender = mock(ReportSender.class);
-        reconciliationService.sendReport(query, sender);
+        reconciliationService.sendReport(query, newArrayList(sender));
         verifyZeroInteractions(sender);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void itShouldPropagateSenderIOException() {
-        final ReportSender sender = mock(ReportSender.class);
-        doThrow(IOException.class).when(sender).sendReport(any(InputStream.class), anyString());
-        reconciliationService.sendReport(query, sender);
+    @Test
+    public void itShouldIgnoreIndividualSenderExceptions() {
+        final ReportSender sender1 = mock(ReportSender.class);
+        final ReportSender sender2 = mock(ReportSender.class);
+        doThrow(IOException.class).when(sender1).sendReport(any(InputStream.class), anyString());
+        reconciliationService.sendReport(query, newArrayList(sender1, sender2));
+        verify(sender2).sendReport(any(InputStream.class), anyString());
     }
 }

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/status/ReconciliationReportStatusIndicatorTest.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/status/ReconciliationReportStatusIndicatorTest.java
@@ -10,6 +10,7 @@ import org.opentestsystem.rdw.ingest.tasking.service.ReportSender;
 
 import java.util.List;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,7 +26,7 @@ public class ReconciliationReportStatusIndicatorTest {
         reportRepository = mock(ReportRepository.class);
         reportSender = mock(ReportSender.class);
 
-        statusIndicator = new ReconciliationReportStatusIndicator(reportRepository, reportSender);
+        statusIndicator = new ReconciliationReportStatusIndicator(reportRepository, newArrayList(reportSender));
     }
 
     @Test

--- a/task-service/src/test/resources/application-report.yml
+++ b/task-service/src/test/resources/application-report.yml
@@ -1,0 +1,12 @@
+task:
+  send-reconciliation-report:
+    cron: 0 0 14 * * *
+    query: status=PROCESSED&after=-PT24H
+    senders:
+      - type: log
+      - type: ftp
+        server: localhost
+        username: test
+        password: pswd
+      - type: archive
+        root: file:///tmp/


### PR DESCRIPTION
The idea is to have multiple senders for a single reconciliation report. This allows the report to be sent to ETS via FTP and to SB Ops via S3 archive.