### PR TITLE
Add group ingest to the group-processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=0.0.1-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "0.0.1-34"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "0.0.1-134"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "0.0.1-152"
 
 allprojects {
     group = 'org.opentestsystem.rdw.ingest'

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorApplication.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorApplication.java
@@ -12,7 +12,11 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import( { GroupProcessorConfiguration.class, YamlPropertiesConfigurator.class, StatusConfiguration.class } )
+@Import({
+        GroupProcessorConfiguration.class,
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class
+})
 public class GroupProcessorApplication {
 
     public static void main(String[] args) {

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/ProcessingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/ProcessingGroupImportService.java
@@ -1,0 +1,77 @@
+package org.opentestsystem.rdw.ingest.group.service;
+
+/**
+ * Implementations of this interface are responsible for creating and importing student groups
+ * while processing a group definition import.
+ *
+ * The service is designed to be executed as an ordered flow to support transaction boundaries:
+ * <ol>
+ *     <li>{@link #createImports(long)}</li>
+ *     <li>{@link #insertMissingGroups(long)}</li>
+ *     <li>{@link #updateDeletedGroups(long)}</li>
+ *     <li>{@link #updateModifiedGroups(long)}</li>
+ *     <li>{@link #updateModifiedGroupUsers(long)}</li>
+ *     <li>{@link #updateModifiedGroupStudents(long)}</li>
+ *     <li>{@link #triggerImport(long)}</li>
+ * </ol>
+ */
+public interface ProcessingGroupImportService {
+
+    /**
+     * Create and register an import for any groups that:
+     * <ol>
+     *     <li>do not currently exist in the system</li>
+     *     <li>have a change in student membership</li>
+     *     <li>have a change in authorized users</li>
+     *     <li>have a change in subject</li>
+     *     <li>have been deleted</li>
+     * </ol>
+     * In the interests of performance there will be one import per school.
+     *
+     * @param batchId The batch id
+     */
+    void createImports(long batchId);
+
+    /**
+     * Insert missing group records into the student_group table.
+     *
+     * @param batchId The batch id
+     */
+    void insertMissingGroups(long batchId);
+
+    /**
+     * Update existing, referenced deleted group records to mark
+     * them as not deleted.
+     *
+     * @param batchId The batch id
+     */
+    void updateDeletedGroups(long batchId);
+
+    /**
+     * Update modified groups.
+     *
+     * @param batchId The batch id
+     */
+    void updateModifiedGroups(long batchId);
+
+    /**
+     * Update the authenticated users for ingested groups.
+     *
+     * @param batchId The batch id
+     */
+    void updateModifiedGroupUsers(long batchId);
+
+    /**
+     * Update the student membership for ingested groups.
+     *
+     * @param batchId The batch id
+     */
+    void updateModifiedGroupStudents(long batchId);
+
+    /**
+     * Trigger the created imports and clean up.
+     *
+     * @param batchId The batch id
+     */
+    void triggerImport(long batchId);
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.group.service.impl;
 
 import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingReferenceService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingStandardizationService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
@@ -16,14 +17,17 @@ public class DefaultGroupProcessor implements GroupProcessor {
     private final ProcessingStandardizationService standardizationService;
     private final ProcessingReferenceService referenceService;
     private final ProcessingUserImportService userImportService;
+    private final ProcessingGroupImportService groupImportService;
 
     @Autowired
     public DefaultGroupProcessor(final ProcessingStandardizationService standardizationService,
                                  final ProcessingReferenceService referenceService,
-                                 final ProcessingUserImportService userImportService) {
+                                 final ProcessingUserImportService userImportService,
+                                 final ProcessingGroupImportService groupImportService) {
         this.standardizationService = standardizationService;
         this.referenceService = referenceService;
         this.userImportService = userImportService;
+        this.groupImportService = groupImportService;
     }
 
     /**
@@ -39,12 +43,23 @@ public class DefaultGroupProcessor implements GroupProcessor {
 
         // TODO once CSV is loaded into DB
 //        try {
+//            final long batchId = 33;
 //            standardizationService.standardizeBatch(batchId);
+//
 //            referenceService.lookupBatchReferences(batchId);
+//
 //            userImportService.createImports(batchId);
 //            userImportService.insertMissingStudents(batchId);
 //            userImportService.updateDeletedStudents(batchId);
 //            userImportService.triggerImport(batchId);
+//
+//            groupImportService.createImports(33);
+//            groupImportService.insertMissingGroups(33);
+//            groupImportService.updateDeletedGroups(33);
+//            groupImportService.updateModifiedGroups(33);
+//            groupImportService.updateModifiedGroupUsers(33);
+//            groupImportService.updateModifiedGroupStudents(33);
+//            groupImportService.triggerImport(33);
 //        } catch (final Exception e) {
 //            logger.error("Problem processing batch: {}", batchId, e);
 //        }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportService.java
@@ -7,6 +7,7 @@ import org.opentestsystem.rdw.ingest.group.configuration.GroupProcessingSqlConfi
 import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.List;
 /**
  * Default implementation of a ProcessingGroupImportService
  */
+@Service
 public class DefaultProcessingGroupImportService implements ProcessingGroupImportService {
     private static final Logger logger = LoggerFactory.getLogger(DefaultProcessingUserImportService.class);
 

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportService.java
@@ -1,0 +1,168 @@
+package org.opentestsystem.rdw.ingest.group.service.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.ingest.common.repository.SqlListExecutionRepository;
+import org.opentestsystem.rdw.ingest.common.util.SqlListBuilder;
+import org.opentestsystem.rdw.ingest.group.configuration.GroupProcessingSqlConfiguration;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Default implementation of a ProcessingGroupImportService
+ */
+public class DefaultProcessingGroupImportService implements ProcessingGroupImportService {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultProcessingUserImportService.class);
+
+    private final SqlListExecutionRepository repository;
+    private final GroupProcessingSqlConfiguration sqlConfiguration;
+
+    public DefaultProcessingGroupImportService(final SqlListExecutionRepository repository,
+                                               final GroupProcessingSqlConfiguration configuration) {
+        this.repository = repository;
+        this.sqlConfiguration = configuration;
+    }
+
+    @Override
+    public void createImports(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "stage-new")
+                .addNext("import-groups", "stage-membership-change")
+                .addNext("import-groups", "stage-user-change")
+                .addNext("import-groups", "stage-subject-change")
+                .addNext("import-groups", "create-imports")
+                .addNext("import-groups", "assign-imports")
+                .addNext("import-groups", "propagate-imports")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+        } catch (final Exception e) {
+            logger.error("Failure creating Group imports", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void insertMissingGroups(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "insert-missing")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+        } catch (final Exception e) {
+            logger.error("Failure creating new groups", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateDeletedGroups(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "update-deleted")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+        } catch (final Exception e) {
+            logger.error("Failure updating deleted groups", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateModifiedGroups(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "assign-imported-groups")
+                .addNext("import-groups", "update-modified")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+        } catch (final Exception e) {
+            logger.error("Failure updating modified groups", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateModifiedGroupUsers(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "clear-updated-users")
+                .addNext("import-groups", "add-updated-users")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+        } catch (final Exception e) {
+            logger.error("Failure updating modified group users", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateModifiedGroupStudents(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "clear-updated-students")
+                .addNext("import-groups", "add-updated-students")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+        } catch (final Exception e) {
+            logger.error("Failure updating modified group students", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    @Override
+    public void triggerImport(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "update-migration")
+                .addNext("import-groups", "clean-import-stage")
+                .addNext("import-groups", "clean-import-upload")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "import_status", 1));
+        } catch (final Exception e) {
+            logger.error("Failure triggering group import", e);
+            abortImports(batchId);
+            throw e;
+        }
+    }
+
+    private void abortImports(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
+                .addNext("import-groups", "update-migration")
+                .build();
+        repository.execute(sql, ImmutableMap.of(
+                "batch_id", batchId,
+                "import_status", -1));
+    }
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingUserImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingUserImportService.java
@@ -35,7 +35,6 @@ public class DefaultProcessingUserImportService implements ProcessingUserImportS
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-students", "stage-new")
-                .addNext("import-students", "stage-deleted")
                 .addNext("import-students", "create-imports")
                 .addNext("import-students", "assign-imports")
                 .addNext("import-students", "propagate-imports")

--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -48,9 +48,13 @@ sql:
 
           group: >-
             UPDATE upload_student_group sgl
-              JOIN student_group sg ON sgl.name = sg.name AND sgl.school_year = sg.school_year AND sgl.school_id = sg.school_id
+              JOIN student_group sg
+                ON sgl.group_name = sg.name
+                  AND sgl.school_year = sg.school_year
+                  AND sgl.school_id = sg.school_id
             SET group_id = sg.id
-            WHERE batch_id = :batch_id
+            WHERE sg.deleted = 0
+                  AND batch_id = :batch_id
 
       # ------------ Import Student SSIDs
       # Import deleted/non-existent student SSIDs
@@ -68,19 +72,6 @@ sql:
                     AND sgl.student_ssid IS NOT NULL
                     AND sgl.batch_id = :batch_id
 
-          stage-deleted: >-
-            INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
-              SELECT
-                batch_id,
-                school_id,
-                student_ssid,
-                0
-              FROM upload_student_group sgl
-                JOIN student s ON sgl.student_ssid = s.ssid
-              WHERE s.deleted = 1
-                    AND sgl.student_ssid IS NOT NULL
-                    AND sgl.batch_id = :batch_id
-
           #TODO review this, should we modify import table to have batch_ref_id and ref_id fields to avoid casting?
           create-imports: >-
             INSERT INTO import (status, content, contentType, digest, batch)
@@ -91,7 +82,7 @@ sql:
                 cast(school_id as CHAR(32)) AS digest,
                 cast(:batch_id AS CHAR(50)) AS batch
               FROM upload_student_group_import sgl
-              WHERE ref_type IN (0, 1)
+              WHERE ref_type = 1
                     AND batch_id = :batch_id
 
           assign-imports: >-
@@ -105,7 +96,7 @@ sql:
                           AND cast(batch AS UNSIGNED) = :batch_id) AS si
                 ON si.school_id = sgl.school_id
             SET sgl.import_id = si.id
-            WHERE sgl.ref_type IN (0, 1)
+            WHERE sgl.ref_type = 1
                   AND sgl.batch_id = :batch_id
 
           propagate-imports: >-
@@ -165,6 +156,248 @@ sql:
             DELETE FROM upload_student_group_import
             WHERE batch_id = :batch_id
 
+      import-groups:
+        sql:
+          stage-new: >-
+            INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
+              SELECT
+                sgl.batch_id,
+                sgl.school_id,
+                concat(sgl.group_name, sgl.school_id, sgl.school_year),
+                2
+              FROM upload_student_group sgl
+              WHERE sgl.group_id IS NULL
+                    AND batch_id = :batch_id
+
+          stage-membership-change: >-
+            INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
+              SELECT
+                batch_id,
+                school_id,
+                concat(loading.group_name, loading.school_id, loading.school_year),
+                3
+              FROM (
+                     SELECT
+                       batch_id,
+                       school_id,
+                       group_id,
+                       group_name,
+                       GROUP_CONCAT(student_id ORDER BY student_id) AS students,
+                       school_year
+                     FROM upload_student_group
+                     WHERE student_id IS NOT NULL AND batch_id = :batch_id
+                     GROUP BY group_id) AS loading
+                JOIN
+                (
+                  SELECT
+                    student_group_id,
+                    GROUP_CONCAT(student_id ORDER BY student_id) AS students
+                  FROM student_group_membership
+                  GROUP BY student_group_id
+                ) AS existing
+                  ON existing.student_group_id = loading.group_id
+              WHERE existing.students <> loading.students;
+
+          stage-user-change: >-
+            INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
+              SELECT
+                batch_id,
+                school_id,
+                concat(loading.group_name, loading.school_id, loading.school_year),
+                4
+              FROM (
+                     SELECT
+                       batch_id,
+                       school_id,
+                       group_id,
+                       group_name,
+                       GROUP_CONCAT(group_user_login ORDER BY group_user_login) AS users,
+                       school_year
+                     FROM
+                       (select DISTINCT batch_id, school_id, group_id, group_name, school_year, group_user_login from upload_student_group) u
+                     WHERE group_user_login IS NOT NULL AND batch_id = :batch_id
+                     GROUP BY group_id) AS loading
+                JOIN
+                (
+                  SELECT
+                    student_group_id,
+                    GROUP_CONCAT(user_login ORDER BY user_login) AS users
+                  FROM user_student_group
+                  GROUP BY student_group_id
+                ) AS existing
+                  ON existing.student_group_id = loading.group_id
+              WHERE existing.users <> loading.users;
+
+          stage-subject-change: >-
+            INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
+              SELECT
+              	loading.batch_id,
+              	loading.school_id,
+              	concat(loading.group_name, loading.school_id, loading.school_year),
+              	5
+              FROM (
+              	 SELECT
+              	   batch_id,
+              	   school_id,
+              	   group_id,
+              	   group_name,
+              	   subject_id,
+              	   school_year
+              	 FROM
+              	   (SELECT DISTINCT batch_id, school_id, group_id, group_name, school_year, subject_id from upload_student_group ORDER BY subject_id DESC) u
+              	 WHERE batch_id = :batch_id
+              	 GROUP BY group_id) AS loading
+              JOIN student_group sg
+                ON sg.id = loading.group_id
+              WHERE ifnull(sg.subject_id, -1) != ifnull(loading.subject_id, -1);
+
+          create-imports: >-
+            INSERT INTO import (status, content, contentType, digest, batch)
+              SELECT DISTINCT
+                0                           AS status,
+                5                           AS content,
+                'group batch'               AS contentType,
+                cast(school_id as CHAR(32)) AS digest,
+                cast(:batch_id AS CHAR(50)) AS batch
+              FROM upload_student_group_import sgl
+              WHERE ref_type IN (2, 3, 4, 5)
+                    AND batch_id = :batch_id
+
+          assign-imports: >-
+            UPDATE upload_student_group_import sgl
+              JOIN (SELECT
+                      id,
+                      cast(digest AS SIGNED INTEGER) AS school_id
+                    FROM import
+                    WHERE status = 0
+                          AND contentType = 'group batch'
+                          AND cast(batch AS UNSIGNED) = :batch_id) AS si
+            SET sgl.import_id = si.id
+            WHERE si.school_id = sgl.school_id
+                  AND sgl.ref_type IN (2, 3, 4, 5)
+                  AND sgl.batch_id = :batch_id
+
+          propagate-imports: >-
+            UPDATE upload_student_group sgl
+              JOIN (SELECT DISTINCT school_id, import_id
+                    FROM upload_student_group_import
+                    WHERE ref_type IN (2, 3, 4, 5) AND batch_id = :batch_id) i
+                ON sgl.school_id = i.school_id
+            SET sgl.import_id = i.import_id
+            WHERE sgl.batch_id = :batch_id
+
+          insert-missing: >-
+            INSERT IGNORE INTO student_group (name, school_id, active, school_year, subject_id, creator, import_id, update_import_id)
+              SELECT
+                sgl.group_name,
+                sgl.school_id,
+                1,
+                sgl.school_year,
+                sgl.subject_id,
+                sgl.creator,
+                sgl.import_id,
+                sgl.import_id
+              FROM upload_student_group sgl
+                LEFT JOIN student_group sg
+                  ON sgl.group_name = sg.name
+                  AND sgl.school_id = sg.school_id
+                  AND sgl.school_year = sg.school_year
+              WHERE sg.id IS NULL
+                    AND sgl.group_id IS NULL
+                    AND sgl.batch_id = :batch_id
+
+          update-deleted: >-
+            UPDATE student_group sg
+              JOIN upload_student_group sgl
+                ON sgl.school_id = sg.school_id
+                AND sgl.group_name = sg.name
+                AND sgl.school_year = sg.school_year
+            SET sg.deleted = 0,
+                sg.update_import_id = sgl.import_id
+            WHERE sg.deleted = 1
+                  AND sgl.batch_id = :batch_id
+
+          assign-imported-groups: >-
+            UPDATE upload_student_group sgl
+              JOIN student_group sg
+                ON sgl.group_name = sg.name
+                  AND sgl.school_year = sg.school_year
+                  AND sgl.school_id = sg.school_id
+            SET sgl.group_id = sg.id
+            WHERE sgl.group_id IS NULL
+                  AND batch_id = :batch_id
+
+          update-modified: >-
+            UPDATE student_group sg
+              JOIN (SELECT
+                      import_id,
+                      group_id,
+                      subject_id
+                    FROM
+                      (SELECT DISTINCT batch_id, school_id, group_id, group_name, school_year, subject_id, import_id from upload_student_group ORDER BY subject_id DESC) u
+                    WHERE import_id IS NOT NULL
+                          AND batch_id = :batch_id
+                    GROUP BY group_id) AS loading
+                ON sg.id = loading.group_id
+            SET sg.subject_id = loading.subject_id,
+              sg.update_import_id = loading.import_id
+            WHERE ifnull(sg.subject_id, -1) != ifnull(loading.subject_id, -1);
+
+          clear-updated-users: >-
+            DELETE users FROM user_student_group users
+              JOIN (SELECT DISTINCT
+                      group_id
+                    FROM upload_student_group upload
+                    WHERE upload.import_id IS NOT NULL
+                          AND upload.batch_id = :batch_id) updated
+                ON updated.group_id = users.student_group_id
+            WHERE users.student_group_id IS NOT NULL
+
+          add-updated-users: >-
+            INSERT INTO user_student_group (student_group_id, user_login)
+              SELECT
+                upload.group_id,
+                upload.group_user_login
+              FROM upload_student_group upload
+              WHERE upload.import_id IS NOT NULL
+                    AND upload.group_user_login IS NOT NULL
+                    AND upload.batch_id = :batch_id
+
+          clear-updated-students: >-
+            DELETE students FROM student_group_membership students
+              JOIN (SELECT DISTINCT
+                      group_id
+                    FROM upload_student_group upload
+                    WHERE upload.import_id IS NOT NULL
+                          AND upload.batch_id = :batch_id) updated
+                ON updated.group_id = students.student_group_id
+            WHERE students.student_group_id IS NOT NULL
+
+          add-updated-students: >-
+            INSERT INTO student_group_membership (student_group_id, student_id)
+              SELECT
+                upload.group_id,
+                upload.student_id
+              FROM upload_student_group upload
+              WHERE upload.import_id IS NOT NULL
+                    AND upload.student_id IS NOT NULL
+                    AND upload.batch_id = :batch_id
+
+          update-migration: >-
+            UPDATE import i
+              JOIN upload_student_group_import sgli ON sgli.import_id = i.id
+            SET i.status = :import_status
+            WHERE i.status = 0
+                  AND sgli.ref_type IN (2, 3, 4, 5)
+                  AND sgli.batch_id = :batch_id
+
+          clean-import-stage: >-
+            DELETE FROM upload_student_group_import
+            WHERE batch_id = :batch_id
+
+          clean-import-upload: >-
+            DELETE FROM upload_student_group
+            WHERE batch_id = :batch_id
 
       # ------------ Validate ------------------------------------------------------------------
       validate:

--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -249,7 +249,7 @@ sql:
               	 GROUP BY group_id) AS loading
               JOIN student_group sg
                 ON sg.id = loading.group_id
-              WHERE ifnull(sg.subject_id, -1) != ifnull(loading.subject_id, -1);
+              WHERE NOT sg.subject_id <=> loading.subject_id;
 
           create-imports: >-
             INSERT INTO import (status, content, contentType, digest, batch)
@@ -341,7 +341,7 @@ sql:
                 ON sg.id = loading.group_id
             SET sg.subject_id = loading.subject_id,
               sg.update_import_id = loading.import_id
-            WHERE ifnull(sg.subject_id, -1) != ifnull(loading.subject_id, -1);
+            WHERE NOT sg.subject_id <=> loading.subject_id;
 
           clear-updated-users: >-
             DELETE users FROM user_student_group users
@@ -398,11 +398,3 @@ sql:
           clean-import-upload: >-
             DELETE FROM upload_student_group
             WHERE batch_id = :batch_id
-
-      # ------------ Validate ------------------------------------------------------------------
-      validate:
-        sql:
-          invalid-school-exists: >-
-            SELECT 1 FROM upload_student_group WHERE school_id IS NULL AND batch_id = :batch_id LIMIT 1;
-          invalid-subject-exists: >-
-            SELECT 1 FROM upload_student_group WHERE subject_id IS NULL AND batch_id = :batch_id LIMIT 1;

--- a/group-processor/src/main/resources/application.yml
+++ b/group-processor/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
           group: default
 
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true
+    url: jdbc:mysql://localhost:3306/warehouse?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true&sessionVariables=group_concat_max_len=10000
     username: root
     password:
     testWhileIdle: true

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/RepositoryBackedConfig.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/RepositoryBackedConfig.java
@@ -1,0 +1,9 @@
+package org.opentestsystem.rdw.ingest.group;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableAutoConfiguration
+public class RepositoryBackedConfig {
+}

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/RepositoryBackedIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/RepositoryBackedIT.java
@@ -4,10 +4,10 @@ import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.group.configuration.DataSourceConfiguration;
 import org.opentestsystem.rdw.ingest.group.configuration.GroupProcessingSqlConfiguration;
 import org.opentestsystem.rdw.ingest.group.repository.JdbcSqlListExecutionRepository;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,13 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
  * test database.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@Transactional
-@Import({
+@SpringBootTest(classes = {
         DataSourceConfiguration.class,
         GroupProcessingSqlConfiguration.class,
-        JdbcSqlListExecutionRepository.class
+        JdbcSqlListExecutionRepository.class,
+        YamlPropertiesConfigurator.class
 })
+@ContextConfiguration(classes = {RepositoryBackedConfig.class})
+@Transactional
 @ActiveProfiles("test")
 public abstract class RepositoryBackedIT {
 

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportServiceIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportServiceIT.java
@@ -1,0 +1,275 @@
+package org.opentestsystem.rdw.ingest.group.service.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.group.RepositoryBackedIT;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(DefaultProcessingGroupImportService.class)
+@Sql(scripts = {
+        "classpath:WarehouseImportSetup.sql",
+        "classpath:WarehouseCodesSetup.sql",
+        "classpath:WarehouseEntitiesSetup.sql",
+        "classpath:WarehouseGroupImportServiceSetup.sql"
+})
+public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
+
+    @Autowired
+    public ProcessingGroupImportService service;
+
+    @Autowired
+    public NamedParameterJdbcTemplate template;
+
+    @Test
+    public void itShouldStageNewGroupsForImport() {
+        service.createImports(33);
+
+        final List<Map<String, Object>> imports = template.queryForList(
+                "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 2",
+                new HashMap<>());
+
+        //NOTE: This also stages the "deleted" groups for import
+        assertThat(imports).hasSize(3);
+        final List<Integer> schoolIds = imports.stream()
+                .map(record -> (int) record.get("school_id"))
+                .collect(Collectors.toList());
+        assertThat(schoolIds).containsOnly(-98, -1, -99);
+    }
+
+    @Test
+    public void itShouldStageGroupMembershipChangesForImport() {
+        service.createImports(33);
+
+        final List<Map<String, Object>> imports = template.queryForList(
+                "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 3",
+                new HashMap<>());
+
+        assertThat(imports).hasSize(2);
+        final List<Integer> schoolIds = imports.stream()
+                .map(record -> (int) record.get("school_id"))
+                .collect(Collectors.toList());
+        assertThat(schoolIds).containsOnly(-98, -1);
+    }
+
+    @Test
+    public void itShouldStageGroupUserChangesForImport() {
+        service.createImports(33);
+
+        final List<Map<String, Object>> imports = template.queryForList(
+                "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 4",
+                new HashMap<>());
+
+        assertThat(imports).hasSize(2);
+        final List<Integer> schoolIds = imports.stream()
+                .map(record -> (int) record.get("school_id"))
+                .collect(Collectors.toList());
+        assertThat(schoolIds).containsOnly(-98, -1);
+    }
+
+    @Test
+    public void itShouldStageGroupSubjectChangesForImport() {
+        service.createImports(33);
+
+        final List<Map<String, Object>> imports = template.queryForList(
+                "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 5",
+                new HashMap<>());
+
+        assertThat(imports).hasSize(1);
+        final List<Integer> schoolIds = imports.stream()
+                .map(record -> (int) record.get("school_id"))
+                .collect(Collectors.toList());
+        assertThat(schoolIds).containsOnly(-1);
+    }
+
+    @Test
+    public void itShouldCreateAnImportPerSchool() {
+        service.createImports(33);
+
+        final List<Map<String, Object>> imports = template.queryForList(
+                "SELECT * from import WHERE batch='33'",
+                new HashMap<>());
+
+        assertThat(imports).hasSize(3);
+        final List<Integer> schoolIds = imports.stream()
+                .map(record -> Integer.valueOf((String) record.get("digest")))
+                .collect(Collectors.toList());
+        assertThat(schoolIds).containsOnly(-1, -98, -99);
+    }
+
+    @Test
+    public void itShouldUpdateImportReferences() {
+        service.createImports(33);
+
+        final List<Map<String, Object>> records = template.queryForList(
+                "SELECT * from upload_student_group WHERE batch_id=33",
+                new HashMap<>());
+
+        final Map<Long, Integer> importToSchool = new HashMap<>();
+        records.forEach(row -> {
+                    final Long importId = (long) row.get("import_id");
+                    final Integer schoolId = (int) row.get("school_id");
+                    importToSchool.put(importId, schoolId);
+                });
+        assertThat(importToSchool.values()).containsOnly(-1, -98, -99);
+    }
+
+    @Test
+    public void itShouldInsertNewGroups() {
+        final List<Integer> existingGroups = template.queryForList(
+                "SELECT id from student_group",
+                new HashMap<>(),
+                Integer.class);
+
+        service.createImports(33);
+        service.insertMissingGroups(33);
+
+        final List<Map<String, Object>> newGroups = template.queryForList(
+                "SELECT * from student_group WHERE id NOT IN (:existing_groups)",
+                ImmutableMap.of("existing_groups", existingGroups));
+
+        assertThat(newGroups).hasSize(2);
+        final List<String> groupNames = newGroups.stream()
+                .map(record -> (String) record.get("name"))
+                .collect(Collectors.toList());
+        assertThat(groupNames).containsOnly("New Group 1", "New Group 2");
+    }
+
+    @Test
+    public void itShouldUpdateDeletedGroups() {
+        service.createImports(33);
+        service.insertMissingGroups(33);
+        service.updateDeletedGroups(33);
+
+        final Map<String, Object> deletedGroup = template.queryForMap(
+                "SELECT * from student_group WHERE name = 'Test Student Group 9 - updated school'",
+                new HashMap<>());
+
+        assertThat(deletedGroup.get("deleted")).isEqualTo(0);
+    }
+
+    @Test
+    public void itShouldAssignCreatedAndUnDeletedGroupIds() {
+        service.createImports(33);
+        service.insertMissingGroups(33);
+        service.updateDeletedGroups(33);
+        service.updateModifiedGroups(33);
+
+        final List<Map<String, Object>> noGroupId = template.queryForList(
+                "SELECT * from upload_student_group WHERE group_id IS NULL",
+                new HashMap<>());
+
+        assertThat(noGroupId).isEmpty();
+    }
+
+    @Test
+    public void itShouldUpdateModifiedGroupSubjects() {
+        service.createImports(33);
+        service.insertMissingGroups(33);
+        service.updateDeletedGroups(33);
+        service.updateModifiedGroups(33);
+
+        final Map<String, Object> modifiedGroup = template.queryForMap(
+                "SELECT * from student_group WHERE name = 'Test Student Group 8'",
+                new HashMap<>());
+
+        assertThat(modifiedGroup.get("subject_id")).isEqualTo(1);
+    }
+
+    @Test
+    public void itShouldUpdateModifiedGroupUsers() {
+        service.createImports(33);
+        service.insertMissingGroups(33);
+        service.updateDeletedGroups(33);
+        service.updateModifiedGroups(33);
+        service.updateModifiedGroupUsers(33);
+
+        final List<Map<String, Object>> group8Users = template.queryForList(
+                "SELECT * from user_student_group WHERE student_group_id = -8",
+                new HashMap<>());
+        assertThat(group8Users).hasSize(2);
+        assertThat(group8Users.stream().map(row -> row.get("user_login")))
+                .containsOnly("user1@somewhere.com", "user2@somewhere.com");
+
+        final List<Map<String, Object>> group7Users = template.queryForList(
+                "SELECT * from user_student_group WHERE student_group_id = -7",
+                new HashMap<>());
+        assertThat(group7Users).hasSize(1);
+        assertThat(group7Users.stream().map(row -> row.get("user_login")))
+                .containsOnly("user3@somewhere.com");
+
+        final List<Map<String, Object>> unchangedUsers = template.queryForList(
+                "SELECT * from user_student_group WHERE student_group_id = -6",
+                new HashMap<>());
+        assertThat(unchangedUsers).hasSize(2);
+        assertThat(unchangedUsers.stream().map(row -> row.get("user_login")))
+                .containsOnly("dwtest@example.com-6-1", "dwtest@example.com-6-2");
+    }
+
+    @Test
+    public void itShouldUpdateModifiedGroupStudents() {
+        service.createImports(33);
+        service.insertMissingGroups(33);
+        service.updateDeletedGroups(33);
+        service.updateModifiedGroups(33);
+        service.updateModifiedGroupUsers(33);
+        service.updateModifiedGroupStudents(33);
+
+        final List<Map<String, Object>> group8Students = template.queryForList(
+                "SELECT * from student_group_membership WHERE student_group_id = -8",
+                new HashMap<>());
+        assertThat(group8Students).hasSize(2);
+        assertThat(group8Students.stream().map(row -> row.get("student_id")))
+                .containsOnly(-88, -86);
+
+        final List<Map<String, Object>> group7Students = template.queryForList(
+                "SELECT * from student_group_membership WHERE student_group_id = -7",
+                new HashMap<>());
+        assertThat(group7Students).hasSize(1);
+        assertThat(group7Students.stream().map(row -> row.get("student_id")))
+                .containsOnly(-88);
+
+        final List<Map<String, Object>> unchangedUsers = template.queryForList(
+                "SELECT * from student_group_membership WHERE student_group_id = -6",
+                new HashMap<>());
+        assertThat(unchangedUsers).hasSize(3);
+        assertThat(unchangedUsers.stream().map(row -> row.get("student_id")))
+                .containsOnly(-87, -86, -33);
+    }
+
+    @Test
+    public void itShouldTriggerAMigration() {
+        service.createImports(33);
+        service.insertMissingGroups(33);
+        service.updateDeletedGroups(33);
+        service.updateModifiedGroups(33);
+        service.updateModifiedGroupUsers(33);
+        service.updateModifiedGroupStudents(33);
+
+        final List<Long> importIds = template.queryForList(
+                "SELECT DISTINCT import_id from upload_student_group WHERE batch_id = 33",
+                new HashMap<>(),
+                Long.class);
+
+        service.triggerImport(33);
+
+        final List<Map<String, Object>> imports = template.queryForList(
+                "SELECT * FROM import WHERE id IN (:import_ids)",
+                ImmutableMap.of("import_ids", importIds));
+
+        assertThat(imports).hasSize(3);
+        assertThat(imports.stream().map(row -> row.get("status")))
+                .containsOnly(1);
+    }
+
+}

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingReferenceServiceIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingReferenceServiceIT.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.SqlGroup;
 
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +33,7 @@ public class DefaultProcessingReferenceServiceIT extends RepositoryBackedIT {
         service.lookupBatchReferences(33);
 
         final List<Map<String, Object>> rows = template.queryForList(
-                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY name",
+                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY group_name",
                 new HashMap<>());
 
         assertThat(rows.size()).isEqualTo(2);
@@ -51,7 +50,7 @@ public class DefaultProcessingReferenceServiceIT extends RepositoryBackedIT {
         service.lookupBatchReferences(33);
 
         final List<Map<String, Object>> rows = template.queryForList(
-                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY name",
+                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY group_name",
                 new HashMap<>());
 
         assertThat(rows.size()).isEqualTo(2);
@@ -68,7 +67,7 @@ public class DefaultProcessingReferenceServiceIT extends RepositoryBackedIT {
         service.lookupBatchReferences(33);
 
         final List<Map<String, Object>> rows = template.queryForList(
-                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY name",
+                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY group_name",
                 new HashMap<>());
 
         assertThat(rows.size()).isEqualTo(2);

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingStandardizationServiceIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingStandardizationServiceIT.java
@@ -1,7 +1,6 @@
 package org.opentestsystem.rdw.ingest.group.service.impl;
 
 import org.junit.Test;
-import org.opentestsystem.rdw.ingest.common.repository.SqlListExecutionRepository;
 import org.opentestsystem.rdw.ingest.group.RepositoryBackedIT;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -25,7 +24,7 @@ public class DefaultProcessingStandardizationServiceIT extends RepositoryBackedI
 
     @Test
     @Sql(statements = {
-            "INSERT INTO upload_student_group (batch_id, name, school_year, school_natural_id, subject_code, student_ssid, group_user_login) VALUES" +
+            "INSERT INTO upload_student_group (batch_id, group_name, school_year, school_natural_id, subject_code, student_ssid, group_user_login) VALUES" +
             "   (33, 'group-a', 2017, 'school1', '', 'student1', '')," +
             "   (33, 'group-b', 2017, 'school1', 'ELA', '', 'user@somewhere.com')"
     })
@@ -33,7 +32,7 @@ public class DefaultProcessingStandardizationServiceIT extends RepositoryBackedI
         service.standardizeBatch(33);
 
         final List<Map<String, Object>> rows = template.queryForList(
-                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY name",
+                "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY group_name",
                 new HashMap<>());
 
         assertThat(rows.size()).isEqualTo(2);

--- a/group-processor/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/group-processor/src/test/resources/WarehouseEntitiesSetup.sql
@@ -69,7 +69,8 @@ INSERT INTO warehouse_test.student_ethnicity(student_id, ethnicity_id) values
 INSERT INTO warehouse_test.student_group (id, creator, school_id, school_year, name, subject_id, import_id, update_import_id, active, deleted, created, updated) VALUES
   (-91, 'dwtest@example.com', -99, 2017, 'Test Student Group 9 - updated school', null, -5000, -79, 1, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:10:34.966000'),
   (-8, 'dwtest@example.com', -1, 2017, 'Test Student Group 8', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
-  (-7, 'dwtest@example.com', -98, 2017, 'Test Student Group 7', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000');
+  (-7, 'dwtest@example.com', -98, 2017, 'Test Student Group 7', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
+  (-6, 'dwtest@example.com', -1, 2017, 'Test Student Group 6', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000');
 
 INSERT INTO warehouse_test.student_group_membership (student_group_id, student_id) VALUES
   (-91, -89),
@@ -79,13 +80,18 @@ INSERT INTO warehouse_test.student_group_membership (student_group_id, student_i
   (-8, -87),
   (-7, -87),
   (-7, -86),
-  (-7, -33);
+  (-7, -33),
+  (-6, -87),
+  (-6, -86),
+  (-6, -33);
 
 INSERT INTO warehouse_test.user_student_group (student_group_id, user_login) VALUES
   (-91, 'dwtest@example.com-91'),
   (-8, 'dwtest@example.com-8'),
   (-7, 'dwtest@example.com-7'),
-  (-91, 'dwtest@example.com-91-2');
+  (-91, 'dwtest@example.com-91-2'),
+  (-6, 'dwtest@example.com-6-1'),
+  (-6, 'dwtest@example.com-6-2');
 
 
 INSERT INTO warehouse_test.exam_student ( id, grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage,

--- a/group-processor/src/test/resources/WarehouseGroupImportServiceSetup.sql
+++ b/group-processor/src/test/resources/WarehouseGroupImportServiceSetup.sql
@@ -1,0 +1,17 @@
+INSERT INTO upload_student_group (batch_id, group_name, school_year, school_natural_id, school_id, student_ssid, student_id, group_id, group_user_login, subject_id) VALUES
+  -- New Groups
+  (33, 'New Group 1', 2017, 'natural_id-1', -1, '88', -88, null, null, null),
+  (33, 'New Group 1', 2017, 'natural_id-1', -1, '86', -86, null, null, null),
+  (33, 'New Group 2', 2017, 'natural_id-98', -98, '88', -88, null, null, null),
+  -- Membership change groups
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, '88', -88, -8, null, null),
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, '86', -86, -8, null, null),
+  (33, 'Test Student Group 7', 2017, 'natural_id-98', -98, '88', -88, -7, null, null),
+  -- User change groups
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, null, null, -8, 'user1@somewhere.com', null),
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, null, null, -8, 'user2@somewhere.com', null),
+  (33, 'Test Student Group 7', 2017, 'natural_id-98', -98, null, null, -7, 'user3@somewhere.com', null),
+  -- Subject change group
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, null, null, -8, null, 1),
+  -- Deleted group
+  (33, 'Test Student Group 9 - updated school', 2017, 'natural_id-99', -99, null, null, null, null, null);

--- a/group-processor/src/test/resources/WarehouseReferenceServiceSetup.sql
+++ b/group-processor/src/test/resources/WarehouseReferenceServiceSetup.sql
@@ -1,3 +1,3 @@
-INSERT INTO upload_student_group (batch_id, name, school_year, school_natural_id, student_ssid) VALUES
+INSERT INTO upload_student_group (batch_id, group_name, school_year, school_natural_id, student_ssid) VALUES
   (33, 'Test Student Group 8', 2017, 'natural_id-1', '88'),
   (33, 'Test Student Group 7', 2017, 'natural_id-98', '87');

--- a/group-processor/src/test/resources/WarehouseUserImportServiceSetup.sql
+++ b/group-processor/src/test/resources/WarehouseUserImportServiceSetup.sql
@@ -1,4 +1,4 @@
-INSERT INTO upload_student_group (batch_id, name, school_year, school_natural_id, school_id, student_ssid, student_id) VALUES
+INSERT INTO upload_student_group (batch_id, group_name, school_year, school_natural_id, school_id, student_ssid, student_id) VALUES
   -- Existing Student
   (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, '88', -88),
   -- No student

--- a/group-processor/src/test/resources/application-test.yml
+++ b/group-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true
+    url: jdbc:mysql://localhost:3306/warehouse_test?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8&rewriteBatchedStatements=true&sessionVariables=group_concat_max_len=10000


### PR DESCRIPTION
This PR is step 2 for ingesting groups.

It follows the same pattern as ingesting group students:
1. stage groups that need to be imported/modified
2. create import records for modified groups, chunked by school
3. make the student_group, user_student_group, and student_group_membership tables match the declarations
4. trigger the import and clean up