### PR TITLE
reduce connections/threads for apps that only have management end-points

### DIFF
--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -5,6 +5,9 @@ management:
     enabled: false
 server:
   port: 8008
+  tomcat:
+    max-connections: 2
+    max-threads: 2
 
 spring:
   cache:
@@ -29,6 +32,11 @@ spring:
     maxActive: 10
     initialSize: 4
     maxWait: 10000
+
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
 
 jdbc:
   retry:

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -5,6 +5,9 @@ management:
     enabled: false
 server:
   port: 8008
+  tomcat:
+    max-connections: 2
+    max-threads: 2
 
 migrate:
   batch:

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -5,6 +5,9 @@ management:
     enabled: false
 server:
   port: 8008
+  tomcat:
+    max-connections: 2
+    max-threads: 2
 
 spring:
   cloud:

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -5,6 +5,9 @@ management:
     enabled: false
 server:
   port: 8008
+  tomcat:
+    max-connections: 2
+    max-threads: 2
 
 # there needs to be a default aws region configured
 cloud:
@@ -29,6 +32,7 @@ spring:
     initialize: false
     maxActive: 10
     initialSize: 4
+
   jackson:
     default-property-inclusion: non_null
     serialization:


### PR DESCRIPTION
Near as i can tell, for apps that have both a real endpoint and management endpoints, the same tomcat connection/thread management is shared. So i left import-service alone.