### PR TITLE
DWR-569 fix performance issues

### DIFF
--- a/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
@@ -492,7 +492,7 @@ sql:
                   claim4.scale_score as claim4_scale_score,
                   claim4.scale_score_std_err as claim4_scale_score_std_err,
                   claim4.category as claim4_category,
-                  se.available_accommodation_codes
+                  code.codes
                 FROM staging.staging_exam se
                   JOIN staging.staging_exam_student ses ON se.exam_student_id = ses.id
                   LEFT JOIN (
@@ -535,6 +535,12 @@ sql:
                   JOIN reporting.administration_condition rac ON rac.id = se.administration_condition_id
                   JOIN reporting.completeness rc ON rc.id = se.completeness_id
                   JOIN reporting.grade rg ON rg.id = ses.grade_id
+                  LEFT JOIN
+                    (SELECT seaa.exam_id as exam_id, GROUP_CONCAT(ra.code ORDER BY ra.id SEPARATOR '|') AS codes
+                      FROM staging.staging_exam_available_accommodation seaa
+                        JOIN reporting.accommodation ra ON ra.id = seaa.accommodation_id
+                      GROUP BY seaa.exam_id
+                    ) AS code ON code.exam_id = se.id
                 WHERE re.id IS NULL AND se.deleted = 0;
 
             update: >-
@@ -580,6 +586,12 @@ sql:
                               INNER JOIN reporting.exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
                                                                                  AND m.num = 4
                           ) AS claim4 ON claim4.exam_id = se.id
+                LEFT JOIN
+                        (SELECT seaa.exam_id as exam_id, GROUP_CONCAT(ra.code ORDER BY ra.id SEPARATOR '|') AS codes
+                            FROM staging.staging_exam_available_accommodation seaa
+                              JOIN reporting.accommodation ra ON ra.id = seaa.accommodation_id
+                            GROUP BY seaa.exam_id
+                        ) AS code ON code.exam_id = se.id
               SET
                 re.grade_id = ses.grade_id,
                 re.grade_code = rg.code,
@@ -621,7 +633,7 @@ sql:
                 re.claim4_category = claim4.category,
                 re.administration_condition_code = rac.code,
                 re.completeness_code = rc.code,
-                re.available_accommodation_codes = se.available_accommodation_codes
+                re.available_accommodation_codes = code.codes
               WHERE se.deleted = 0;
 
             delete: >-

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -787,25 +787,16 @@ sql:
                 we.scale_score_std_err,
                 we.completed_at,
                 we.deleted,
-                we.update_import_id AS import_id,
-                code.codes as available_accommodation_codes
+                we.update_import_id AS import_id
               FROM warehouse.exam we
                JOIN warehouse.import wi on wi.id = we.import_id
-               LEFT JOIN
-                     (SELECT
-                        weaa.exam_id as exam_id,
-                        GROUP_CONCAT(wa.code ORDER BY wa.id SEPARATOR '|') AS codes
-                      FROM warehouse.exam_available_accommodation weaa
-                        JOIN warehouse.accommodation wa ON wa.id = weaa.accommodation_id
-                      GROUP BY weaa.exam_id
-                     ) AS code ON code.exam_id = we.id
-              WHERE wi.status != 0 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
+                             WHERE wi.status != 0 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
 
             stagingInsert: >-
               INSERT INTO staging.staging_exam (id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity,completeness_id, administration_condition_id,
-                                                 session_id, performance_level, scale_score, scale_score_std_err, available_accommodation_codes, completed_at, deleted, import_id, migrate_id) VALUES
+                                                 session_id, performance_level, scale_score, scale_score_std_err, completed_at, deleted, import_id, migrate_id) VALUES
                                                (:id, :type_id, :exam_student_id, :school_year, :asmt_id, :asmt_version, :opportunity, :completeness_id, :administration_condition_id,
-                                                :session_id, :performance_level, :scale_score, :scale_score_std_err, :available_accommodation_codes, :completed_at, :deleted, :import_id, :migrate_id)
+                                                :session_id, :performance_level, :scale_score, :scale_score_std_err, :completed_at, :deleted, :import_id, :migrate_id)
         exam_by_update_import_id:
           sql:
             warehouseRead: >-
@@ -825,25 +816,16 @@ sql:
                 we.scale_score_std_err,
                 we.completed_at,
                 we.deleted,
-                we.update_import_id AS import_id,
-                code.codes as available_accommodation_codes
+                we.update_import_id AS import_id
               FROM warehouse.exam we
                 JOIN warehouse.import wi on wi.id = we.update_import_id
-                LEFT JOIN
-                  (SELECT
-                      weaa.exam_id as exam_id,
-                      GROUP_CONCAT(wa.code ORDER BY wa.id SEPARATOR '|') AS codes
-                    FROM warehouse.exam_available_accommodation weaa
-                      JOIN warehouse.accommodation wa ON wa.id = weaa.accommodation_id
-                      GROUP BY weaa.exam_id
-                  ) AS code ON code.exam_id = we.id
-              WHERE wi.status != 0 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
+                           WHERE wi.status != 0 AND wi.id >= :start_import_id AND wi.id <= :end_import_id
 
             stagingInsert: >-
               INSERT IGNORE INTO staging.staging_exam (id, type_id, exam_student_id, school_year, asmt_id, asmt_version, opportunity,completeness_id, administration_condition_id,
-                                                 session_id, performance_level, scale_score, scale_score_std_err, available_accommodation_codes, completed_at, deleted, import_id, migrate_id) VALUES
+                                                 session_id, performance_level, scale_score, scale_score_std_err, completed_at, deleted, import_id, migrate_id) VALUES
                                                (:id, :type_id, :exam_student_id, :school_year, :asmt_id, :asmt_version, :opportunity, :completeness_id, :administration_condition_id,
-                                                :session_id, :performance_level, :scale_score, :scale_score_std_err, :available_accommodation_codes, :completed_at, :deleted, :import_id, :migrate_id)
+                                                :session_id, :performance_level, :scale_score, :scale_score_std_err, :completed_at, :deleted, :import_id, :migrate_id)
 
         # ------------ exam_item  ---------------------------------------------------------------------------------------
         exam_item:

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -8,7 +8,7 @@ server:
 
 migrate:
   batch:
-    size: 1000
+    size: 2000
     delay: 60000
 
 spring:

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
@@ -79,8 +79,6 @@ public class StageExamIT extends SpringBatchStepIT {
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         // exam with id -88 is deleted
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 4, "id in (-88, -87, -86, -85)"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 1, "id in (-88) and available_accommodation_codes ='code1-test|code2-test'"));
-        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam", 3, "id in (-87, -86, -85) and available_accommodation_codes ='code2-test'"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 3, "id in (-17, -15, -16)"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_student", 0, "id in (-18)"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, StagingTablePrefix + "exam_available_accommodation", 3, "exam_id in (-87, -86, -85)"));

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
@@ -58,6 +58,7 @@ public class UpsertExamsIT extends SpringBatchStepIT {
     public void itShouldInsert() {
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam_available_accommodation", 2, "exam_id in (-88, -87)"));
+        tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam", 1, "id in (-88) and available_accommodation_codes ='code1-test|code2-test'"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam_item", 4, "exam_id in (-88, -87, -86)"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam", 2, "id in (-88, -87, -86)"));
         tableTestCounts.add(new TableTestCountHelper(jdbcTemplate, "reporting_test.exam", 2, "id in (-88, -87, -86) AND grade_code in ('98')"));


### PR DESCRIPTION
A previous approach made the migrate process 3 times slower. 

I guess it is a good coincidence that I was testing performance and had 'before the change' times captured. This bring it back to what it was before.