### PR TITLE
don't expect java 8 clock to support microseconds

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
@@ -81,7 +81,6 @@ class JdbcRdwImportRepository implements RdwImportRepository {
                 .addValue("digest", rdwImport.getDigest())
                 .addValue("batch", rdwImport.getBatch())
                 .addValue("creator", rdwImport.getCreator())
-                .addValue("created", Timestamp.from(rdwImport.getCreated()))
                 .addValue("message", rdwImport.getMessage());
 
         jdbcTemplate.update(sqlCreate, parameterSource, keyHolder);

--- a/import-service/src/main/resources/application.sql.yml
+++ b/import-service/src/main/resources/application.sql.yml
@@ -4,8 +4,8 @@ sql:
       SELECT count(*) from import
 
     create: >-
-      INSERT INTO import (status, content, contentType, digest, batch, creator, created, message)
-        VALUES (:status, :content, :contentType, :digest, :batch, :creator, :created, :message)
+      INSERT INTO import (status, content, contentType, digest, batch, creator, message)
+        VALUES (:status, :content, :contentType, :digest, :batch, :creator, :message)
 
     delete: >-
       DELETE FROM import WHERE id=:id

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -12,6 +12,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
@@ -88,6 +90,16 @@ public class RdwImportRepositoryIT {
         assertThat(repository.findByReplayId(replayId)).hasSize(2);
 
         assertThat(repository.clearReplayId(replayId)).isEqualTo(2);
+    }
+
+    @Test
+    public void itShouldLetDatabaseSetCreated() {
+        // this establishes that the database generates microsecond precision
+        // and that the repo lets it do so, and preserves the result
+        // (in theory, this test will fail 1/1000 times)
+        final RdwImport alice = repository.findOne(createTestData().get("alice"));
+        final Instant created = alice.getCreated();
+        assertThat(created).isNotEqualTo(created.truncatedTo(ChronoUnit.MILLIS));
     }
 
     private Map<String, Long> createTestData() {

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateJobParameters.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateJobParameters.java
@@ -21,24 +21,25 @@ class MigrateJobParameters extends JobParameters {
     public MigrateJobParameters(final Instant firstAt, final Instant lastAt, final boolean migrateCodes, final int batchSize) {
         super(new JobParametersBuilder()
                 .addLong(JobIdentifier, System.currentTimeMillis())
-                // As defined in the {@link JobParameter}, only the following types can be parameters: String, Long, Date, and Double.
-                .addDate(FirstAt, Date.from(firstAt), false)
-                .addDate(LastAt, Date.from(lastAt), false)
+                // As defined in the {@link JobParameter}, only the following types can be parameters: String, Long,
+                // Date, and Double. And Date/Long doesn't have enough precision ...
+                .addString(FirstAt, firstAt.toString(), false)
+                .addString(LastAt, lastAt.toString(), false)
                 .addLong(MigrateCodes, migrateCodes ? 1L : 0, false)
                 .addLong(BatchSize, (long) batchSize)
                 .toJobParameters().getParameters());
     }
 
     public Instant getFirstAt() {
-        return getDate(FirstAt).toInstant();
+        return Instant.parse(getString(FirstAt));
     }
 
     public Instant getLastAt() {
-        return getDate(LastAt).toInstant();
+        return Instant.parse(getString(LastAt));
     }
 
     public boolean getMigrateCodes() {
-        return getLong(MigrateCodes) == 1 ? true : false;
+        return getLong(MigrateCodes) == 1;
     }
 
     public int getBatchSize() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateJobParamsTest.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateJobParamsTest.java
@@ -24,4 +24,14 @@ public class MigrateJobParamsTest {
         assertThat(jobParameters.getMigrateCodes()).isTrue();
         assertThat(jobParameters.getBatchSize()).isEqualTo(10);
     }
+
+    @Test
+    public void itShouldRoundtripTimestampsWithMicrosecondPrecision() {
+        final Instant firstAt = Instant.parse("2017-05-18T19:06:34.966123Z");
+        final Instant lastAt = Instant.parse("2017-05-20T19:06:34.966456Z");
+        final MigrateJobParameters jobParameters = new MigrateJobParameters(firstAt, lastAt, true, 10);
+
+        assertThat(jobParameters.getFirstAt()).isEqualTo(firstAt);
+        assertThat(jobParameters.getLastAt()).isEqualTo(lastAt);
+    }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcWarehouseImportRepositoryIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcWarehouseImportRepositoryIT.java
@@ -88,4 +88,16 @@ public class JdbcWarehouseImportRepositoryIT extends RepositoryIT {
         assertThat(migrateImportValues.getImportCount()).isZero();
         assertThat(migrateImportValues.migrateCodes()).isFalse();
     }
+
+    @Sql(statements = {"DELETE FROM warehouse_test.import",
+            "INSERT INTO warehouse_test.import (id, status, content, contentType, digest, created, updated) VALUES\n" +
+                    "  (-996, 1, 1, 'application/xml', 'digest', '2017-07-18 19:45:33.966123', '2017-07-18 19:45:33.966123');"})
+    @Test
+    public void itShouldPreserveDatabaseTimestampPrecision() {
+        // Although the java 8 clock doesn't necessarily have better than millisecond precision
+        // the Instant class should parse up to microseconds and the Timestamp class should preserve
+        // up to nanosecond precision from the database.
+        final MigrateImportValues migrateImportValues = repository.getMigrateImportValues(null, 10);
+        assertThat(migrateImportValues.getLastAt()).isEqualTo(Instant.parse("2017-07-18T19:45:33.966123Z"));
+    }
 }


### PR DESCRIPTION
Every day is a learning opportunity ...

Apparently java 8 Instant supports nanosecond precision but the clock that generates instants does not. So, this change lets the database do all the timestamp creation while the java code merely passes the values around. Oh yeah, and Date doesn't even support microseconds so let's avoid that.