### PR TITLE
DWR-519 Perf: migrate performance

### DIFF
--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
           group: default
 
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false&rewriteBatchedStatements=true
     username: root
     password:
     testWhileIdle: true

--- a/exam-processor/src/test/resources/application-test.yml
+++ b/exam-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false&rewriteBatchedStatements=true

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -860,7 +860,7 @@ sql:
                                               (:id, :exam_id, :item_id, :score, :score_status, :position, :response, :trait_evidence_elaboration_score,
                                                  :trait_evidence_elaboration_score_status, :trait_organization_purpose_score,
                                                  :trait_organization_purpose_score_status, :trait_conventions_score,
-                                                 :trait_conventions_score_status, migrate_id)
+                                                 :trait_conventions_score_status, :migrate_id)
 
         exam_item_by_update_import_id:
           sql:
@@ -894,7 +894,7 @@ sql:
                                               (:id, :exam_id, :item_id, :score, :score_status, :position, :response, :trait_evidence_elaboration_score,
                                                  :trait_evidence_elaboration_score_status, :trait_organization_purpose_score,
                                                  :trait_organization_purpose_score_status, :trait_conventions_score,
-                                                 :trait_conventions_score_status, migrate_id)
+                                                 :trait_conventions_score_status, :migrate_id)
 
         # ------------ exam_available_accommodation  ---------------------------------------------------------------------------------------
         exam_available_accommodation:

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -13,7 +13,7 @@ migrate:
 
 spring:
   batch_datasource:
-    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false&useLegacyDatetimeCode=false
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting?useSSL=false&useLegacyDatetimeCode=false&rewriteBatchedStatements=true
     username: root
     password:
     testWhileIdle: true

--- a/migrate-reporting/src/test/resources/application-test.yml
+++ b/migrate-reporting/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   batch_datasource:
-    url: jdbc:mysql://localhost:3306/spring_batch_reporting_test?useSSL=false&useLegacyDatetimeCode=false
+    url: jdbc:mysql://localhost:3306/spring_batch_reporting_test?useSSL=false&useLegacyDatetimeCode=false&rewriteBatchedStatements=true

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
           group: default
 
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false&rewriteBatchedStatements=true
     username: root
     password:
     testWhileIdle: true

--- a/package-processor/src/test/resources/application-test.yml
+++ b/package-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false&rewriteBatchedStatements=true


### PR DESCRIPTION
Thanks @jtreuting!

With this change a single insert of 300 records dropped from 12 s. to 75.90 ms.

Here is more info: https://stackoverflow.com/questions/26307760/mysql-and-jdbc-with-rewritebatchedstatements-true

There are some concerns about using this flag ( I assume this is why it is not enabled by default), but I do not think it affects us. 

https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html#rewriteBatchedStatements 

I tested by migrating from AWS ETS to my local reporting, here are the stats:
select count(*) from exam; -- 420,571
select timestampdiff(SECOND,min(created), max(updated)) from reporting.migrate
-- 2495 seconds (41 min)  = 168 per second


NOTE: I did not update all the connections, just those that use ```batchUpdate``` call. Let me  know if you think I should blindly change all.

