### PR TITLE
add actuator end-points for triggering tasks

### DIFF
--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/ReconciliationReportConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/ReconciliationReportConfiguration.java
@@ -14,7 +14,10 @@ import org.opentestsystem.rdw.ingest.tasking.status.ReconciliationReportStatusIn
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.endpoint.GenericPostableMvcEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -118,10 +121,28 @@ public class ReconciliationReportConfiguration {
         return new ReconciliationReportStatusIndicator(reportRepository, reportSenders);
     }
 
+    /**
+     * Bean for actuator end-point to manually trigger reconciliation report task.
+     * It supports POST instead of GET, e.g.:<pre>
+     * curl -X POST http://localhost:8008/reconciliationReport
+     * </pre>
+     *
+     * @param reconciliationService service
+     * @param reportSenders senders
+     * @param query import query
+     * @return reconciliation report end-point
+     */
+    @Bean
+    public MvcEndpoint reconciliationReportEndpoint(
+            final ReconciliationService reconciliationService,
+            final List<ReportSender> reportSenders,
+            @Value("${task.send-reconciliation-report.query}") final String query) {
+        return new GenericPostableMvcEndpoint(
+                new ReconciliationReportEndpoint(reconciliationService, reportSenders, RdwImportQuery.builder().params(query).build()));
+    }
+
 
     static class ReconciliationReportTask {
-        private static final Logger logger = LoggerFactory.getLogger(ReconciliationReportTask.class);
-
         private final ReconciliationService reconciliationService;
         private final List<ReportSender> senders;
         private final RdwImportQuery query;
@@ -142,6 +163,33 @@ public class ReconciliationReportConfiguration {
                 logger.debug("Scheduled task completed: Send Reconciliation Report");
             } catch (final Exception e) {
                 logger.warn("Error sending reconciliation report", e);
+            }
+        }
+    }
+
+    static class ReconciliationReportEndpoint extends AbstractEndpoint<Boolean> {
+        private final ReconciliationService reconciliationService;
+        private final List<ReportSender> senders;
+        private final RdwImportQuery query;
+
+        ReconciliationReportEndpoint(final ReconciliationService reconciliationService,
+                                     final List<ReportSender> senders,
+                                     final RdwImportQuery query) {
+            super("reconciliationReport", true, true);
+            this.reconciliationService = reconciliationService;
+            this.senders = senders;
+            this.query = query;
+        }
+
+        @Override
+        public Boolean invoke() {
+            try {
+                logger.info("Manual task triggered: Send Reconciliation Report");
+                reconciliationService.sendReport(query, senders);
+                return true;
+            } catch (final Exception e) {
+                logger.warn("Error sending reconciliation report", e);
+                return false;
             }
         }
     }

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/UpdateOrganizationsConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/UpdateOrganizationsConfiguration.java
@@ -13,7 +13,10 @@ import org.opentestsystem.rdw.ingest.tasking.status.UpdateOrganizationsStatusInd
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.endpoint.GenericPostableMvcEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -37,7 +40,15 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @Configuration
 @ConditionalOnProperty(prefix = "task.update-organizations", name = { "cron", "state" })
 public class UpdateOrganizationsConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(UpdateOrganizationsConfiguration.class);
 
+    /**
+     * Bean for the main update organizations task.
+     *
+     * @param updateOrganizationsService service
+     * @param organizationState state, e.g. "CA"
+     * @return update organizations task
+     */
     @Bean
     public UpdateOrganizationsTask updateOrganizationsTask(
             final UpdateOrganizationsService updateOrganizationsService,
@@ -70,6 +81,13 @@ public class UpdateOrganizationsConfiguration {
         return new RestImportServiceClient(restTemplate, properties);
     }
 
+    /**
+     * Bean for indicator that adds task info to the status end-point.
+     *
+     * @param organizationRepository organization repo
+     * @param importServiceClient import service client
+     * @return update organizations task status indicator
+     */
     @Bean
     public UpdateOrganizationsStatusIndicator updateOrganizationsStatusIndicator(
             final OrganizationRepository organizationRepository,
@@ -77,9 +95,25 @@ public class UpdateOrganizationsConfiguration {
         return new UpdateOrganizationsStatusIndicator(organizationRepository, importServiceClient);
     }
 
-    static class UpdateOrganizationsTask {
-        private static final Logger logger = LoggerFactory.getLogger(UpdateOrganizationsTask.class);
+    /**
+     * Bean for actuator end-point to manually trigger update organizations task.
+     * It supports POST instead of GET, e.g.:<pre>
+     * curl -X POST http://localhost:8008/updateOrganizations
+     * </pre>
+     *
+     * @param updateOrganizationsService service
+     * @param organizationState state, e.g. "CA"
+     * @return update organizations end-point
+     */
+    @Bean
+    public MvcEndpoint updateOrganizationsEndpoint(
+            final UpdateOrganizationsService updateOrganizationsService,
+            @Value("${task.update-organizations.state}") final String organizationState) {
+        return new GenericPostableMvcEndpoint(
+                new UpdateOrganizationsEndpoint(updateOrganizationsService, organizationState));
+    }
 
+    static class UpdateOrganizationsTask {
         private final UpdateOrganizationsService updateOrganizationsService;
         private final String organizationState;
 
@@ -93,6 +127,25 @@ public class UpdateOrganizationsConfiguration {
             logger.info("Scheduled task triggered: Update Organizations");
             updateOrganizationsService.doUpdate(organizationState);
             logger.debug("Scheduled task completed: Update Organizations");
+        }
+    }
+
+    static class UpdateOrganizationsEndpoint extends AbstractEndpoint<Boolean> {
+        private final UpdateOrganizationsService updateOrganizationsService;
+        private final String organizationState;
+
+        UpdateOrganizationsEndpoint(final UpdateOrganizationsService updateOrganizationsService,
+                                    final String organizationState) {
+            super("updateOrganizations", true, true);
+            this.updateOrganizationsService = updateOrganizationsService;
+            this.organizationState = organizationState;
+        }
+
+        @Override
+        public Boolean invoke() {
+            logger.info("Manual task triggered: Update Organizations");
+            updateOrganizationsService.doUpdate(organizationState);
+            return true;
         }
     }
 }

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -66,7 +66,7 @@ task:
 #    cron: 0 0 4 * * *
 #    state: CA
 #    art-client:
-#      districts-url: https://art-deployment.sbtds.org/rest/district?stateAbbreviation={state}
+#      districts-url: https://art-deployment.sbtds.org/rest/district?stateAbbreviation={state}&pageSize=5000
 #      groups-of-schools-url: https://art-deployment.sbtds.org/rest/groupofinstitution?stateAbbreviation={state}&pageSize=1000
 #      schools-url: https://art-deployment.sbtds.org/rest/institution?stateAbbreviation={state}&pageSize=20000
 #      status-url: https://art-deployment.sbtds.org/rest/status


### PR DESCRIPTION
During deployment there were a number of times that i wanted to trigger the tasks to test configuration. I had to resort to changing the configuration file (setting cron to every 5 minutes or something), pushing the config changes, waiting, reverting the config changes. 

This lets a client post to actuator end-points to trigger a task.