### PR TITLE
fix build

### DIFF
--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -241,10 +241,10 @@ sql:
               	   school_id,
               	   group_id,
               	   group_name,
-              	   subject_id,
+              	   MAX(subject_id) as subject_id,
               	   school_year
               	 FROM
-              	   (SELECT DISTINCT batch_id, school_id, group_id, group_name, school_year, subject_id from upload_student_group ORDER BY ISNULL(subject_id), subject_id) u
+              	   (SELECT DISTINCT batch_id, school_id, group_id, group_name, school_year, subject_id from upload_student_group) u
               	 WHERE batch_id = :batch_id
               	 GROUP BY group_id) AS loading
               JOIN student_group sg
@@ -332,16 +332,16 @@ sql:
               JOIN (SELECT
                       import_id,
                       group_id,
-                      subject_id
+                      MAX(subject_id) as subject_id
                     FROM
-                      (SELECT DISTINCT batch_id, school_id, group_id, group_name, school_year, subject_id, import_id from upload_student_group ORDER BY ISNULL(subject_id), subject_id DESC) u
+                      (SELECT DISTINCT batch_id, group_id, subject_id, import_id from upload_student_group) u
                     WHERE import_id IS NOT NULL
                           AND batch_id = :batch_id
                     GROUP BY group_id) AS loading
                 ON sg.id = loading.group_id
             SET sg.subject_id = loading.subject_id,
               sg.update_import_id = loading.import_id
-            WHERE NOT sg.subject_id <=> loading.subject_id;
+            WHERE NOT sg.subject_id <=> loading.subject_id
 
           clear-updated-users: >-
             DELETE users FROM user_student_group users


### PR DESCRIPTION
Although the "order by" worked every time on my local box, the TeamCity build server regularly failed to find the first non-null subject-id for a group.  Switched to a MAX call. 