### PR TITLE
DWR-969 Allow adding users/students to group with no users/students

### DIFF
--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -195,63 +195,75 @@ sql:
               SELECT
                 batch_id,
                 school_id,
-                concat(loading.group_name, loading.school_id, loading.school_year),
+                concat(name, school_id, school_year),
                 3
               FROM (
-                     SELECT
-                       batch_id,
-                       school_id,
-                       group_id,
-                       group_name,
-                       GROUP_CONCAT(student_id ORDER BY student_id) AS students,
-                       school_year
-                     FROM upload_student_group
-                     WHERE student_id IS NOT NULL
-                           AND batch_id = :batch_id
-                           AND school_id = :school_id
-                     GROUP BY group_id) AS loading
-                JOIN
-                (
                   SELECT
-                    student_group_id,
-                    GROUP_CONCAT(student_id ORDER BY student_id) AS students
-                  FROM student_group_membership
-                  GROUP BY student_group_id
+                    grp.id,
+                    grp.school_id,
+                    grp.name,
+                    grp.school_year,
+                    upload.batch_id,
+                    GROUP_CONCAT(membership.student_id ORDER BY membership.student_id) AS students
+                  FROM student_group grp
+                    JOIN upload_student_group upload
+                      ON grp.id = upload.group_id
+                    LEFT JOIN student_group_membership membership
+                      ON membership.student_group_id = grp.id
+                  WHERE upload.batch_id = :batch_id
+                    AND upload.school_id = :school_id
+                  GROUP BY grp.id
                 ) AS existing
-                  ON existing.student_group_id = loading.group_id
-              WHERE existing.students <> loading.students;
+              LEFT JOIN (
+                  SELECT
+                    group_id,
+                    GROUP_CONCAT(student_id ORDER BY student_id) AS students
+                  FROM upload_student_group
+                  WHERE student_id IS NOT NULL
+                        AND batch_id = :batch_id
+                        AND school_id = :school_id
+                  GROUP BY group_id
+                ) AS loading
+                ON existing.id = loading.group_id
+              WHERE NOT existing.students <=> loading.students
 
           stage-user-change: >-
             INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
               SELECT
                 batch_id,
                 school_id,
-                concat(loading.group_name, loading.school_id, loading.school_year),
+                concat(name, school_id, school_year),
                 4
               FROM (
-                     SELECT
-                       batch_id,
-                       school_id,
-                       group_id,
-                       group_name,
-                       GROUP_CONCAT(group_user_login ORDER BY group_user_login) AS users,
-                       school_year
-                     FROM
-                       (select DISTINCT batch_id, school_id, group_id, group_name, school_year, group_user_login from upload_student_group) u
-                     WHERE group_user_login IS NOT NULL
-                           AND batch_id = :batch_id
-                           AND school_id = :school_id
-                     GROUP BY group_id) AS loading
-                JOIN
-                (
                   SELECT
-                    student_group_id,
+                    grp.id,
+                    grp.school_id,
+                    grp.name,
+                    grp.school_year,
+                    upload.batch_id,
                     GROUP_CONCAT(user_login ORDER BY user_login) AS users
-                  FROM user_student_group
-                  GROUP BY student_group_id
-                ) AS existing
-                  ON existing.student_group_id = loading.group_id
-              WHERE existing.users <> loading.users;
+                  FROM student_group grp
+                    JOIN upload_student_group upload
+                      ON grp.id = upload.group_id
+                    LEFT JOIN user_student_group user
+                      on user.student_group_id = grp.id
+                  WHERE upload.batch_id = :batch_id
+                    AND upload.school_id = :school_id
+                  GROUP BY grp.id
+                  ) AS existing
+              LEFT JOIN (
+                  SELECT
+                    group_id,
+                    GROUP_CONCAT(group_user_login ORDER BY group_user_login) AS users
+                  FROM
+                    (select DISTINCT batch_id, school_id, group_id, group_user_login from upload_student_group) u
+                  WHERE group_user_login IS NOT NULL
+                        AND batch_id = :batch_id
+                        AND school_id = :school_id
+                  GROUP BY group_id
+                ) AS loading
+                ON existing.id = loading.group_id
+              WHERE NOT existing.users <=> loading.users;
 
           stage-subject-change: >-
             INSERT IGNORE INTO upload_student_group_import (batch_id, school_id, ref, ref_type)
@@ -449,5 +461,3 @@ sql:
       subject_code = nullif(TRIM(REPLACE(@vsubject_code, '\r', '')), ''),
       student_ssid = nullif(TRIM(REPLACE(@vstudent_ssid, '\r', '')), ''),
       group_user_login = nullif(TRIM(REPLACE(@vgroup_user_login, '\r', '')), '')
-
-

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportServiceIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingGroupImportServiceIT.java
@@ -41,7 +41,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageNewGroupsForImport() {
-        createImports();
+        createImports(BatchId);
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 2",
@@ -57,7 +57,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageGroupMembershipChangesForImport() {
-        createImports();
+        createImports(BatchId);
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 3",
@@ -72,7 +72,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageGroupUserChangesForImport() {
-        createImports();
+        createImports(BatchId);
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 4",
@@ -87,7 +87,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldStageGroupSubjectChangesForImport() {
-        createImports();
+        createImports(BatchId);
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from upload_student_group_import WHERE batch_id=33 AND ref_type = 5",
@@ -102,7 +102,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldCreateAnImportPerSchool() {
-        createImports();
+        createImports(BatchId);
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * from import WHERE batch='33'",
@@ -117,7 +117,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateImportReferences() {
-        createImports();
+        createImports(BatchId);
 
         final List<Map<String, Object>> records = template.queryForList(
                 "SELECT * from upload_student_group WHERE batch_id=33",
@@ -139,7 +139,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
                 new HashMap<>(),
                 Integer.class);
 
-        insertMissingGroups();
+        insertMissingGroups(BatchId);
 
         final List<Map<String, Object>> newGroups = template.queryForList(
                 "SELECT * from student_group WHERE id NOT IN (:existing_groups)",
@@ -154,7 +154,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateDeletedGroups() {
-        updateDeletedGroups();
+        updateDeletedGroups(BatchId);
 
         final Map<String, Object> deletedGroup = template.queryForMap(
                 "SELECT * from student_group WHERE name = 'Test Student Group 9 - updated school'",
@@ -165,7 +165,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldAssignCreatedAndUnDeletedGroupIds() {
-        updateModifiedGroups();
+        updateModifiedGroups(BatchId);
 
         final List<Map<String, Object>> noGroupId = template.queryForList(
                 "SELECT * from upload_student_group WHERE group_id IS NULL",
@@ -176,7 +176,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateModifiedGroupSubjects() {
-        updateModifiedGroups();
+        updateModifiedGroups(BatchId);
 
         final Map<String, Object> modifiedGroup = template.queryForMap(
                 "SELECT * from student_group WHERE name = 'Test Student Group 8'",
@@ -187,7 +187,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateModifiedGroupUsers() {
-        updateModifiedGroupUsers();
+        updateModifiedGroupUsers(BatchId);
 
         final List<Map<String, Object>> group8Users = template.queryForList(
                 "SELECT * from user_student_group WHERE student_group_id = -8",
@@ -213,7 +213,7 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateModifiedGroupStudents() {
-        updateModifiedGroupStudents();
+        updateModifiedGroupStudents(BatchId);
 
         Map<String, Object> group = template.queryForMap(
                 "SELECT * from student_group WHERE id = -8",
@@ -253,8 +253,48 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
     }
 
     @Test
+    public void itShouldAddStudentsToEmptyGroup() {
+        createImports(34);
+
+        final Map<String, Object> groupWithAddedStudents = template.queryForMap(
+                "SELECT * from upload_student_group where group_id = -5",
+                new HashMap<>());
+        assertThat(groupWithAddedStudents.get("import_id")).isNotNull();
+    }
+
+    @Test
+    public void itShouldClearStudentsFromPopulatedGroup() {
+        createImports(35);
+
+        final Map<String, Object> groupWithClearedStudents = template.queryForMap(
+                "SELECT * from upload_student_group where group_id = -3",
+                new HashMap<>());
+        assertThat(groupWithClearedStudents.get("import_id")).isNotNull();
+    }
+
+    @Test
+    public void itShouldAddUsersToEmptyGroup() {
+        createImports(36);
+
+        final Map<String, Object> groupWithClearedStudents = template.queryForMap(
+                "SELECT * from upload_student_group where group_id = -4",
+                new HashMap<>());
+        assertThat(groupWithClearedStudents.get("import_id")).isNotNull();
+    }
+
+    @Test
+    public void itShouldClearUsersFromPopulatedGroup() {
+        createImports(37);
+
+        final Map<String, Object> groupWithClearedStudents = template.queryForMap(
+                "SELECT * from upload_student_group where group_id = -2",
+                new HashMap<>());
+        assertThat(groupWithClearedStudents.get("import_id")).isNotNull();
+    }
+
+    @Test
     public void itShouldTriggerAMigration() {
-        triggerImports();
+        triggerImports(BatchId);
 
         final List<Map<String, Object>> imports = template.queryForList(
                 "SELECT * FROM import WHERE batch = '33'",
@@ -265,66 +305,66 @@ public class DefaultProcessingGroupImportServiceIT extends RepositoryBackedIT {
                 .containsOnly(1);
     }
 
-    private void createImports() {
+    private void createImports(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
         }
     }
 
-    private void insertMissingGroups() {
+    private void insertMissingGroups(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
-            service.insertMissingGroups(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
+            service.insertMissingGroups(batchId, schoolId);
         }
     }
 
-    private void updateDeletedGroups() {
+    private void updateDeletedGroups(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
-            service.insertMissingGroups(BatchId, schoolId);
-            service.updateDeletedGroups(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
+            service.insertMissingGroups(batchId, schoolId);
+            service.updateDeletedGroups(batchId, schoolId);
         }
     }
 
-    private void updateModifiedGroups() {
+    private void updateModifiedGroups(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
-            service.insertMissingGroups(BatchId, schoolId);
-            service.updateDeletedGroups(BatchId, schoolId);
-            service.updateModifiedGroups(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
+            service.insertMissingGroups(batchId, schoolId);
+            service.updateDeletedGroups(batchId, schoolId);
+            service.updateModifiedGroups(batchId, schoolId);
         }
     }
 
-    private void updateModifiedGroupUsers() {
+    private void updateModifiedGroupUsers(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
-            service.insertMissingGroups(BatchId, schoolId);
-            service.updateDeletedGroups(BatchId, schoolId);
-            service.updateModifiedGroups(BatchId, schoolId);
-            service.updateModifiedGroupUsers(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
+            service.insertMissingGroups(batchId, schoolId);
+            service.updateDeletedGroups(batchId, schoolId);
+            service.updateModifiedGroups(batchId, schoolId);
+            service.updateModifiedGroupUsers(batchId, schoolId);
         }
     }
 
-    private void updateModifiedGroupStudents() {
+    private void updateModifiedGroupStudents(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
-            service.insertMissingGroups(BatchId, schoolId);
-            service.updateDeletedGroups(BatchId, schoolId);
-            service.updateModifiedGroups(BatchId, schoolId);
-            service.updateModifiedGroupUsers(BatchId, schoolId);
-            service.updateModifiedGroupStudents(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
+            service.insertMissingGroups(batchId, schoolId);
+            service.updateDeletedGroups(batchId, schoolId);
+            service.updateModifiedGroups(batchId, schoolId);
+            service.updateModifiedGroupUsers(batchId, schoolId);
+            service.updateModifiedGroupStudents(batchId, schoolId);
         }
     }
 
-    private void triggerImports() {
+    private void triggerImports(final long batchId) {
         for (final int schoolId : SchoolIds) {
-            service.createImports(BatchId, schoolId);
-            service.insertMissingGroups(BatchId, schoolId);
-            service.updateDeletedGroups(BatchId, schoolId);
-            service.updateModifiedGroups(BatchId, schoolId);
-            service.updateModifiedGroupUsers(BatchId, schoolId);
-            service.updateModifiedGroupStudents(BatchId, schoolId);
-            service.triggerImport(BatchId, schoolId);
+            service.createImports(batchId, schoolId);
+            service.insertMissingGroups(batchId, schoolId);
+            service.updateDeletedGroups(batchId, schoolId);
+            service.updateModifiedGroups(batchId, schoolId);
+            service.updateModifiedGroupUsers(batchId, schoolId);
+            service.updateModifiedGroupStudents(batchId, schoolId);
+            service.triggerImport(batchId, schoolId);
         }
     }
 }

--- a/group-processor/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/group-processor/src/test/resources/WarehouseEntitiesSetup.sql
@@ -70,7 +70,11 @@ INSERT INTO warehouse_test.student_group (id, creator, school_id, school_year, n
   (-91, 'dwtest@example.com', -99, 2017, 'Test Student Group 9 - updated school', null, -5000, -79, 1, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:10:34.966000'),
   (-8, 'dwtest@example.com', -1, 2017, 'Test Student Group 8', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
   (-7, 'dwtest@example.com', -98, 2017, 'Test Student Group 7', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
-  (-6, 'dwtest@example.com', -1, 2017, 'Test Student Group 6', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000');
+  (-6, 'dwtest@example.com', -1, 2017, 'Test Student Group 6', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
+  (-5, 'dwtest@example.com', -1, 2017, 'No Student Group', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
+  (-4, 'dwtest@example.com', -1, 2017, 'No User Group', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
+  (-3, 'dwtest@example.com', -1, 2017, 'Existing Student Group', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000'),
+  (-2, 'dwtest@example.com', -1, 2017, 'Existing User Group', null, -79, -79, 1, 0, '2017-07-18 19:10:34.966000', '2017-07-18 19:10:34.966000');
 
 INSERT INTO warehouse_test.student_group_membership (student_group_id, student_id) VALUES
   (-91, -89),
@@ -83,7 +87,8 @@ INSERT INTO warehouse_test.student_group_membership (student_group_id, student_i
   (-7, -33),
   (-6, -87),
   (-6, -86),
-  (-6, -33);
+  (-6, -33),
+  (-3, -33);
 
 INSERT INTO warehouse_test.user_student_group (student_group_id, user_login) VALUES
   (-91, 'dwtest@example.com-91'),
@@ -91,7 +96,8 @@ INSERT INTO warehouse_test.user_student_group (student_group_id, user_login) VAL
   (-7, 'dwtest@example.com-7'),
   (-91, 'dwtest@example.com-91-2'),
   (-6, 'dwtest@example.com-6-1'),
-  (-6, 'dwtest@example.com-6-2');
+  (-6, 'dwtest@example.com-6-2'),
+  (-2, 'dwtest@example.com-6-2');
 
 
 INSERT INTO warehouse_test.exam_student ( id, grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage,

--- a/group-processor/src/test/resources/WarehouseGroupImportServiceSetup.sql
+++ b/group-processor/src/test/resources/WarehouseGroupImportServiceSetup.sql
@@ -15,4 +15,12 @@ INSERT INTO upload_student_group (batch_id, group_name, school_year, school_natu
   -- Subject change group
   (33, 'Test Student Group 8', 2017, 'natural_id-1', -1, null, null, -8, null, 1),
   -- Deleted group
-  (33, 'Test Student Group 9 - updated school', 2017, 'natural_id-99', -99, null, null, null, null, null);
+  (33, 'Test Student Group 9 - updated school', 2017, 'natural_id-99', -99, null, null, null, null, null),
+  -- Add student to group without students
+  (34, 'No Student Group', 2017, 'natural_id-1', -1, '33', -33, -5, null, null),
+  -- Remove students from group with students
+  (35, 'Existing Student Group', 2017, 'natural_id-1', -1, null, null, -3, null, null),
+  -- Add user to group without students
+  (36, 'No User Group', 2017, 'natural_id-1', -1, null, null, -4, 'user1@somewhere.com', null),
+  -- Remove users from group with users
+  (37, 'Existing User Group', 2017, 'natural_id-1', -1, null, null, -2, null, null);


### PR DESCRIPTION
Allow clearing users/students from group with users/students

This PR updates the SQL that detects user/student membership changes for groups to account for empty user/student membership lists in both the existing group and uploaded CSV.