### PR TITLE
add import message on success

### DIFF
--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfiguration.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfiguration.java
@@ -37,17 +37,17 @@ public class PackageProcessorConfiguration {
 
 
     @ServiceActivator(inputChannel = ImportPayloadSink.CODES_INPUT)
-    void processCodes(final Message<?> message) {
+    public void processCodes(final Message<?> message) {
         handleIncomingMessage(message, accommodationsProcessor);
     }
 
     @ServiceActivator(inputChannel = ImportPayloadSink.ORGANIZATION_INPUT)
-    void processOrganization(final Message<?> message) {
+    public void processOrganization(final Message<?> message) {
         handleIncomingMessage(message, organizationProcessor);
     }
 
     @ServiceActivator(inputChannel = ImportPayloadSink.PACKAGE_INPUT)
-    void processPackage(final Message<?> message) {
+    public void processPackage(final Message<?> message) {
         handleIncomingMessage(message, packageProcessor);
     }
 

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfiguration.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfiguration.java
@@ -5,6 +5,7 @@ import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.repository.ImportRepository;
 import org.opentestsystem.rdw.ingest.processor.service.AccommodationsProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.AssessmentPackageProcessor;
+import org.opentestsystem.rdw.ingest.processor.service.ImportPayloadProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.slf4j.Logger;
@@ -13,8 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
-
-import java.util.function.ObjLongConsumer;
 
 @EnableBinding(ImportPayloadSink.class)
 public class PackageProcessorConfiguration {
@@ -38,29 +37,29 @@ public class PackageProcessorConfiguration {
 
 
     @ServiceActivator(inputChannel = ImportPayloadSink.CODES_INPUT)
-    public void processCodes(final Message<?> message) {
-        handleIncomingMessage(message, (payload, importId) -> accommodationsProcessor.process(payload));
+    void processCodes(final Message<?> message) {
+        handleIncomingMessage(message, accommodationsProcessor);
     }
 
     @ServiceActivator(inputChannel = ImportPayloadSink.ORGANIZATION_INPUT)
-    public void processOrganization(final Message<?> message) {
-        handleIncomingMessage(message, organizationProcessor::process);
+    void processOrganization(final Message<?> message) {
+        handleIncomingMessage(message, organizationProcessor);
     }
 
     @ServiceActivator(inputChannel = ImportPayloadSink.PACKAGE_INPUT)
-    public void processPackage(final Message<?> message) {
-        handleIncomingMessage(message, packageProcessor::process);
+    void processPackage(final Message<?> message) {
+        handleIncomingMessage(message, packageProcessor);
     }
 
-    private void handleIncomingMessage(final Message<?> message, final ObjLongConsumer<byte[]> processor) {
+    private void handleIncomingMessage(final Message<?> message, final ImportPayloadProcessor processor) {
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
         final byte[] payload = (byte[]) message.getPayload();
         final long importId = accessor.getImportId();
 
         logger.info("received " + accessor.getContent());
         try {
-            processor.accept(payload, importId);
-            importRepository.updateStatusAndMessageById(importId, ImportStatus.PROCESSED, null);
+            final String msg = processor.process(payload, importId);
+            importRepository.updateStatusAndMessageById(importId, ImportStatus.PROCESSED, msg);
         } catch (final ImportException ie) {
             logger.error("failed with an import error: " + ie);
             importRepository.updateStatusAndMessageById(importId, ie.getStatus(), ie.getMessage());

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/AccommodationsProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/AccommodationsProcessor.java
@@ -4,12 +4,8 @@ import org.opentestsystem.rdw.ingest.common.model.ImportException;
 
 /**
  * CodesPackageProcessor - Processes an Accessibility/Accommodations Configuration file for importing codes
- * and translations to data warehouse
+ * and translations to data warehouse.
+ * Payload spec: https://github.com/SmarterApp/AccessibilityAccommodationConfigurations
  */
-public interface AccommodationsProcessor {
-    /**
-     * @param accessibilityConfig An Accessibility Config File as referenced at https://github.com/SmarterApp/AccessibilityAccommodationConfigurations
-     * @throws ImportException
-     */
-    void process(final byte[] accessibilityConfig) throws ImportException;
+public interface AccommodationsProcessor extends ImportPayloadProcessor {
 }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/ImportPayloadProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/ImportPayloadProcessor.java
@@ -10,7 +10,8 @@ public interface ImportPayloadProcessor {
     /**
      * @param payload the payload to process
      * @param importId id of the import
+     * @return process message, included in import record
      * @throws ImportException if any errors during processing
      */
-    void process(byte[] payload, long importId) throws ImportException;
+    String process(byte[] payload, long importId) throws ImportException;
 }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAccommodationsProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAccommodationsProcessor.java
@@ -44,17 +44,17 @@ import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.checkNotBla
  * DefaultAccessibilityProcessor
  */
 @Service
-public class DefaultAccommodationsProcessor implements AccommodationsProcessor {
+class DefaultAccommodationsProcessor implements AccommodationsProcessor {
     private static final Logger logger = LoggerFactory.getLogger(DefaultAccommodationsProcessor.class);
 
     private final AccommodationTranslationRepository translationRepository;
     private final LanguageRepository languageRepository;
 
-    private XPathExpression xpathAccSelections;
-    private XPathExpression xpathCode;
-    private XPathExpression xpathText;
-    private XPathExpression xpathLanguage;
-    private XPathExpression xpathLabel;
+    private final XPathExpression xpathAccSelections;
+    private final XPathExpression xpathCode;
+    private final XPathExpression xpathText;
+    private final XPathExpression xpathLanguage;
+    private final XPathExpression xpathLabel;
 
     @Autowired
     public DefaultAccommodationsProcessor(final AccommodationTranslationRepository translationRepository,
@@ -84,10 +84,11 @@ public class DefaultAccommodationsProcessor implements AccommodationsProcessor {
      * </p>
      *
      * @param accessibilityConfig An Accessibility Config File as referenced at https://github.com/SmarterApp/AccessibilityAccommodationConfigurations
+     * @param importId id of the import
      * @throws ImportException if any errors are encountered during processing
      */
     @Override
-    public void process(final byte[] accessibilityConfig) throws ImportException {
+    public String process(final byte[] accessibilityConfig, final long importId) throws ImportException {
 
         final Document doc = parseDoc(accessibilityConfig);
 
@@ -118,7 +119,9 @@ public class DefaultAccommodationsProcessor implements AccommodationsProcessor {
         //Insert into database
         translationRepository.create(accommodations);
 
-        logger.info(String.format("Processed %d accommodation codes", accommodations.size()));
+        final String msg = accommodations.size() + " accommodations processed";
+        logger.info(msg);
+        return msg;
     }
 
     private Document parseDoc(final byte[] accessibilityConfig) throws ImportException {

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentPackageProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentPackageProcessor.java
@@ -15,7 +15,7 @@ import java.util.List;
 import static org.opentestsystem.rdw.ingest.common.model.ImportStatus.BAD_DATA;
 
 @Service
-public class DefaultAssessmentPackageProcessor implements AssessmentPackageProcessor {
+class DefaultAssessmentPackageProcessor implements AssessmentPackageProcessor {
     private static final Logger logger = LoggerFactory.getLogger(DefaultAssessmentPackageProcessor.class);
     private final AssessmentPackageRepository packageRepository;
     private final AssessmentParser parser;
@@ -30,18 +30,24 @@ public class DefaultAssessmentPackageProcessor implements AssessmentPackageProce
     }
 
     @Override
-    public void process(final byte[] assessmentPackage, final long importId) {
+    public String process(final byte[] assessmentPackage, final long importId) {
         final DataElementErrorCollector elementErrorCollector = new DataElementErrorCollector();
 
         final List<Assessment> assessments = parser.parse(assessmentPackage, elementErrorCollector);
 
         //If there are errors in the container, don't insert anything into the database, just bail out
-        if (!elementErrorCollector.isEmpty()) throw new ImportException(BAD_DATA, elementErrorCollector.toJson());
+        if (!elementErrorCollector.isEmpty()) {
+            throw new ImportException(BAD_DATA, elementErrorCollector.toJson());
+        }
 
         //Insert into database
-        if (!assessments.isEmpty()) packageRepository.createPackage(assessments, importId);
+        if (!assessments.isEmpty()) {
+            packageRepository.createPackage(assessments, importId);
+        }
 
-        logger.info(String.format("Processed %d assessments", assessments.size()));
+        final String msg = assessments.size() + " assessments processed";
+        logger.info(msg);
+        return msg;
     }
 
 }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
@@ -38,7 +38,7 @@ class DefaultOrganizationProcessor implements OrganizationProcessor {
     }
 
     @Override
-    public void process(final byte[] payload, final long importId) throws ImportException {
+    public String process(final byte[] payload, final long importId) throws ImportException {
         for (final OrganizationParser parser : parsers) {
             try {
                 final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
@@ -47,8 +47,9 @@ class DefaultOrganizationProcessor implements OrganizationProcessor {
                     throw new ImportException(BAD_DATA, errorCollector.toJson());
                 }
                 schoolRepository.upsert(schools, importId);
-                logger.info("upsert called for {} schools", schools.size());
-                return;
+                final String msg = schools.size() + " schools processed";
+                logger.info(msg);
+                return msg;
             } catch (final IllegalArgumentException iae) {
                 // expected, just loop
             }

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfigurationTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorConfigurationTest.java
@@ -63,13 +63,20 @@ public class PackageProcessorConfigurationTest {
     @Test
     public void itShouldProcessAccommodations() throws UnsupportedEncodingException {
         processor.processCodes(createMessage(2, CODES, MediaType.APPLICATION_XML, "/AccessibilityConfig.xml"));
-        verify(accommodationsProcessor).process(any(byte[].class));
+        verify(accommodationsProcessor).process(any(byte[].class), eq(2L));
         verify(importRepository).updateStatusAndMessageById(2, ImportStatus.PROCESSED, null);
     }
 
     @Test
     public void itShouldProcessOrganization() throws UnsupportedEncodingException {
         processor.processOrganization(createMessage(1, ORGANIZATION, MediaType.APPLICATION_JSON, "/organization.json"));
+        verify(organizationProcessor).process(any(byte[].class), eq(1L));
+        verify(importRepository).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
+    }
+
+    @Test
+    public void itShouldProcessCalpadsOrganization() throws UnsupportedEncodingException {
+        processor.processOrganization(createMessage(1, ORGANIZATION, MediaType.APPLICATION_JSON, "/CA_schools.csv"));
         verify(organizationProcessor).process(any(byte[].class), eq(1L));
         verify(importRepository).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
     }

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAccommodationsProcessorIT.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAccommodationsProcessorIT.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.ingest.processor.service.impl;
 import com.google.common.io.ByteStreams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.test.CachingTest;
 import org.opentestsystem.rdw.ingest.processor.PackageProcessorApplication;
 import org.opentestsystem.rdw.ingest.processor.service.AccommodationsProcessor;
@@ -15,6 +14,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -29,6 +30,7 @@ public class DefaultAccommodationsProcessorIT {
 
     @Test
     public void itShouldProcessAccommodations() throws IOException {
-        processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.xml")));
+        assertThat(processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.xml")), 1L))
+                .isEqualTo("11 accommodations processed");
     }
 }

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAccommodationsProcessorTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAccommodationsProcessorTest.java
@@ -38,7 +38,8 @@ public class DefaultAccommodationsProcessorTest {
 
     @Test
     public void itShouldProcessAccommodations() throws IOException {
-        processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.xml")));
+        assertThat(processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.xml")), 1L))
+                .isEqualTo("11 accommodations processed");
         final ArgumentCaptor<List<Accommodation>> captor = ArgumentCaptor.forClass((Class) List.class);
         verify(translationRepository).create(captor.capture());
         final List<Accommodation> accommodations = captor.getValue();
@@ -51,18 +52,18 @@ public class DefaultAccommodationsProcessorTest {
 
     @Test(expected = ImportException.class)
     public void itShouldFailToProcessPayloadWithInvalidSchema() throws IOException {
-        processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.schema.xml")));
+        processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.schema.xml")), 1L);
     }
 
     @Test(expected = ImportException.class)
     public void itShouldFailToProcessPayloadWithBadXml() throws IOException {
-        processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.badxml.xml")));
+        processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.badxml.xml")), 1L);
     }
 
     @Test
     public void itShouldFailToProcessPayloadWithBadData() throws IOException {
         try {
-            processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.baddata.xml")));
+            processor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/AccessibilityConfig.baddata.xml")), 1L);
             fail("it should have thrown exception for bad data");
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentPackageProcessorIT.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentPackageProcessorIT.java
@@ -38,7 +38,8 @@ public class DefaultAssessmentPackageProcessorIT {
         final int beforeAssessmentCount = countRowsInTable(jdbcTemplate, "asmt") + countRowsInTable(jdbcTemplate, "asmt");
         final int beforeItemCount = countRowsInTable(jdbcTemplate, "item") + countRowsInTable(jdbcTemplate, "item");
 
-        packageProcessor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/IAB_ICA_Combined.items.csv")), -99);
+        assertThat(packageProcessor.process(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/IAB_ICA_Combined.items.csv")), -99))
+                .isEqualTo("9 assessments processed");
         assertThat(countRowsInTable(jdbcTemplate, "asmt")).isEqualTo(beforeAssessmentCount + 9);
         assertThat(countRowsInTable(jdbcTemplate, "item")).isEqualTo(beforeItemCount + 81);
     }

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/OrganizationParserTest.java
@@ -37,7 +37,7 @@ public class OrganizationParserTest {
         final SchoolRepository schoolRepository = mock(SchoolRepository.class);
         final OrganizationProcessor processor = new DefaultOrganizationProcessor(schoolRepository);
 
-        processor.process(payload, 1L);
+        assertThat(processor.process(payload, 1L)).isEqualTo("5 schools processed");
         verify(schoolRepository).upsert(schoolsCaptor.capture(), eq(1L));
         assertThat(schoolsCaptor.getValue()).hasSize(5);
     }
@@ -49,7 +49,7 @@ public class OrganizationParserTest {
         final SchoolRepository schoolRepository = mock(SchoolRepository.class);
         final OrganizationProcessor processor = new DefaultOrganizationProcessor(schoolRepository);
 
-        processor.process(payload, 1L);
+        assertThat(processor.process(payload, 1L)).isEqualTo("23 schools processed");
         verify(schoolRepository).upsert(schoolsCaptor.capture(), eq(1L));
         assertThat(schoolsCaptor.getValue()).hasSize(23);
     }


### PR DESCRIPTION
@agorina made a comment yesterday about having useful status messages in the database for group loading. That made me think that it would be nice to preserve import messages for successes as well as failures. This is a start on that. 

Opinions?