### PR TITLE
clean up; use exists instead of count

### DIFF
--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepository.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepository.java
@@ -31,7 +31,6 @@ import static com.google.common.collect.Lists.newArrayList;
 @Repository
 class JdbcReportRepository implements ReportRepository {
     private static final Logger logger = LoggerFactory.getLogger(JdbcReportRepository.class);
-    private static final String[] DefaultHeaders = new String[]{"student_id", "asmt_guid", "school_year", "opp_id", "batch", "import_id"};
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -41,8 +40,8 @@ class JdbcReportRepository implements ReportRepository {
     @Value("${sql.import.status}")
     private String sqlImportStatus;
 
-    @Value("${sql.import.count}")
-    private String sqlImportCount;
+    @Value("${sql.import.exists}")
+    private String sqlImportExists;
 
     @Autowired
     public JdbcReportRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
@@ -51,8 +50,8 @@ class JdbcReportRepository implements ReportRepository {
 
     @Override
     public void writeReconciliationReport(final RdwImportQuery query, final OutputStream os) {
-        try (final CsvResultSetWriterAdapter writer = new CsvResultSetWriterAdapter(new OutputStreamWriter(os), CsvPreference.EXCEL_PREFERENCE)) {
-            writer.writeHeader(DefaultHeaders);
+        try (final ReconciliationCsvWriter writer = new ReconciliationCsvWriter(new OutputStreamWriter(os), CsvPreference.EXCEL_PREFERENCE)) {
+            writer.writeHeader(ReconciliationCsvWriter.Headers);
             final MapSqlParameterSource parameterSource = mapQueryToSqlParameterSource(query);
             try {
                 jdbcTemplate.query(sqlImportExams, parameterSource, writer);
@@ -65,8 +64,8 @@ class JdbcReportRepository implements ReportRepository {
     }
 
     @Override
-    public long countExamImports(final RdwImportQuery query) {
-        return jdbcTemplate.queryForObject(sqlImportCount, mapQueryToSqlParameterSource(query), Long.class);
+    public boolean exists(final RdwImportQuery query) {
+        return jdbcTemplate.queryForObject(sqlImportExists, mapQueryToSqlParameterSource(query), Boolean.class);
     }
 
     @Override
@@ -80,14 +79,23 @@ class JdbcReportRepository implements ReportRepository {
         return true;
     }
 
+    private MapSqlParameterSource mapQueryToSqlParameterSource(final RdwImportQuery query) {
+        return new MapSqlParameterSource()
+                .addValue("batch", query.getBatch())
+                .addValue("creator", query.getCreator())
+                .addValue("before", query.getBefore() == null ? null : Timestamp.from(query.getBefore()))
+                .addValue("after", query.getAfter() == null ? null : Timestamp.from(query.getAfter()));
+    }
+
     /**
-     * Helper that writes query result rows to CSV.
+     * Helper that writes query result rows to reconciliation report CSV.
      * Note that {@link CsvResultSetWriter} doesn't work for us because it processes the entire
      * result set at once and it sticks in headers every time.
      */
-    private static class CsvResultSetWriterAdapter extends AbstractCsvWriter implements RowCallbackHandler {
+    private static class ReconciliationCsvWriter extends AbstractCsvWriter implements RowCallbackHandler {
+        static final String[] Headers = new String[]{ "student_id", "asmt_guid", "school_year", "opp_id", "batch", "import_id" };
 
-        CsvResultSetWriterAdapter(final Writer writer, final CsvPreference preference) {
+        ReconciliationCsvWriter(final Writer writer, final CsvPreference preference) {
             super(writer, preference);
         }
 
@@ -107,13 +115,5 @@ class JdbcReportRepository implements ReportRepository {
                 logger.warn("Error writing results {} to reconciliation report {}", rs, e.getMessage());
             }
         }
-    }
-
-    private MapSqlParameterSource mapQueryToSqlParameterSource(final RdwImportQuery query) {
-        return new MapSqlParameterSource()
-                .addValue("batch", query.getBatch())
-                .addValue("creator", query.getCreator())
-                .addValue("before", query.getBefore() == null ? null : Timestamp.from(query.getBefore()))
-                .addValue("after", query.getAfter() == null ? null : Timestamp.from(query.getAfter()));
     }
 }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/ReportRepository.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/ReportRepository.java
@@ -1,9 +1,7 @@
 package org.opentestsystem.rdw.ingest.tasking.repository;
 
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.tasking.model.ReconciliationReport;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 /**
@@ -23,13 +21,10 @@ public interface ReportRepository {
     void writeReconciliationReport(RdwImportQuery query, OutputStream os);
 
     /**
-     * Return count of exam import records matching the query parameters.
-     * query.content and query.status are ignored: all EXAMs of any status are counted.
-     *
      * @param query import query
-     * @return number of import records matching the query
+     * @return true if any imports exist matching the query
      */
-    long countExamImports(RdwImportQuery query);
+    boolean exists(RdwImportQuery query);
 
     /**
      * @return return true if repository is available to get reports

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/service/impl/DefaultReconciliationService.java
@@ -87,7 +87,7 @@ public class DefaultReconciliationService implements ReconciliationService {
      * @return true if any import records exist matching query while ignoring status
      */
     private boolean anyImportActivity(final RdwImportQuery query) {
-        return reportRepository.countExamImports(query.copy().status((String) null).build()) > 0;
+        return reportRepository.exists(query.copy().status((String) null).build());
     }
 
     private void cleanupReportFile(final Path file) {

--- a/task-service/src/main/resources/application.sql.yml
+++ b/task-service/src/main/resources/application.sql.yml
@@ -14,13 +14,15 @@ sql:
         AND (:after IS NULL OR i.updated > :after)
       ORDER BY i.id
 
-    count: >-
-      SELECT count(*) FROM import i
-      WHERE i.content = 1
-        AND (:batch IS NULL OR i.batch = :batch)
-        AND (:creator IS NULL OR i.creator = :creator)
-        AND (:before IS NULL OR i.created < :before)
-        AND (:after IS NULL OR i.updated > :after)
+    exists: >-
+      SELECT EXISTS(
+        SELECT 1 FROM import i
+        WHERE i.content = 1
+          AND (:batch IS NULL OR i.batch = :batch)
+          AND (:creator IS NULL OR i.creator = :creator)
+          AND (:before IS NULL OR i.created < :before)
+          AND (:after IS NULL OR i.updated > :after)
+        LIMIT 1)
 
     status: >-
       SELECT s.ssid, a.natural_id, e.school_year, e.oppId, i.batch, i.id
@@ -29,4 +31,5 @@ sql:
           JOIN exam_student es ON es.id = e.exam_student_id
           JOIN student s ON s.id = es.student_id
           JOIN asmt a ON a.id = e.asmt_id
+        WHERE i.content = 1
         LIMIT 1

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepositoryIT.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/repository/JdbcReportRepositoryIT.java
@@ -41,9 +41,8 @@ public class JdbcReportRepositoryIT {
     }
 
     @Test
-    public void itShouldCount() {
-        // this won't work if there are pre-existing EXAM import records
-        assertThat(repository.countExamImports(RdwImportQuery.builder().build())).isEqualTo(4);
+    public void testExists() {
+        assertThat(repository.exists(RdwImportQuery.builder().build())).isTrue();
     }
 
     @Test

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ReconciliationServiceTest.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/service/impl/ReconciliationServiceTest.java
@@ -2,7 +2,6 @@ package org.opentestsystem.rdw.ingest.tasking.service.impl;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.tasking.repository.ReportRepository;
@@ -37,7 +36,7 @@ public class ReconciliationServiceTest {
     @Before
     public void setup() {
         reportRepository = mock(ReportRepository.class);
-        when(reportRepository.countExamImports(any(RdwImportQuery.class))).thenReturn(5L);
+        when(reportRepository.exists(any(RdwImportQuery.class))).thenReturn(true);
         doAnswer(invocation -> {
             ((OutputStream) invocation.getArguments()[1]).write(report);
             return null;
@@ -62,11 +61,11 @@ public class ReconciliationServiceTest {
 
     @Test
     public void itShouldNotSendAReportIfThereHaveBeenNoImports() {
-        when(reportRepository.countExamImports(any(RdwImportQuery.class))).thenReturn(0L);
+        when(reportRepository.exists(any(RdwImportQuery.class))).thenReturn(false);
         final ReportSender sender = mock(ReportSender.class);
 
         reconciliationService.sendReport(query, newArrayList(sender));
-        verify(reportRepository).countExamImports(any(RdwImportQuery.class));
+        verify(reportRepository).exists(any(RdwImportQuery.class));
         verifyZeroInteractions(sender);
     }
 


### PR DESCRIPTION
when i was in there investigating an "unprocessed import" report, i noticed that we're counting imports when we really just need to check that at least one exists. And we know that counting things is a really bad idea.