### PR TITLE
Feature/add group upload status update

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportStatus.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportStatus.java
@@ -10,6 +10,7 @@ package org.opentestsystem.rdw.ingest.common.model;
  * </p>
  */
 public enum ImportStatus {
+    FAILED(-7),
     UNKNOWN_SCHOOL(-6),
     UNKNOWN_ASMT(-5),
     UNAUTHORIZED(-4),

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportStatus.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/ImportStatus.java
@@ -10,7 +10,6 @@ package org.opentestsystem.rdw.ingest.common.model;
  * </p>
  */
 public enum ImportStatus {
-    FAILED(-7),
     UNKNOWN_SCHOOL(-6),
     UNKNOWN_ASMT(-5),
     UNAUTHORIZED(-4),

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfiguration.java
@@ -2,6 +2,8 @@ package org.opentestsystem.rdw.ingest.group;
 
 import com.google.gson.Gson;
 import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.group.repository.StudentGroupBatchRepository;
 import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.slf4j.Logger;
@@ -21,28 +23,38 @@ public class GroupProcessorConfiguration {
     private static final Logger logger = LoggerFactory.getLogger(GroupProcessorConfiguration.class);
 
     private final GroupProcessor groupProcessor;
+    private final StudentGroupBatchRepository groupBatchRepository;
 
     @Autowired
-    public GroupProcessorConfiguration(final GroupProcessor groupProcessor) {
+    public GroupProcessorConfiguration(final GroupProcessor groupProcessor,
+                                       final StudentGroupBatchRepository groupBatchRepository) {
         this.groupProcessor = groupProcessor;
+        this.groupBatchRepository = groupBatchRepository;
     }
 
     @ServiceActivator(inputChannel = Processor.INPUT)
     public void process(final Message<?> message) {
-
-        final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
-        //payload should be a json object
-        final String payload = new String((byte[]) message.getPayload(), StandardCharsets.UTF_8);
-
-        logger.info("received " + accessor.getContent());
-
-        logger.info("Received payload: " + (payload.length() > 80 ? payload.substring(0, 80) + "..." : payload));
-
+        RdwMessageHeaderAccessor accessor = null;
         try {
-            GroupMessage gm = new Gson().fromJson(payload, GroupMessage.class);
+            //payload should be a json object
+            accessor = RdwMessageHeaderAccessor.wrap(message);
+            final String payload = new String((byte[]) message.getPayload(), StandardCharsets.UTF_8);
+
+            logger.info("received " + accessor.getContent());
+
+            logger.info("Received payload: " + (payload.length() > 80 ? payload.substring(0, 80) + "..." : payload));
+
+            final GroupMessage gm = new Gson().fromJson(payload, GroupMessage.class);
             groupProcessor.process(gm);
         } catch (final Exception e) {
             logger.error("failed with an unexpected import error: " + e.getMessage());
+            if (accessor != null) {
+                try {
+                    groupBatchRepository.updateBatchStatus(accessor.getImportId(), ImportStatus.FAILED, e.getMessage());
+                } catch (final Exception e2) {
+                    logger.error("Failed to update batch status: {}", accessor.getImportId());
+                }
+            }
         }
     }
 

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfiguration.java
@@ -50,7 +50,7 @@ public class GroupProcessorConfiguration {
             logger.error("failed with an unexpected import error: " + e.getMessage());
             if (accessor != null) {
                 try {
-                    groupBatchRepository.updateBatchStatus(accessor.getImportId(), ImportStatus.FAILED, e.getMessage());
+                    groupBatchRepository.updateBatchStatus(accessor.getImportId(), ImportStatus.INVALID, e.getMessage());
                 } catch (final Exception e2) {
                     logger.error("Failed to update batch status: {}", accessor.getImportId());
                 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepository.java
@@ -1,0 +1,35 @@
+package org.opentestsystem.rdw.ingest.group.repository;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * JDBC-backed implementation of a StudentGroupBatchRepository
+ */
+@Repository
+public class JdbcStudentGroupBatchRepository implements StudentGroupBatchRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.update-batch}")
+    public String updateBatch;
+
+    @Autowired
+    public JdbcStudentGroupBatchRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public void updateBatchStatus(final long batchId, final ImportStatus status, final String message) {
+        template.update(
+                updateBatch,
+                ImmutableMap.of(
+                        "batch_id", batchId,
+                        "status", status.getValue(),
+                        "message", message));
+    }
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/StudentGroupBatchRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/StudentGroupBatchRepository.java
@@ -1,0 +1,19 @@
+package org.opentestsystem.rdw.ingest.group.repository;
+
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+
+/**
+ * Implementations of this interface are responsible for working with student group
+ * upload batches.
+ */
+public interface StudentGroupBatchRepository {
+
+    /**
+     * Update a student group batch upload status
+     *
+     * @param batchId   The batch id
+     * @param status    The batch import status
+     * @param message   The batch message
+     */
+    void updateBatchStatus(long batchId, ImportStatus status, String message);
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
@@ -1,6 +1,8 @@
 package org.opentestsystem.rdw.ingest.group.service.impl;
 
 import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.group.repository.StudentGroupBatchRepository;
 import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingLoadService;
@@ -21,18 +23,21 @@ public class DefaultGroupProcessor implements GroupProcessor {
     private final ProcessingUserImportService userImportService;
     private final ProcessingLoadService loadService;
     private final ProcessingGroupImportService groupImportService;
+    private final StudentGroupBatchRepository groupBatchRepository;
 
     @Autowired
     public DefaultGroupProcessor(final ProcessingStandardizationService standardizationService,
                                  final ProcessingReferenceService referenceService,
                                  final ProcessingUserImportService userImportService,
                                  final ProcessingLoadService loadService,
-                                 final ProcessingGroupImportService groupImportService) {
+                                 final ProcessingGroupImportService groupImportService,
+                                 final StudentGroupBatchRepository batchRepository) {
         this.standardizationService = standardizationService;
         this.referenceService = referenceService;
         this.userImportService = userImportService;
         this.loadService = loadService;
         this.groupImportService = groupImportService;
+        this.groupBatchRepository = batchRepository;
     }
 
     /**
@@ -50,12 +55,6 @@ public class DefaultGroupProcessor implements GroupProcessor {
         final long batchId = message.getUploadId();
         try {
             loadService.loadBatch(message.getDigest(), batchId);
-        } catch (final Exception e) {
-            logger.error("Problem loading data for: {}", message.getDigest(), e);
-            return;
-        }
-
-        try {
             standardizationService.standardizeBatch(batchId);
             referenceService.lookupBatchReferences(batchId);
             userImportService.createImports(batchId);
@@ -69,9 +68,15 @@ public class DefaultGroupProcessor implements GroupProcessor {
             groupImportService.updateModifiedGroupUsers(batchId);
             groupImportService.updateModifiedGroupStudents(batchId);
             groupImportService.triggerImport(batchId);
+            updateBatch(batchId, ImportStatus.PROCESSED, "");
         } catch (final Exception e) {
             logger.error("Problem processing batch: {}", batchId, e);
+            updateBatch(batchId, ImportStatus.FAILED, e.getMessage());
         }
+    }
+
+    private void updateBatch(final long batchId, final ImportStatus status, final String message) {
+        groupBatchRepository.updateBatchStatus(batchId, status, message);
     }
 
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
@@ -71,7 +71,7 @@ public class DefaultGroupProcessor implements GroupProcessor {
             updateBatch(batchId, ImportStatus.PROCESSED, "");
         } catch (final Exception e) {
             logger.error("Problem processing batch: {}", batchId, e);
-            updateBatch(batchId, ImportStatus.FAILED, e.getMessage());
+            updateBatch(batchId, ImportStatus.INVALID, e.getMessage());
         }
     }
 

--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -1,4 +1,11 @@
 sql:
+
+  update-batch: >-
+    UPDATE upload_student_group_batch
+    SET status = :status,
+      message = :message
+    WHERE id = :batch_id
+
   process-batch:
     entities:
       # ------------ Standardize NULLS

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfigurationTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfigurationTest.java
@@ -1,9 +1,13 @@
 package org.opentestsystem.rdw.ingest.group;
 
-import com.google.gson.Gson;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.group.repository.StudentGroupBatchRepository;
 import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.springframework.http.MediaType;
@@ -15,25 +19,27 @@ import java.io.UnsupportedEncodingException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(MockitoJUnitRunner.class)
 public class GroupProcessorConfigurationTest {
 
+    @Mock
+    public GroupProcessor groupProcessor;
 
-    private GroupProcessorConfiguration processor;
-    private GroupProcessor groupProcessor;
+    @Mock
+    public StudentGroupBatchRepository repository;
+
     private Message message;
     private GroupMessage groupMessage;
+    private GroupProcessorConfiguration processor;
 
     @Before
     public void createProcessor() throws IOException {
-        RdwMessageHeaderAccessor accessor;
-        groupProcessor = mock(GroupProcessor.class);
-        processor = new GroupProcessorConfiguration(groupProcessor);
+        processor = new GroupProcessorConfiguration(groupProcessor, repository);
         groupMessage = GroupMessage.builder().digest("abcdef").uploadId(1L).build();
-        accessor = RdwMessageHeaderAccessor.wrap(null);
+        final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(null);
         accessor.setContentType(MediaType.APPLICATION_JSON);
 
         message = new GenericMessage(groupMessage.toJson().getBytes("UTF-8"), accessor.getMessageHeaders());
@@ -50,11 +56,23 @@ public class GroupProcessorConfigurationTest {
 
     @Test
     public void itShouldHandleAnyException() throws UnsupportedEncodingException {
-
         doThrow(new RuntimeException("any message")).when(groupProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
         verify(groupProcessor, times(1)).process(groupMessage);
+    }
+
+    @Test
+    public void itShouldUpdateBatchStatusOnExceptionIfIdIsKnown() throws Exception {
+        final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(null);
+        accessor.setContentType(MediaType.APPLICATION_JSON);
+        accessor.setImportId(123L);
+        message = new GenericMessage(groupMessage.toJson().getBytes("UTF-8"), accessor.getMessageHeaders());
+
+        doThrow(new RuntimeException("any message")).when(groupProcessor).process(any(GroupMessage.class));
+        processor.process(message);
+
+        verify(repository).updateBatchStatus(123L, ImportStatus.FAILED, "any message");
     }
 
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfigurationTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfigurationTest.java
@@ -72,7 +72,7 @@ public class GroupProcessorConfigurationTest {
         doThrow(new RuntimeException("any message")).when(groupProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
-        verify(repository).updateBatchStatus(123L, ImportStatus.FAILED, "any message");
+        verify(repository).updateBatchStatus(123L, ImportStatus.INVALID, "any message");
     }
 
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepositoryIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepositoryIT.java
@@ -30,13 +30,13 @@ public class JdbcStudentGroupBatchRepositoryIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateBatchStatusAndMessage() {
-        repository.updateBatchStatus(33, ImportStatus.FAILED, "some message");
+        repository.updateBatchStatus(33, ImportStatus.INVALID, "some message");
 
         final Map<String, Object> batch = template.queryForMap(
                 "SELECT * from upload_student_group_batch WHERE id = 33",
                 new HashMap<>());
 
-        assertThat(batch.get("status")).isEqualTo(ImportStatus.FAILED.getValue());
+        assertThat(batch.get("status")).isEqualTo(ImportStatus.INVALID.getValue());
         assertThat(batch.get("message")).isEqualTo("some message");
     }
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepositoryIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepositoryIT.java
@@ -1,0 +1,42 @@
+package org.opentestsystem.rdw.ingest.group.repository;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.group.RepositoryBackedIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(JdbcStudentGroupBatchRepository.class)
+@Sql(scripts = {
+        "classpath:WarehouseImportSetup.sql",
+        "classpath:WarehouseCodesSetup.sql",
+        "classpath:WarehouseEntitiesSetup.sql",
+        "classpath:WarehouseBatchRepositorySetup.sql"
+})
+public class JdbcStudentGroupBatchRepositoryIT extends RepositoryBackedIT {
+
+    @Autowired
+    public StudentGroupBatchRepository repository;
+
+    @Autowired
+    public NamedParameterJdbcTemplate template;
+
+    @Test
+    public void itShouldUpdateBatchStatusAndMessage() {
+        repository.updateBatchStatus(33, ImportStatus.FAILED, "some message");
+
+        final Map<String, Object> batch = template.queryForMap(
+                "SELECT * from upload_student_group_batch WHERE id = 33",
+                new HashMap<>());
+
+        assertThat(batch.get("status")).isEqualTo(ImportStatus.FAILED.getValue());
+        assertThat(batch.get("message")).isEqualTo("some message");
+    }
+}

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessorTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessorTest.java
@@ -1,0 +1,100 @@
+package org.opentestsystem.rdw.ingest.group.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
+import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.group.repository.StudentGroupBatchRepository;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingLoadService;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingReferenceService;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingStandardizationService;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultGroupProcessorTest {
+
+    @Mock
+    public ProcessingStandardizationService standardizationService;
+
+    @Mock
+    public ProcessingReferenceService referenceService;
+
+    @Mock
+    public ProcessingUserImportService userImportService;
+
+    @Mock
+    public ProcessingLoadService loadService;
+
+    @Mock
+    public ProcessingGroupImportService groupImportService;
+
+    @Mock
+    public StudentGroupBatchRepository groupBatchRepository;
+
+    private GroupMessage message;
+    private DefaultGroupProcessor processor;
+
+    @Before
+    public void setup() {
+        processor = new DefaultGroupProcessor(standardizationService, referenceService, userImportService, loadService, groupImportService, groupBatchRepository);
+
+        message = GroupMessage.builder()
+                .digest("ABCD")
+                .uploadId(123L)
+                .build();
+    }
+
+    @Test
+    public void itShouldCallServiceMethodsInOrder() {
+
+        processor.process(message);
+
+        final InOrder inOrder = inOrder(loadService, standardizationService, referenceService, userImportService, groupImportService, groupBatchRepository);
+
+        final long batchId = message.getUploadId();
+        inOrder.verify(loadService).loadBatch(eq(message.getDigest()), eq(batchId));
+
+        inOrder.verify(standardizationService).standardizeBatch(batchId);
+
+        inOrder.verify(referenceService).lookupBatchReferences(batchId);
+
+        inOrder.verify(userImportService).createImports(batchId);
+        inOrder.verify(userImportService).insertMissingStudents(batchId);
+        inOrder.verify(userImportService).updateDeletedStudents(batchId);
+        inOrder.verify(userImportService).triggerImport(batchId);
+
+        inOrder.verify(groupImportService).createImports(batchId);
+        inOrder.verify(groupImportService).insertMissingGroups(batchId);
+        inOrder.verify(groupImportService).updateDeletedGroups(batchId);
+        inOrder.verify(groupImportService).updateModifiedGroups(batchId);
+        inOrder.verify(groupImportService).updateModifiedGroupUsers(batchId);
+        inOrder.verify(groupImportService).updateModifiedGroupStudents(batchId);
+        inOrder.verify(groupImportService).triggerImport(batchId);
+
+        inOrder.verify(groupBatchRepository).updateBatchStatus(batchId, ImportStatus.PROCESSED, "");
+    }
+
+    @Test
+    public void itShouldHandleAProcessingErrorAndMarkBatchAsFailed() {
+        doThrow(new RuntimeException("Bad juju"))
+                .when(loadService).loadBatch(anyString(), anyLong());
+
+        processor.process(message);
+
+        final long batchId = message.getUploadId();
+        verify(groupBatchRepository).updateBatchStatus(batchId, ImportStatus.FAILED, "Bad juju");
+    }
+
+}

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessorTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessorTest.java
@@ -94,7 +94,7 @@ public class DefaultGroupProcessorTest {
         processor.process(message);
 
         final long batchId = message.getUploadId();
-        verify(groupBatchRepository).updateBatchStatus(batchId, ImportStatus.FAILED, "Bad juju");
+        verify(groupBatchRepository).updateBatchStatus(batchId, ImportStatus.INVALID, "Bad juju");
     }
 
 }

--- a/group-processor/src/test/resources/WarehouseBatchRepositorySetup.sql
+++ b/group-processor/src/test/resources/WarehouseBatchRepositorySetup.sql
@@ -1,0 +1,2 @@
+INSERT INTO upload_student_group_batch (id, digest, status, creator, message, filename) VALUES
+  (33, 'ABCDEF', 0, 'someone@somewhere.com', '', 'some-file.csv');


### PR DESCRIPTION
Currently, once the user has uploaded a CSV they are not sure if or when the upload has been processed.  This PR updates the group-processor to update the batch status from ACCEPTED to either INVALID on failure or PROCESSED on completion.
If INVALID, the exception message is set as the batch message.