### PR TITLE
Created an overload for updateBatch in which a message is not passed …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 build/
+out/
 
 *.iml
 .idea/

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfiguration.java
@@ -48,12 +48,12 @@ public class GroupProcessorConfiguration {
 
             final GroupMessage gm = new Gson().fromJson(payload, GroupMessage.class);
             groupProcessor.process(gm);
-            batchRepository.updateBatchStatus(gm.getUploadId(), ImportStatus.PROCESSED, "");
+            batchRepository.updateBatch(gm.getUploadId(), ImportStatus.PROCESSED);
         } catch (final ImportException e) {
             logger.warn("failed with an unexpected import error: " + e.getMessage());
             if (accessor != null) {
                 try {
-                    batchRepository.updateBatchStatus(accessor.getImportId(), e.getStatus(), e.getMessage());
+                    batchRepository.updateBatch(accessor.getImportId(), e.getStatus(), e.getMessage());
                 } catch (final Exception e2) {
                     logger.error("Failed to update batch status: {}", accessor.getImportId());
                 }
@@ -62,7 +62,7 @@ public class GroupProcessorConfiguration {
             logger.warn("failed with an unexpected import error: " + e.getMessage());
             if (accessor != null) {
                 try {
-                    batchRepository.updateBatchStatus(accessor.getImportId(), ImportStatus.BAD_DATA, e.getMessage());
+                    batchRepository.updateBatch(accessor.getImportId(), ImportStatus.BAD_DATA, e.getMessage());
                 } catch (final Exception e2) {
                     logger.error("Failed to update batch status: {}", accessor.getImportId());
                 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepository.java
@@ -1,9 +1,9 @@
 package org.opentestsystem.rdw.ingest.group.repository;
 
-import com.google.common.collect.ImmutableMap;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -24,12 +24,17 @@ public class JdbcStudentGroupBatchRepository implements StudentGroupBatchReposit
     }
 
     @Override
-    public void updateBatchStatus(final long batchId, final ImportStatus status, final String message) {
+    public void updateBatch(final long batchId, final ImportStatus status) {
+        updateBatch(batchId, status, null);
+    }
+
+    @Override
+    public void updateBatch(final long batchId, final ImportStatus status, final String message) {
         template.update(
                 updateBatch,
-                ImmutableMap.of(
-                        "batch_id", batchId,
-                        "status", status.getValue(),
-                        "message", message));
+                new MapSqlParameterSource()
+                    .addValue("batch_id", batchId)
+                    .addValue("status", status.getValue())
+                    .addValue("message", message));
     }
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/StudentGroupBatchRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/StudentGroupBatchRepository.java
@@ -9,11 +9,19 @@ import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 public interface StudentGroupBatchRepository {
 
     /**
-     * Update a student group batch upload status
+     * Update a student group batch upload status and message
      *
      * @param batchId   The batch id
      * @param status    The batch import status
      * @param message   The batch message
      */
-    void updateBatchStatus(long batchId, ImportStatus status, String message);
+    void updateBatch(long batchId, ImportStatus status, String message);
+
+    /**
+     * Update a student group batch upload status
+     *
+     * @param batchId   The batch id
+     * @param status    The batch import status
+     */
+    void updateBatch(long batchId, ImportStatus status);
 }

--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -3,7 +3,7 @@ sql:
   update-batch: >-
     UPDATE upload_student_group_batch
     SET status = :status,
-      message = :message
+      message = coalesce(:message, message)
     WHERE id = :batch_id
 
   find-schools-by-batch: >-

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfigurationTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorConfigurationTest.java
@@ -53,7 +53,7 @@ public class GroupProcessorConfigurationTest {
         processor.process(message);
 
         verify(groupProcessor, times(1)).process(groupMessage);
-        verify(repository).updateBatchStatus(123L, ImportStatus.PROCESSED, "");
+        verify(repository).updateBatch(123L, ImportStatus.PROCESSED);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class GroupProcessorConfigurationTest {
         doThrow(new ImportException(ImportStatus.INVALID, "any message")).when(groupProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
-        verify(repository).updateBatchStatus(123L, ImportStatus.INVALID, "any message");
+        verify(repository).updateBatch(123L, ImportStatus.INVALID, "any message");
     }
 
     @Test
@@ -77,7 +77,7 @@ public class GroupProcessorConfigurationTest {
         doThrow(new RuntimeException("Bad Juju")).when(groupProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
-        verify(repository).updateBatchStatus(123L, ImportStatus.BAD_DATA, "Bad Juju");
+        verify(repository).updateBatch(123L, ImportStatus.BAD_DATA, "Bad Juju");
     }
 
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepositoryIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/repository/JdbcStudentGroupBatchRepositoryIT.java
@@ -30,13 +30,53 @@ public class JdbcStudentGroupBatchRepositoryIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldUpdateBatchStatusAndMessage() {
-        repository.updateBatchStatus(33, ImportStatus.INVALID, "some message");
+        final String message = "some message";
 
-        final Map<String, Object> batch = template.queryForMap(
-                "SELECT * from upload_student_group_batch WHERE id = 33",
-                new HashMap<>());
+        repository.updateBatch(33, ImportStatus.INVALID, message);
+
+        final Map<String, Object> batch =  getUploadStudentGroupBatch();
 
         assertThat(batch.get("status")).isEqualTo(ImportStatus.INVALID.getValue());
-        assertThat(batch.get("message")).isEqualTo("some message");
+        assertThat(batch.get("message")).isEqualTo(message);
+    }
+
+    @Test
+    public void itShouldNotClearAcceptedMessage() {
+        final String message = "some accepted message";
+
+        repository.updateBatch(33, ImportStatus.ACCEPTED, message);
+
+        final Map<String, Object> batchAccepted =  getUploadStudentGroupBatch();
+
+        assertThat(batchAccepted.get("status")).isEqualTo(ImportStatus.ACCEPTED.getValue());
+        assertThat(batchAccepted.get("message")).isEqualTo(message);
+
+        repository.updateBatch(33, ImportStatus.PROCESSED);
+        final Map<String, Object> batchProcessed =  getUploadStudentGroupBatch();
+
+        assertThat(batchProcessed.get("status")).isEqualTo(ImportStatus.PROCESSED.getValue());
+        assertThat(batchProcessed.get("message")).isEqualTo(message);
+    }
+
+    @Test
+    public void itShouldClearAcceptedWhenEmptyStringMessage() {
+        final String message = "some accepted message";
+
+        repository.updateBatch(33, ImportStatus.ACCEPTED, message);
+
+        final Map<String, Object> batchAccepted =  getUploadStudentGroupBatch();
+
+        assertThat(batchAccepted.get("status")).isEqualTo(ImportStatus.ACCEPTED.getValue());
+        assertThat(batchAccepted.get("message")).isEqualTo(message);
+
+        repository.updateBatch(33, ImportStatus.INVALID, "");
+        final Map<String, Object> batchInvalid = getUploadStudentGroupBatch();
+
+        assertThat(batchInvalid.get("status")).isEqualTo(ImportStatus.INVALID.getValue());
+        assertThat(batchInvalid.get("message")).isEqualTo("");
+    }
+
+    private Map<String, Object> getUploadStudentGroupBatch() {
+        return template.queryForMap("SELECT * from upload_student_group_batch WHERE id = 33",  new HashMap<>());
     }
 }


### PR DESCRIPTION
…and therefor is left unchanged.

Previously the message was being cleared when updating the status from ACCEPTED to PROCESSED.

So I started down the path of actually trying to track how many groups were created / modified by the group processor.  However, the more I got into it, the more of a rabbit hole it became requiring me to modify common interfaces & models that a lot of places were using.  After discussion with @wtritch , we opted to just keep the existing Accept message as good enough for now, and circle back to having a more detailed later message if this becomes a bigger requirement.