### PR TITLE
DWR-932 Spread group processor imports over time

### DIFF
--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcSchoolBatchRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcSchoolBatchRepository.java
@@ -1,0 +1,36 @@
+package org.opentestsystem.rdw.ingest.group.repository;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+/**
+ * JDBC-backed implementation of a SchoolBatchRepository.
+ */
+@Repository
+public class JdbcSchoolBatchRepository implements SchoolBatchRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.find-schools-by-batch}")
+    public String findSchoolsByBatch;
+
+    @Autowired
+    public JdbcSchoolBatchRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public Set<Integer> findSchoolIdsForBatch(final long batchId) {
+        return newHashSet(template.queryForList(
+                findSchoolsByBatch,
+                ImmutableMap.of("batch_id", batchId),
+                Integer.class));
+    }
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/SchoolBatchRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/SchoolBatchRepository.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.ingest.group.repository;
+
+import java.util.Set;
+
+/**
+ * Implementations of this interface are responsible for finding
+ * schools referenced by student group batches.
+ */
+public interface SchoolBatchRepository {
+
+    /**
+     * Find all school ids referenced by the given batch.
+     *
+     * @param batchId The batch id
+     * @return  All school ids referenced by the batch
+     */
+    Set<Integer> findSchoolIdsForBatch(long batchId);
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/BatchingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/BatchingGroupImportService.java
@@ -1,0 +1,17 @@
+package org.opentestsystem.rdw.ingest.group.service;
+
+/**
+ * Implementations of this interface are responsible for processing groups
+ * for a given Group Batch upload.  Imports should be batched into reasonable-
+ * sized Imports spread across time such that a single Import does not
+ * migrate all modified/imported groups.
+ */
+public interface BatchingGroupImportService {
+
+    /**
+     * Process groups for the given batch.
+     *
+     * @param batchId The batch id
+     */
+    void processBatch(long batchId);
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/BatchingUserImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/BatchingUserImportService.java
@@ -1,0 +1,17 @@
+package org.opentestsystem.rdw.ingest.group.service;
+
+/**
+ * Implementations of this interface are responsible for processing users
+ * for a given Group Batch upload.  Imports should be batched into reasonable-
+ * sized Imports spread across time such that a single Import does not
+ * migrate all modified/imported users.
+ */
+public interface BatchingUserImportService {
+
+    /**
+     * Process users for the given batch.
+     *
+     * @param batchId The batch id
+     */
+    void processBatch(long batchId);
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/ProcessingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/ProcessingGroupImportService.java
@@ -3,16 +3,18 @@ package org.opentestsystem.rdw.ingest.group.service;
 /**
  * Implementations of this interface are responsible for creating and importing student groups
  * while processing a group definition import.
+ * NOTE that this service is designed to be iteratively by school followed by a final cleanup call
  *
  * The service is designed to be executed as an ordered flow to support transaction boundaries:
  * <ol>
- *     <li>{@link #createImports(long)}</li>
- *     <li>{@link #insertMissingGroups(long)}</li>
- *     <li>{@link #updateDeletedGroups(long)}</li>
- *     <li>{@link #updateModifiedGroups(long)}</li>
- *     <li>{@link #updateModifiedGroupUsers(long)}</li>
- *     <li>{@link #updateModifiedGroupStudents(long)}</li>
- *     <li>{@link #triggerImport(long)}</li>
+ *     <li>{@link #createImports(long, int)}</li>
+ *     <li>{@link #insertMissingGroups(long, int)}</li>
+ *     <li>{@link #updateDeletedGroups(long, int)}</li>
+ *     <li>{@link #updateModifiedGroups(long, int)}</li>
+ *     <li>{@link #updateModifiedGroupUsers(long, int)}</li>
+ *     <li>{@link #updateModifiedGroupStudents(long, int)}</li>
+ *     <li>{@link #triggerImport(long, int)}</li>
+ *     <li>After looping through schools: {@link #cleanupBatch(long)}</li>
  * </ol>
  */
 public interface ProcessingGroupImportService {
@@ -30,14 +32,14 @@ public interface ProcessingGroupImportService {
      *
      * @param batchId The batch id
      */
-    void createImports(long batchId);
+    void createImports(long batchId, int schoolId);
 
     /**
      * Insert missing group records into the student_group table.
      *
      * @param batchId The batch id
      */
-    void insertMissingGroups(long batchId);
+    void insertMissingGroups(long batchId, int schoolId);
 
     /**
      * Update existing, referenced deleted group records to mark
@@ -45,33 +47,40 @@ public interface ProcessingGroupImportService {
      *
      * @param batchId The batch id
      */
-    void updateDeletedGroups(long batchId);
+    void updateDeletedGroups(long batchId, int schoolId);
 
     /**
      * Update modified groups.
      *
      * @param batchId The batch id
      */
-    void updateModifiedGroups(long batchId);
+    void updateModifiedGroups(long batchId, int schoolId);
 
     /**
      * Update the authenticated users for ingested groups.
      *
      * @param batchId The batch id
      */
-    void updateModifiedGroupUsers(long batchId);
+    void updateModifiedGroupUsers(long batchId, int schoolId);
 
     /**
      * Update the student membership for ingested groups.
      *
      * @param batchId The batch id
      */
-    void updateModifiedGroupStudents(long batchId);
+    void updateModifiedGroupStudents(long batchId, int schoolId);
 
     /**
      * Trigger the created imports and clean up.
      *
      * @param batchId The batch id
      */
-    void triggerImport(long batchId);
+    void triggerImport(long batchId, int schoolId);
+
+    /**
+     * Clean up interim import records.
+     *
+     * @param batchId The batch id
+     */
+    void cleanupBatch(long batchId);
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/ProcessingUserImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/ProcessingUserImportService.java
@@ -3,13 +3,15 @@ package org.opentestsystem.rdw.ingest.group.service;
 /**
  * Implementations of this interface are responsible for creating and importing students
  * while processing a group definition import.
+ * NOTE that this service is designed to be iteratively by school followed by a final cleanup call
  *
  * The service is designed to be executed as an ordered flow to support transaction boundaries:
  * <ol>
- *     <li>{@link #createImports(long)}</li>
- *     <li>{@link #insertMissingStudents(long)}</li>
- *     <li>{@link #updateDeletedStudents(long)}</li>
- *     <li>{@link #triggerImport(long)}</li>
+ *     <li>{@link #createImports(long, int)}</li>
+ *     <li>{@link #insertMissingStudents(long, int)}</li>
+ *     <li>{@link #updateDeletedStudents(long, int)}</li>
+ *     <li>{@link #triggerImport(long, int)}</li>
+ *     <li>After looping through schools: {@link #cleanupBatch(long)}</li>
  * </ol>
  */
 public interface ProcessingUserImportService {
@@ -25,14 +27,14 @@ public interface ProcessingUserImportService {
      *
      * @param batchId The batch id
      */
-    void createImports(long batchId);
+    void createImports(long batchId, int school_id);
 
     /**
      * Insert missing student records into the student table.
      *
      * @param batchId The batch id
      */
-    void insertMissingStudents(long batchId);
+    void insertMissingStudents(long batchId, int school_id);
 
     /**
      * Update existing, referenced deleted student records to mark
@@ -40,12 +42,19 @@ public interface ProcessingUserImportService {
      *
      * @param batchId The batch id
      */
-    void updateDeletedStudents(long batchId);
+    void updateDeletedStudents(long batchId, int school_id);
 
     /**
      * Trigger the created imports and update student references.
      *
      * @param batchId The batch id
      */
-    void triggerImport(long batchId);
+    void triggerImport(long batchId, int school_id);
+
+    /**
+     * Clean up interim import records.
+     *
+     * @param batchId The batch id
+     */
+    void cleanupBatch(long batchId);
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessor.java
@@ -3,12 +3,12 @@ package org.opentestsystem.rdw.ingest.group.service.impl;
 import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.group.service.BatchingGroupImportService;
+import org.opentestsystem.rdw.ingest.group.service.BatchingUserImportService;
 import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
-import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingLoadService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingReferenceService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingStandardizationService;
-import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,16 +20,16 @@ public class DefaultGroupProcessor implements GroupProcessor {
 
     private final ProcessingStandardizationService standardizationService;
     private final ProcessingReferenceService referenceService;
-    private final ProcessingUserImportService userImportService;
+    private final BatchingUserImportService userImportService;
     private final ProcessingLoadService loadService;
-    private final ProcessingGroupImportService groupImportService;
+    private final BatchingGroupImportService groupImportService;
 
     @Autowired
     public DefaultGroupProcessor(final ProcessingStandardizationService standardizationService,
                                  final ProcessingReferenceService referenceService,
-                                 final ProcessingUserImportService userImportService,
+                                 final BatchingUserImportService userImportService,
                                  final ProcessingLoadService loadService,
-                                 final ProcessingGroupImportService groupImportService) {
+                                 final BatchingGroupImportService groupImportService) {
         this.standardizationService = standardizationService;
         this.referenceService = referenceService;
         this.userImportService = userImportService;
@@ -54,17 +54,8 @@ public class DefaultGroupProcessor implements GroupProcessor {
             loadService.loadBatch(message.getDigest(), batchId);
             standardizationService.standardizeBatch(batchId);
             referenceService.lookupBatchReferences(batchId);
-            userImportService.createImports(batchId);
-            userImportService.insertMissingStudents(batchId);
-            userImportService.updateDeletedStudents(batchId);
-            userImportService.triggerImport(batchId);
-            groupImportService.createImports(batchId);
-            groupImportService.insertMissingGroups(batchId);
-            groupImportService.updateDeletedGroups(batchId);
-            groupImportService.updateModifiedGroups(batchId);
-            groupImportService.updateModifiedGroupUsers(batchId);
-            groupImportService.updateModifiedGroupStudents(batchId);
-            groupImportService.triggerImport(batchId);
+            userImportService.processBatch(batchId);
+            groupImportService.processBatch(batchId);
         } catch (final Exception e) {
             logger.error("Problem processing batch: {}", batchId, e);
             throw new ImportException(ImportStatus.INVALID, "Problem processing Batch: " + batchId);

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportService.java
@@ -29,7 +29,7 @@ public class DefaultProcessingGroupImportService implements ProcessingGroupImpor
     }
 
     @Override
-    public void createImports(final long batchId) {
+    public void createImports(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "stage-new")
@@ -42,51 +42,57 @@ public class DefaultProcessingGroupImportService implements ProcessingGroupImpor
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure creating Group imports", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void insertMissingGroups(final long batchId) {
+    public void insertMissingGroups(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "insert-missing")
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure creating new groups", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void updateDeletedGroups(final long batchId) {
+    public void updateDeletedGroups(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "update-deleted")
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure updating deleted groups", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void updateModifiedGroups(final long batchId) {
+    public void updateModifiedGroups(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "assign-imported-groups")
@@ -94,17 +100,19 @@ public class DefaultProcessingGroupImportService implements ProcessingGroupImpor
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure updating modified groups", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void updateModifiedGroupUsers(final long batchId) {
+    public void updateModifiedGroupUsers(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "clear-updated-users")
@@ -112,17 +120,19 @@ public class DefaultProcessingGroupImportService implements ProcessingGroupImpor
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure updating modified group users", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void updateModifiedGroupStudents(final long batchId) {
+    public void updateModifiedGroupStudents(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "clear-updated-students")
@@ -130,41 +140,60 @@ public class DefaultProcessingGroupImportService implements ProcessingGroupImpor
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure updating modified group students", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
-    public void triggerImport(final long batchId) {
+    public void triggerImport(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "update-migration")
+                .build();
+
+        try {
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId,
+                    "import_status", 1));
+        } catch (final Exception e) {
+            logger.error("Failure triggering group import", e);
+            abortImports(batchId, schoolId);
+            throw e;
+        }
+    }
+
+    @Override
+    public void cleanupBatch(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "clean-import-stage")
                 .addNext("import-groups", "clean-import-upload")
                 .build();
 
         try {
             repository.execute(sql, ImmutableMap.of(
-                    "batch_id", batchId,
-                    "import_status", 1));
+                    "batch_id", batchId));
         } catch (final Exception e) {
-            logger.error("Failure triggering group import", e);
-            abortImports(batchId);
+            logger.error("Failure cleaning up group import", e);
             throw e;
         }
     }
 
-    private void abortImports(final long batchId) {
+    private void abortImports(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-groups", "update-migration")
                 .build();
         repository.execute(sql, ImmutableMap.of(
                 "batch_id", batchId,
+                "school_id", schoolId,
                 "import_status", -1));
     }
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingUserImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingUserImportService.java
@@ -31,7 +31,7 @@ public class DefaultProcessingUserImportService implements ProcessingUserImportS
     }
 
     @Override
-    public void createImports(final long batchId) {
+    public void createImports(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-students", "stage-new")
@@ -41,75 +41,97 @@ public class DefaultProcessingUserImportService implements ProcessingUserImportS
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure creating User imports", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void insertMissingStudents(final long batchId) {
+    public void insertMissingStudents(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-students", "insert-missing")
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure inserting missing students", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
     @Transactional
-    public void updateDeletedStudents(final long batchId) {
+    public void updateDeletedStudents(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-students", "update-deleted")
                 .build();
 
         try {
-            repository.execute(sql, ImmutableMap.of("batch_id", batchId));
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId));
         } catch (final Exception e) {
             logger.error("Failure updating deleted students", e);
-            abortImports(batchId);
+            abortImports(batchId, schoolId);
             throw e;
         }
     }
 
     @Override
-    public void triggerImport(final long batchId) {
+    public void triggerImport(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-students", "update-migration")
                 .addNext("import-students", "assign-imported-students")
+                .build();
+        try {
+            repository.execute(sql, ImmutableMap.of(
+                    "batch_id", batchId,
+                    "school_id", schoolId,
+                    "import_status", 1));
+        } catch (final Exception e) {
+            logger.error("Failure starting student import", e);
+            abortImports(batchId, schoolId);
+            throw e;
+        }
+    }
+
+    @Override
+    public void cleanupBatch(final long batchId) {
+        final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
+        final List<String> sql = sqlListBuilder
                 .addNext("import-students", "clean-import-refs")
                 .addNext("import-students", "clean-import-stage")
                 .build();
         try {
             repository.execute(sql, ImmutableMap.of(
-                    "batch_id", batchId,
-                    "import_status", 1));
+                    "batch_id", batchId));
         } catch (final Exception e) {
-            logger.error("Failure starting student import", e);
-            abortImports(batchId);
+            logger.error("Failure cleaning up student import records", e);
             throw e;
         }
     }
 
-    private void abortImports(final long batchId) {
+    private void abortImports(final long batchId, final int schoolId) {
         final SqlListBuilder sqlListBuilder = new SqlListBuilder(sqlConfiguration.getEntities());
         final List<String> sql = sqlListBuilder
                 .addNext("import-students", "update-migration")
                 .build();
         repository.execute(sql, ImmutableMap.of(
                 "batch_id", batchId,
+                "school_id", schoolId,
                 "import_status", -1));
     }
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/SchoolBatchingGroupImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/SchoolBatchingGroupImportService.java
@@ -1,0 +1,44 @@
+package org.opentestsystem.rdw.ingest.group.service.impl;
+
+import org.opentestsystem.rdw.ingest.group.repository.SchoolBatchRepository;
+import org.opentestsystem.rdw.ingest.group.service.BatchingGroupImportService;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+/**
+ * This service processes group imports and modifications for a Group upload
+ * while grouping imports together by school.
+ */
+@Service
+public class SchoolBatchingGroupImportService implements BatchingGroupImportService {
+
+    private final ProcessingGroupImportService importService;
+    private final SchoolBatchRepository repository;
+
+    @Autowired
+    public SchoolBatchingGroupImportService(final ProcessingGroupImportService importService,
+                                           final SchoolBatchRepository repository) {
+        this.importService = importService;
+        this.repository = repository;
+    }
+
+    @Override
+    public void processBatch(final long batchId) {
+        final Set<Integer> schoolIds = repository.findSchoolIdsForBatch(batchId);
+
+        for (final int schoolId : schoolIds) {
+            importService.createImports(batchId, schoolId);
+            importService.insertMissingGroups(batchId, schoolId);
+            importService.updateDeletedGroups(batchId, schoolId);
+            importService.updateModifiedGroups(batchId, schoolId);
+            importService.updateModifiedGroupUsers(batchId, schoolId);
+            importService.updateModifiedGroupStudents(batchId, schoolId);
+            importService.triggerImport(batchId, schoolId);
+        }
+
+        importService.cleanupBatch(batchId);
+    }
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/SchoolBatchingUserImportService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/SchoolBatchingUserImportService.java
@@ -1,0 +1,41 @@
+package org.opentestsystem.rdw.ingest.group.service.impl;
+
+import org.opentestsystem.rdw.ingest.group.repository.SchoolBatchRepository;
+import org.opentestsystem.rdw.ingest.group.service.BatchingUserImportService;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+/**
+ * This service processes user imports and modifications for a Group upload
+ * while grouping imports together by school.
+ */
+@Service
+public class SchoolBatchingUserImportService implements BatchingUserImportService {
+
+    private final ProcessingUserImportService importService;
+    private final SchoolBatchRepository repository;
+
+    @Autowired
+    public SchoolBatchingUserImportService(final ProcessingUserImportService importService,
+                                           final SchoolBatchRepository repository) {
+        this.importService = importService;
+        this.repository = repository;
+    }
+
+    @Override
+    public void processBatch(final long batchId) {
+        final Set<Integer> schoolIds = repository.findSchoolIdsForBatch(batchId);
+
+        for (final int schoolId : schoolIds) {
+            importService.createImports(batchId, schoolId);
+            importService.insertMissingStudents(batchId, schoolId);
+            importService.updateDeletedStudents(batchId, schoolId);
+            importService.triggerImport(batchId, schoolId);
+        }
+
+        importService.cleanupBatch(batchId);
+    }
+}

--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -6,6 +6,11 @@ sql:
       message = :message
     WHERE id = :batch_id
 
+  find-schools-by-batch: >-
+    SELECT DISTINCT school_id
+    FROM upload_student_group upload
+    WHERE upload.batch_id = :batch_id
+
   process-batch:
     entities:
       # ------------ Standardize NULLS
@@ -78,6 +83,7 @@ sql:
               WHERE sgl.student_id IS NULL
                     AND sgl.student_ssid IS NOT NULL
                     AND sgl.batch_id = :batch_id
+                    AND sgl.school_id = :school_id
 
           #TODO review this, should we modify import table to have batch_ref_id and ref_id fields to avoid casting?
           create-imports: >-
@@ -91,6 +97,7 @@ sql:
               FROM upload_student_group_import sgl
               WHERE ref_type = 1
                     AND batch_id = :batch_id
+                    AND school_id = :school_id
 
           assign-imports: >-
             UPDATE upload_student_group_import sgl
@@ -105,6 +112,7 @@ sql:
             SET sgl.import_id = si.id
             WHERE sgl.ref_type = 1
                   AND sgl.batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           propagate-imports: >-
             UPDATE upload_student_group sgl
@@ -113,6 +121,7 @@ sql:
             SET sgl.import_id = i.import_id
             WHERE student_id IS NULL
                   AND sgl.batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           insert-missing: >-
             INSERT IGNORE INTO student (ssid, import_id, update_import_id)
@@ -127,6 +136,7 @@ sql:
                     AND sgl.student_ssid IS NOT NULL
                     AND sgl.import_id IS NOT NULL
                     AND sgl.batch_id = :batch_id
+                    AND sgl.school_id = :school_id
 
           update-deleted: >-
             UPDATE student s
@@ -138,6 +148,7 @@ sql:
                   AND sgl.student_ssid IS NOT NULL
                   AND sgl.import_id IS NOT NULL
                   AND sgl.batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           update-migration: >-
             UPDATE import i
@@ -146,6 +157,7 @@ sql:
             WHERE i.status = 0
                   AND sgli.ref_type = 1
                   AND sgli.batch_id = :batch_id
+                  AND sgli.school_id = :school_id
 
           assign-imported-students: >-
             UPDATE upload_student_group sgl
@@ -153,6 +165,7 @@ sql:
             SET sgl.student_id = s.id
             WHERE student_id IS NULL
                   AND batch_id = :batch_id
+                  AND school_id = :school_id
 
           clean-import-refs: >-
             UPDATE upload_student_group sgl
@@ -175,6 +188,7 @@ sql:
               FROM upload_student_group sgl
               WHERE sgl.group_id IS NULL
                     AND batch_id = :batch_id
+                    AND school_id = :school_id
 
           stage-membership-change: >-
             INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
@@ -192,7 +206,9 @@ sql:
                        GROUP_CONCAT(student_id ORDER BY student_id) AS students,
                        school_year
                      FROM upload_student_group
-                     WHERE student_id IS NOT NULL AND batch_id = :batch_id
+                     WHERE student_id IS NOT NULL
+                           AND batch_id = :batch_id
+                           AND school_id = :school_id
                      GROUP BY group_id) AS loading
                 JOIN
                 (
@@ -222,7 +238,9 @@ sql:
                        school_year
                      FROM
                        (select DISTINCT batch_id, school_id, group_id, group_name, school_year, group_user_login from upload_student_group) u
-                     WHERE group_user_login IS NOT NULL AND batch_id = :batch_id
+                     WHERE group_user_login IS NOT NULL
+                           AND batch_id = :batch_id
+                           AND school_id = :school_id
                      GROUP BY group_id) AS loading
                 JOIN
                 (
@@ -253,6 +271,7 @@ sql:
               	 FROM
               	   (SELECT DISTINCT batch_id, school_id, group_id, group_name, school_year, subject_id from upload_student_group) u
               	 WHERE batch_id = :batch_id
+              	       AND school_id = :school_id
               	 GROUP BY group_id) AS loading
               JOIN student_group sg
                 ON sg.id = loading.group_id
@@ -269,6 +288,7 @@ sql:
               FROM upload_student_group_import sgl
               WHERE ref_type IN (2, 3, 4, 5)
                     AND batch_id = :batch_id
+                    AND school_id = :school_id
 
           assign-imports: >-
             UPDATE upload_student_group_import sgl
@@ -283,6 +303,7 @@ sql:
             WHERE si.school_id = sgl.school_id
                   AND sgl.ref_type IN (2, 3, 4, 5)
                   AND sgl.batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           propagate-imports: >-
             UPDATE upload_student_group sgl
@@ -292,6 +313,7 @@ sql:
                 ON sgl.school_id = i.school_id
             SET sgl.import_id = i.import_id
             WHERE sgl.batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           insert-missing: >-
             INSERT IGNORE INTO student_group (name, school_id, active, school_year, subject_id, creator, import_id, update_import_id)
@@ -312,6 +334,7 @@ sql:
               WHERE sg.id IS NULL
                     AND sgl.group_id IS NULL
                     AND sgl.batch_id = :batch_id
+                    AND sgl.school_id = :school_id
 
           update-deleted: >-
             UPDATE student_group sg
@@ -323,6 +346,7 @@ sql:
                 sg.update_import_id = sgl.import_id
             WHERE sg.deleted = 1
                   AND sgl.batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           assign-imported-groups: >-
             UPDATE upload_student_group sgl
@@ -333,6 +357,7 @@ sql:
             SET sgl.group_id = sg.id
             WHERE sgl.group_id IS NULL
                   AND batch_id = :batch_id
+                  AND sgl.school_id = :school_id
 
           update-modified: >-
             UPDATE student_group sg
@@ -341,9 +366,10 @@ sql:
                       group_id,
                       MAX(subject_id) as subject_id
                     FROM
-                      (SELECT DISTINCT batch_id, group_id, subject_id, import_id from upload_student_group) u
+                      (SELECT DISTINCT batch_id, school_id, group_id, subject_id, import_id from upload_student_group) u
                     WHERE import_id IS NOT NULL
                           AND batch_id = :batch_id
+                          AND school_id = :school_id
                     GROUP BY group_id) AS loading
                 ON sg.id = loading.group_id
             SET sg.subject_id = loading.subject_id,
@@ -355,7 +381,8 @@ sql:
                       group_id
                     FROM upload_student_group upload
                     WHERE upload.import_id IS NOT NULL
-                          AND upload.batch_id = :batch_id) updated
+                          AND upload.batch_id = :batch_id
+                          AND upload.school_id = :school_id) updated
                 ON updated.group_id = users.student_group_id
             WHERE users.student_group_id IS NOT NULL
 
@@ -368,6 +395,7 @@ sql:
               WHERE upload.import_id IS NOT NULL
                 AND upload.group_user_login IS NOT NULL
                 AND upload.batch_id = :batch_id
+                AND upload.school_id = :school_id
 
           clear-updated-students: >-
             DELETE students FROM student_group_membership students
@@ -375,7 +403,8 @@ sql:
                       group_id
                     FROM upload_student_group upload
                     WHERE upload.import_id IS NOT NULL
-                          AND upload.batch_id = :batch_id) updated
+                          AND upload.batch_id = :batch_id
+                          AND upload.school_id = :school_id) updated
                 ON updated.group_id = students.student_group_id
             WHERE students.student_group_id IS NOT NULL
 
@@ -388,6 +417,7 @@ sql:
               WHERE upload.import_id IS NOT NULL
                     AND upload.student_id IS NOT NULL
                     AND upload.batch_id = :batch_id
+                    AND upload.school_id = :school_id
 
           update-migration: >-
             UPDATE import i
@@ -396,6 +426,7 @@ sql:
             WHERE i.status = 0
                   AND sgli.ref_type IN (2, 3, 4, 5)
                   AND sgli.batch_id = :batch_id
+                  AND sgli.school_id = :school_id
 
           clean-import-stage: >-
             DELETE FROM upload_student_group_import

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcSchoolBatchRepositoryIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcSchoolBatchRepositoryIT.java
@@ -1,0 +1,30 @@
+package org.opentestsystem.rdw.ingest.group.repository;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.ingest.group.RepositoryBackedIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(JdbcSchoolBatchRepository.class)
+@Sql(scripts = {
+        "classpath:WarehouseImportSetup.sql",
+        "classpath:WarehouseCodesSetup.sql",
+        "classpath:WarehouseEntitiesSetup.sql",
+        "classpath:WarehouseSchoolBatchRepositorySetup.sql"
+})
+public class JdbcSchoolBatchRepositoryIT extends RepositoryBackedIT {
+
+    @Autowired
+    public SchoolBatchRepository repository;
+
+    @Test
+    public void itShouldFindDistinctSchoolsForABatch() {
+        final Set<Integer> schoolIds = repository.findSchoolIdsForBatch(33);
+        assertThat(schoolIds).containsOnly(-1, -98);
+    }
+}

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessorTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupProcessorTest.java
@@ -8,11 +8,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
-import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
+import org.opentestsystem.rdw.ingest.group.service.BatchingGroupImportService;
+import org.opentestsystem.rdw.ingest.group.service.BatchingUserImportService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingLoadService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingReferenceService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingStandardizationService;
-import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
 
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -30,13 +30,13 @@ public class DefaultGroupProcessorTest {
     private ProcessingReferenceService referenceService;
 
     @Mock
-    private ProcessingUserImportService userImportService;
+    private BatchingUserImportService userImportService;
 
     @Mock
     private ProcessingLoadService loadService;
 
     @Mock
-    private ProcessingGroupImportService groupImportService;
+    private BatchingGroupImportService groupImportService;
 
     private GroupMessage message;
     private DefaultGroupProcessor processor;
@@ -65,18 +65,9 @@ public class DefaultGroupProcessorTest {
 
         inOrder.verify(referenceService).lookupBatchReferences(batchId);
 
-        inOrder.verify(userImportService).createImports(batchId);
-        inOrder.verify(userImportService).insertMissingStudents(batchId);
-        inOrder.verify(userImportService).updateDeletedStudents(batchId);
-        inOrder.verify(userImportService).triggerImport(batchId);
+        inOrder.verify(userImportService).processBatch(batchId);
 
-        inOrder.verify(groupImportService).createImports(batchId);
-        inOrder.verify(groupImportService).insertMissingGroups(batchId);
-        inOrder.verify(groupImportService).updateDeletedGroups(batchId);
-        inOrder.verify(groupImportService).updateModifiedGroups(batchId);
-        inOrder.verify(groupImportService).updateModifiedGroupUsers(batchId);
-        inOrder.verify(groupImportService).updateModifiedGroupStudents(batchId);
-        inOrder.verify(groupImportService).triggerImport(batchId);
+        inOrder.verify(groupImportService).processBatch(batchId);
     }
 
     @Test(expected = ImportException.class)

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportServiceIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportServiceIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.group.service.impl;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.opentestsystem.rdw.ingest.group.RepositoryBackedIT;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingGroupImportService;
@@ -15,6 +16,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +30,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
+    private static final long BatchId = 33;
+    private static final Set<Integer> SchoolIds = ImmutableSet.of(-1, -98, -99);
+
     @Autowired
     public ProcessingGroupImportService service;
 
@@ -36,7 +41,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageNewGroupsForImport() {
-        service.createImports(33);
+        createImports();
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 2",
@@ -52,7 +57,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageGroupMembershipChangesForImport() {
-        service.createImports(33);
+        createImports();
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 3",
@@ -67,7 +72,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageGroupUserChangesForImport() {
-        service.createImports(33);
+        createImports();
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 4",
@@ -82,7 +87,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageGroupSubjectChangesForImport() {
-        service.createImports(33);
+        createImports();
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 5",
@@ -97,7 +102,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldCreateAnImportPerSchool() {
-        service.createImports(33);
+        createImports();
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from import WHERE batch='33'",
@@ -112,7 +117,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateImportReferences() {
-        service.createImports(33);
+        createImports();
 
         final List<Map<String, Object>> records = template.queryForList(
                 "SELECT * from upload_student_group WHERE batch_id=33",
@@ -134,8 +139,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
                 new HashMap<>(),
                 Integer.class);
 
-        service.createImports(33);
-        service.insertMissingGroups(33);
+        insertMissingGroups();
 
         final List<Map<String, Object>> newGroups = template.queryForList(
                 "SELECT * from student_group WHERE id NOT IN (:existing_groups)",
@@ -150,9 +154,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateDeletedGroups() {
-        service.createImports(33);
-        service.insertMissingGroups(33);
-        service.updateDeletedGroups(33);
+        updateDeletedGroups();
 
         final Map<String, Object> deletedGroup = template.queryForMap(
                 "SELECT * from student_group WHERE name = 'Test Student Group 9 - updated school'",
@@ -163,10 +165,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldAssignCreatedAndUnDeletedGroupIds() {
-        service.createImports(33);
-        service.insertMissingGroups(33);
-        service.updateDeletedGroups(33);
-        service.updateModifiedGroups(33);
+        updateModifiedGroups();
 
         final List<Map<String, Object>> noGroupId = template.queryForList(
                 "SELECT * from upload_student_group WHERE group_id IS NULL",
@@ -177,10 +176,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateModifiedGroupSubjects() {
-        service.createImports(33);
-        service.insertMissingGroups(33);
-        service.updateDeletedGroups(33);
-        service.updateModifiedGroups(33);
+        updateModifiedGroups();
 
         final Map<String, Object> modifiedGroup = template.queryForMap(
                 "SELECT * from student_group WHERE name = 'Test Student Group 8'",
@@ -191,11 +187,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateModifiedGroupUsers() {
-        service.createImports(33);
-        service.insertMissingGroups(33);
-        service.updateDeletedGroups(33);
-        service.updateModifiedGroups(33);
-        service.updateModifiedGroupUsers(33);
+        updateModifiedGroupUsers();
 
         final List<Map<String, Object>> group8Users = template.queryForList(
                 "SELECT * from user_student_group WHERE student_group_id = -8",
@@ -221,12 +213,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateModifiedGroupStudents() {
-        service.createImports(33);
-        service.insertMissingGroups(33);
-        service.updateDeletedGroups(33);
-        service.updateModifiedGroups(33);
-        service.updateModifiedGroupUsers(33);
-        service.updateModifiedGroupStudents(33);
+        updateModifiedGroupStudents();
 
         Map<String, Object> group = template.queryForMap(
                 "SELECT * from student_group WHERE id = -8",
@@ -267,27 +254,77 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldTriggerAMigration() {
-        service.createImports(33);
-        service.insertMissingGroups(33);
-        service.updateDeletedGroups(33);
-        service.updateModifiedGroups(33);
-        service.updateModifiedGroupUsers(33);
-        service.updateModifiedGroupStudents(33);
-
-        final List<Long> importIds = template.queryForList(
-                "SELECT DISTINCT import_id from upload_student_group WHERE batch_id = 33",
-                new HashMap<>(),
-                Long.class);
-
-        service.triggerImport(33);
+        triggerImports();
 
         final List<Map<String, Object>> imports = template.queryForList(
-                "SELECT * FROM import WHERE id IN (:import_ids)",
-                ImmutableMap.of("import_ids", importIds));
+                "SELECT * FROM import WHERE batch = '33'",
+                ImmutableMap.of());
 
         assertThat(imports).hasSize(3);
         assertThat(imports.stream().map(row -> row.get("status")))
                 .containsOnly(1);
     }
 
+    private void createImports() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+        }
+    }
+
+    private void insertMissingGroups() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+            service.insertMissingGroups(BatchId, schoolId);
+        }
+    }
+
+    private void updateDeletedGroups() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+            service.insertMissingGroups(BatchId, schoolId);
+            service.updateDeletedGroups(BatchId, schoolId);
+        }
+    }
+
+    private void updateModifiedGroups() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+            service.insertMissingGroups(BatchId, schoolId);
+            service.updateDeletedGroups(BatchId, schoolId);
+            service.updateModifiedGroups(BatchId, schoolId);
+        }
+    }
+
+    private void updateModifiedGroupUsers() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+            service.insertMissingGroups(BatchId, schoolId);
+            service.updateDeletedGroups(BatchId, schoolId);
+            service.updateModifiedGroups(BatchId, schoolId);
+            service.updateModifiedGroupUsers(BatchId, schoolId);
+        }
+    }
+
+    private void updateModifiedGroupStudents() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+            service.insertMissingGroups(BatchId, schoolId);
+            service.updateDeletedGroups(BatchId, schoolId);
+            service.updateModifiedGroups(BatchId, schoolId);
+            service.updateModifiedGroupUsers(BatchId, schoolId);
+            service.updateModifiedGroupStudents(BatchId, schoolId);
+        }
+    }
+
+    private void triggerImports() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(BatchId, schoolId);
+            service.insertMissingGroups(BatchId, schoolId);
+            service.updateDeletedGroups(BatchId, schoolId);
+            service.updateModifiedGroups(BatchId, schoolId);
+            service.updateModifiedGroupUsers(BatchId, schoolId);
+            service.updateModifiedGroupStudents(BatchId, schoolId);
+            service.triggerImport(BatchId, schoolId);
+        }
+    }
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingUserImportServiceIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingUserImportServiceIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.group.service.impl;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.opentestsystem.rdw.ingest.group.RepositoryBackedIT;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
@@ -12,6 +13,7 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "classpath:WarehouseUserImportServiceSetup.sql"
 })
 public class DefaultProcessingUserImportServiceIT extends RepositoryBackedIT {
+    private static final Set<Integer> SchoolIds = ImmutableSet.of(-1, -98);
 
     @Autowired
     public ProcessingUserImportService service;
@@ -33,10 +36,7 @@ public class DefaultProcessingUserImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldIgnoreExistingStudentRecords() {
-        service.createImports(33);
-        service.insertMissingStudents(33);
-        service.updateDeletedStudents(33);
-        service.triggerImport(33);
+        executeService();
 
         final List<Map<String, Object>> rows = template.queryForList(
                 "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY student_ssid",
@@ -46,16 +46,13 @@ public class DefaultProcessingUserImportServiceIT extends RepositoryBackedIT {
         final Map<String, Object> existing = rows.stream()
                 .filter(record -> "88".equals(record.get("student_ssid")))
                 .findFirst()
-                .orElse(null);
+                .orElseThrow(() -> new IllegalStateException("Student 88 not found"));
         assertThat(existing.get("student_id")).isEqualTo(-88);
     }
 
     @Test
     public void itShouldIgnoreNonStudentRecords() {
-        service.createImports(33);
-        service.insertMissingStudents(33);
-        service.updateDeletedStudents(33);
-        service.triggerImport(33);
+        executeService();
 
         final List<Map<String, Object>> rows = template.queryForList(
                 "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY student_ssid",
@@ -67,24 +64,22 @@ public class DefaultProcessingUserImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldCreateAnImportForNonExistingStudentsBySchool() {
-        service.createImports(33);
+        executeService();
 
         final List<Map<String, Object>> imports = template.queryForList(
-                "SELECT * from upload_student_group_import WHERE batch_id=33",
+                "SELECT cast(digest AS SIGNED INTEGER) AS school_id, updated from import WHERE batch='33'",
                 new HashMap<>());
 
-        final List<Integer> schoolIds = imports.stream()
-                .map(record -> (int) record.get("school_id"))
-                .collect(Collectors.toList());
-        assertThat(schoolIds).containsOnly(-98, -1);
+        assertThat(imports).hasSize(2);
+        assertThat(imports.get(0).get("updated")).isNotEqualTo(imports.get(1).get("updated"));
+        assertThat(imports.stream()
+                .map(record -> record.get("school_id")))
+                .containsOnly(-1L, -98L);
     }
 
     @Test
     public void itShouldUpdateNonExistingStudentReferences() {
-        service.createImports(33);
-        service.insertMissingStudents(33);
-        service.updateDeletedStudents(33);
-        service.triggerImport(33);
+        executeService();
 
         final List<Map<String, Object>> rows = template.queryForList(
                 "SELECT * from upload_student_group WHERE batch_id=33 ORDER BY student_ssid",
@@ -121,10 +116,7 @@ public class DefaultProcessingUserImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldCreateAnImportForDeletedStudents() {
-        service.createImports(33);
-        service.insertMissingStudents(33);
-        service.updateDeletedStudents(33);
-        service.triggerImport(33);
+        executeService();
 
         //Assert the deleted student has an id assigned
         final List<Map<String, Object>> rows = template.queryForList(
@@ -148,5 +140,15 @@ public class DefaultProcessingUserImportServiceIT extends RepositoryBackedIT {
         assertThat(student.get("update_import_id"))
                 .isNotNull()
                 .isNotEqualTo(student.get("import_id"));
+    }
+
+    private void executeService() {
+        for (final int schoolId : SchoolIds) {
+            service.createImports(33, schoolId);
+            service.insertMissingStudents(33, schoolId);
+            service.updateDeletedStudents(33, schoolId);
+            service.triggerImport(33, schoolId);
+        }
+        service.cleanupBatch(33);
     }
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/SchoolBatchingUserImportServiceTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/SchoolBatchingUserImportServiceTest.java
@@ -1,0 +1,53 @@
+package org.opentestsystem.rdw.ingest.group.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.ingest.group.repository.SchoolBatchRepository;
+import org.opentestsystem.rdw.ingest.group.service.ProcessingUserImportService;
+
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SchoolBatchingUserImportServiceTest {
+
+    @Mock
+    private SchoolBatchRepository repository;
+
+    @Mock
+    private ProcessingUserImportService importService;
+
+    private SchoolBatchingUserImportService service;
+
+    @Before
+    public void setup() {
+        service = new SchoolBatchingUserImportService(importService, repository);
+    }
+
+    @Test
+    public void itShouldIngestUsersForABatchOneSchoolAtATime() {
+        final long batchId = 33;
+        final Set<Integer> schoolIds = of(1, 2, 3);
+        when(repository.findSchoolIdsForBatch(batchId)).thenReturn(schoolIds);
+
+        service.processBatch(batchId);
+
+        for (final int schoolId : schoolIds) {
+            final InOrder order = inOrder(importService);
+            order.verify(importService).createImports(batchId, schoolId);
+            order.verify(importService).insertMissingStudents(batchId, schoolId);
+            order.verify(importService).updateDeletedStudents(batchId, schoolId);
+            order.verify(importService).triggerImport(batchId, schoolId);
+        }
+
+        verify(importService).cleanupBatch(batchId);
+    }
+}

--- a/group-processor/src/test/resources/WarehouseSchoolBatchRepositorySetup.sql
+++ b/group-processor/src/test/resources/WarehouseSchoolBatchRepositorySetup.sql
@@ -1,0 +1,9 @@
+INSERT INTO upload_student_group (batch_id, group_name, school_year, school_natural_id, school_id, student_ssid, student_id) VALUES
+  -- Batch 33, School 1
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, '88', -88),
+  (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, null, null),
+  -- Batch 33, School 98
+  (33, 'Test Student Group 7', 2017, 'natural_id-98', -98, 'unknown_student1', null),
+  (33, 'Test Student Group 7', 2017, 'natural_id-98', -98, 'unknown_student2', null),
+  -- Batch 34, School 99
+  (34, 'Test Student Group 8', 2017, 'natural_id-99', -99, 'unknown_student3', null);


### PR DESCRIPTION
Previously while processing a group batch upload we were creating:
* An import record per school for processing student creation/modification
* An import record per school for processing group creation/modification

However, each student import for each school had the exact same "updated" timestamp, and each group import for each school had the exact same "updated" timestamp.  This means that although we may only *intend* to process half of the imports, *all* of the student or *all* of the group data would be migrated at once, do to being within the migration start-time/end-time boundaries.

This PR uses java to loop over each school individually, naturally spreading the imports in time and allowing bite-sized migration chunks.