### PR TITLE
working version is 1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ SNAPSHOT version of the RDW_Schema:
 and then run the integration tests as usual, but using the local SNAPSHOT version of RDW_Schema:
 ```bash
 //under the RDW_Ingest directory...
- ./gradlew build it -Pschema=0.0.1-SNAPSHOT
+ ./gradlew build it -Pschema=1.0.0-SNAPSHOT
 ```
 
 ### Running
@@ -57,8 +57,8 @@ The artifacts are Spring Boot executable jars so you can just run them. Just as 
 is to run without a configuration server so all secrets must be specified as program arguments and ports must be
 specified to avoid conflict.
 ```bash
-java -jar import-service/build/libs/rdw-ingest-import-service-0.0.1-SNAPSHOT.jar
-java -jar exam-processor/build/libs/rdw-ingest-exam-processor-0.0.1-SNAPSHOT.jar --server.port=8082
+java -jar import-service/build/libs/rdw-ingest-import-service-1.0.0-SNAPSHOT.jar
+java -jar exam-processor/build/libs/rdw-ingest-exam-processor-1.0.0-SNAPSHOT.jar --server.port=8082
 ```
 
 #### FTP Server

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ git checkout develop
 Then to use those new changes, you can specify the SNAPSHOT version of RDW_Common
 ```bash
 //In RDW_Ingest
-./gradlew build it -Pcommon=0.0.1-SNAPSHOT
+./gradlew build it -Pcommon=1.0.0-SNAPSHOT
 ```
 
 Now you should be able to build and test the ingest apps from where you cloned this project:
@@ -129,8 +129,8 @@ Running the applications locally depends on the local database being configured 
 ```bash
 To completely clean out any existing data you might have and start fresh:
 ./gradlew cleanallprod migrateallprod
-or, if you want to use a different version of the schema, say version 0.0.1-68 of RDW_Schema
-./gradlew -Pschema=0.0.1-68 cleanallprod migrateallprod
+or, if you want to use a different version of the schema, say version 1.0.0-68 of RDW_Schema
+./gradlew -Pschema=1.0.0-68 cleanallprod migrateallprod
 ```
 
 The apps are wrapped in docker containers and should be built and run that way. There is a docker-compose spec

--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,15 @@ plugins {
 
 apply plugin: 'io.spring.dependency-management'
 
-// Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=0.0.1-SNAPSHOT`
+// Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.0.0-SNAPSHOT`
 
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "0.0.1-39"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "0.0.1-186"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.0.0-40"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.0.0-189"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {
     group = 'org.opentestsystem.rdw.ingest'
-    version = '0.0.1-SNAPSHOT'
+    version = '1.0.0-SNAPSHOT'
 
     apply plugin: 'idea'
     apply plugin: 'propdeps'


### PR DESCRIPTION
The CI process is such that `develop` should have the version number set to what we're working towards, in this case 1.0.0.

I've already bumped common and schema.

Note that i am not resetting the build number cause it really should've been 1.0.0 for a while.