### PR TITLE
slight efficiency improvements

### DIFF
--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
@@ -3,15 +3,21 @@ package org.opentestsystem.rdw.ingest.migrate.reporting.repository.impl;
 import org.opentestsystem.rdw.ingest.migrate.reporting.repository.SqlCopyWarehouseToStagingRepository;
 import org.opentestsystem.rdw.ingest.migrate.reporting.step.SqlCopyStatements;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.ColumnMapRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Jdbc implementation of {@link SqlCopyWarehouseToStagingRepository}.
@@ -32,38 +38,59 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
     @Override
     @Transactional
     public void execute(final List<SqlCopyStatements> copyStatementsList, final Instant firstAt, final Instant lastAt, final long migrateId) {
+        final MapSqlParameterSource queryParams = new MapSqlParameterSource()
+                .addValue("first_at", Timestamp.from(firstAt))
+                .addValue("last_at", Timestamp.from(lastAt));
         for (final SqlCopyStatements sqlCopyStatements : copyStatementsList) {
-            final List<Map<String, Object>> result = warehouseJdbcTemplate.queryForList(sqlCopyStatements.getWarehouseRead(),
-                    new MapSqlParameterSource("first_at", Timestamp.from(firstAt))
-                            .addValue("last_at", Timestamp.from(lastAt)));
-
-            execute(sqlCopyStatements.getStagingInsert(), result, migrateId);
+            final List<SqlParameterSource> params = warehouseJdbcTemplate.query(
+                    sqlCopyStatements.getWarehouseRead(), queryParams, new SqlParamsRowMapper(migrateId));
+            final SqlParameterSource[] stagingParams = params.toArray(new SqlParameterSource[params.size()]);
+            reportingJdbcTemplate.batchUpdate(sqlCopyStatements.getStagingInsert(), stagingParams);
         }
     }
 
     @Override
     @Transactional
     public void execute(final List<SqlCopyStatements> copyStatementsList) {
+        final MapSqlParameterSource queryParams = new MapSqlParameterSource();
         for (final SqlCopyStatements sqlCopyStatements : copyStatementsList) {
-            execute(sqlCopyStatements.getStagingInsert(), warehouseJdbcTemplate.queryForList(sqlCopyStatements.getWarehouseRead(), new MapSqlParameterSource()), null);
+            final List<SqlParameterSource> params = warehouseJdbcTemplate.query(
+                    sqlCopyStatements.getWarehouseRead(), queryParams, new SqlParamsRowMapper());
+            final SqlParameterSource[] stagingParams = params.toArray(new SqlParameterSource[params.size()]);
+            reportingJdbcTemplate.batchUpdate(sqlCopyStatements.getStagingInsert(), stagingParams);
         }
     }
 
-    private void execute(final String stagingInsertSql, final List<Map<String, Object>> result, final Long migrateId) {
-        if (result.isEmpty()) return;
+    /**
+     * A RowMapper that converts a row directly into a SqlParameterSource.
+     * Implementation inspired by {@link ColumnMapRowMapper}.
+     */
+    private static class SqlParamsRowMapper implements RowMapper<SqlParameterSource> {
 
-        final MapSqlParameterSource[] stagingParams = new MapSqlParameterSource[result.size()];
-        int i = 0;
-        for (final Map<String, Object> row : result) {
+        private final Long migrateId;
 
-            final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-            for (final String col : row.keySet()) {
-                parameterSource.addValue(col, row.get(col));
-            }
-            if (migrateId != null) parameterSource.addValue("migrate_id", migrateId);
-            stagingParams[i++] = parameterSource;
+        SqlParamsRowMapper() {
+            this.migrateId = null;
         }
 
-        reportingJdbcTemplate.batchUpdate(stagingInsertSql, stagingParams);
+        SqlParamsRowMapper(final Long migrateId) {
+            this.migrateId = migrateId;
+        }
+
+        @Override
+        public SqlParameterSource mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+            final ResultSetMetaData rsmd = rs.getMetaData();
+            final int columnCount = rsmd.getColumnCount();
+            final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+            for (int i = 1; i <= columnCount; i++) {
+                final String key = JdbcUtils.lookupColumnName(rsmd, i);
+                final Object value = JdbcUtils.getResultSetValue(rs, i);
+                parameterSource.addValue(key, value);
+            }
+            if (migrateId != null) {
+                parameterSource.addValue("migrate_id", migrateId);
+            }
+            return parameterSource;
+        }
     }
 }


### PR DESCRIPTION
The code before was doing the query into a `List<Map<key,value>>` and then converting that into a `List<MapSqlParameterSource>`. This eliminates that middle collection, converting directly to the parameter sources. Not sure how much it will really reduce memory consumption but it won't hurt.

I wanted to take it a step further, eliminating the collection of results completely. But the mysql driver doesn't support client-side cursors so i found it wasn't actually streaming the results: it collected the entire result set no matter what i did. After reading about it, there is a workaround to that but it involves server-side cursors which uses temporary tables and ... (ugh).