### PR TITLE
remove school caches

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.ingest.common.repository;
 import org.opentestsystem.rdw.ingest.common.model.School;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.SqlOutParameter;
@@ -45,7 +44,6 @@ class JdbcSchoolRepository implements SchoolRepository {
     }
 
     @Override
-    @Cacheable(value = "school", key = "#school")
     public int upsert(final School school, final long importId) {
         return (int) upsertSchool.execute(upsertSchoolParameters(school, importId)).get("p_id");
     }
@@ -66,7 +64,6 @@ class JdbcSchoolRepository implements SchoolRepository {
     }
 
     @Override
-    @Cacheable(value = "schoolId")
     public Integer findIdByNaturalId(final String naturalId) {
         try {
             return jdbcTemplate.queryForObject(sqlFindIdByNaturalId, new Object[]{naturalId}, Integer.class);

--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -12,7 +12,7 @@ server:
 spring:
   cache:
     type: SIMPLE
-    cache-names: completeness, adminCondition, assessmentType, ethnicity, ethnicityCodes, gender, grade, subject, school, accCode, schoolId
+    cache-names: completeness, adminCondition, assessmentType, ethnicity, ethnicityCodes, gender, grade, subject, accCode
 
   cloud:
     stream:
@@ -29,8 +29,8 @@ spring:
     validationQuery: SELECT 1
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
-    maxActive: 10
-    initialSize: 4
+    maxActive: 12
+    initialSize: 6
     maxWait: 10000
 
   jackson:

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/SchoolRepositoryIT.java
@@ -8,8 +8,6 @@ import org.opentestsystem.rdw.ingest.common.repository.SchoolRepository;
 import org.opentestsystem.rdw.ingest.common.test.CachingTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -26,9 +24,6 @@ import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 @CachingTest
 @ActiveProfiles("test")
 public class SchoolRepositoryIT {
-    @Autowired
-    private CacheManager cacheManager;
-
     @Autowired
     private SchoolRepository repository;
 
@@ -129,46 +124,11 @@ public class SchoolRepositoryIT {
 
     @Test
     @Sql(statements = {
-            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')"
-    })
-    public void itShouldCacheReturnedIdForSchool() {
-
-        final School school = School.builder()
-                .name("New School To Test Cache")
-                .naturalId("cache123")
-                .district(District.builder().naturalId("cache123").name("New District to test Cache").build())
-                .build();
-
-        final Cache codes = this.cacheManager.getCache("school");
-        assertThat(codes.get(school)).isNull();
-
-        final int newSchoolId = repository.upsert(school, -99);
-
-        assertThat(codes.get(school, Integer.class)).isEqualTo(newSchoolId);
-    }
-
-    @Test
-    @Sql(statements = {
             "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
             "INSERT INTO district (id, name, natural_id) VALUES (-22, 'Sample District 1', 'DistrictNaturalId');",
             "INSERT INTO school (id, district_id, name, natural_id, import_id, update_import_id) VALUES (-27, -22, 'Sample School 1', 'SchoolNaturalId', -99, -99);"
     })
-    public void itShouldCacheReturnedIdForNaturalId() {
-        final Cache codes = this.cacheManager.getCache("schoolId");
-        assertThat(codes.get("SchoolNaturalId")).isNull();
-
-        repository.findIdByNaturalId("SchoolNaturalId");
-
-        assertThat(codes.get("SchoolNaturalId", Integer.class)).isEqualTo(-27);
-    }
-
-    @Test
-    @Sql(statements = {
-            "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
-            "INSERT INTO district (id, name, natural_id) VALUES (-22, 'Sample District 1', 'DistrictNaturalId');",
-            "INSERT INTO school (id, district_id, name, natural_id, import_id, update_import_id) VALUES (-27, -22, 'Sample School 1', 'SchoolNaturalId', -99, -99);"
-    })
-    public void itShouldCacheFindIdByNaturalId() {
+    public void itShouldFindIdByNaturalId() {
         assertThat(repository.findIdByNaturalId("SchoolNaturalId")).isEqualTo(-27);
         assertThat(repository.findIdByNaturalId("test")).isNull();
     }


### PR DESCRIPTION
Pending the results of the investigation of how much the school cache helps, this simply removes it. The risk of rejecting test results outweighs the performance improvements. At least until the test result volume picks up. 