### PR TITLE
make components in common public so AoP can interact with them properly

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcImportRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcImportRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import static org.opentestsystem.rdw.ingest.common.repository.JdbcUtils.safeText;
 
 @Repository
-class JdbcImportRepository implements ImportRepository {
+public class JdbcImportRepository implements ImportRepository {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSchoolRepository.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 
 @Repository
-class JdbcSchoolRepository implements SchoolRepository {
+public class JdbcSchoolRepository implements SchoolRepository {
 
     private final JdbcTemplate jdbcTemplate;
     private final SimpleJdbcCall upsertSchool;

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorApplication.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorApplication.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.PropertySource;
 })
 public class GroupProcessorApplication {
 
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         SpringApplication.run(GroupProcessorApplication.class, args);
     }
 }


### PR DESCRIPTION
Apparently `gradle bootRun` does some AoP magick that doesn't like components in shared libraries to be non-public.