### PR TITLE
Clean up JdbcSqlListExecutionRepository.

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSqlListExecutionRepository.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/repository/JdbcSqlListExecutionRepository.java
@@ -1,0 +1,38 @@
+package org.opentestsystem.rdw.ingest.common.repository;
+
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * JDBC implementation of a SqlListExecutionRepository.
+ */
+public class JdbcSqlListExecutionRepository implements SqlListExecutionRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public JdbcSqlListExecutionRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Transactional
+    @Override
+    public void execute(final Iterable<String> sqls) {
+        final JdbcOperations operations = jdbcTemplate.getJdbcOperations();
+        for (final String sql : sqls) {
+            operations.execute(sql);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void execute(final Iterable<String> sqls, final Map<String, ?> parameters) {
+        final SqlParameterSource params = new MapSqlParameterSource(parameters);
+        for (final String sql : sqls) {
+            jdbcTemplate.update(sql, params);
+        }
+    }
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/DefaultSqlListExecutionRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/DefaultSqlListExecutionRepository.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.group.repository;
 
+import org.opentestsystem.rdw.ingest.common.repository.JdbcSqlListExecutionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -8,10 +9,10 @@ import org.springframework.stereotype.Repository;
  * JDBC implementation of a SqlListExecutionRepository.
  */
 @Repository
-public class JdbcSqlListExecutionRepository extends org.opentestsystem.rdw.ingest.common.repository.JdbcSqlListExecutionRepository {
+public class DefaultSqlListExecutionRepository extends JdbcSqlListExecutionRepository {
 
     @Autowired
-    public JdbcSqlListExecutionRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
+    public DefaultSqlListExecutionRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
         super(jdbcTemplate);
     }
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcSqlListExecutionRepository.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/repository/JdbcSqlListExecutionRepository.java
@@ -1,37 +1,17 @@
 package org.opentestsystem.rdw.ingest.group.repository;
 
-import org.opentestsystem.rdw.ingest.common.repository.SqlListExecutionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
-
-import java.util.Map;
 
 /**
  * JDBC implementation of a SqlListExecutionRepository.
  */
 @Repository
-public class JdbcSqlListExecutionRepository implements SqlListExecutionRepository {
+public class JdbcSqlListExecutionRepository extends org.opentestsystem.rdw.ingest.common.repository.JdbcSqlListExecutionRepository {
 
     @Autowired
-    private NamedParameterJdbcTemplate jdbcTemplate;
-
-    @Override
-    public void execute(final Iterable<String> sqls) {
-        final JdbcOperations operations = jdbcTemplate.getJdbcOperations();
-        for (final String sql : sqls) {
-            operations.execute(sql);
-        }
-    }
-
-    @Override
-    public void execute(final Iterable<String> sqls, final Map<String, ?> parameters) {
-        final SqlParameterSource params = new MapSqlParameterSource(parameters);
-        for (final String sql : sqls) {
-            jdbcTemplate.update(sql, params);
-        }
+    public JdbcSqlListExecutionRepository(final NamedParameterJdbcTemplate jdbcTemplate) {
+        super(jdbcTemplate);
     }
 }

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/RepositoryBackedIT.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/RepositoryBackedIT.java
@@ -3,7 +3,7 @@ package org.opentestsystem.rdw.ingest.group;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.group.configuration.DataSourceConfiguration;
 import org.opentestsystem.rdw.ingest.group.configuration.GroupProcessingSqlConfiguration;
-import org.opentestsystem.rdw.ingest.group.repository.JdbcSqlListExecutionRepository;
+import org.opentestsystem.rdw.ingest.group.repository.DefaultSqlListExecutionRepository;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(classes = {
         DataSourceConfiguration.class,
         GroupProcessingSqlConfiguration.class,
-        JdbcSqlListExecutionRepository.class,
+        DefaultSqlListExecutionRepository.class,
         YamlPropertiesConfigurator.class
 })
 @ContextConfiguration(classes = {RepositoryBackedConfig.class})

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcReportingSqlListExecutionRepository.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcReportingSqlListExecutionRepository.java
@@ -10,9 +10,9 @@ import org.springframework.stereotype.Repository;
  * Jdbc implementation of {@link SqlListExecutionRepository} on the reporting datamart
  */
 @Repository
-class JdbcReportingSqlListExecutionRepository extends JdbcSqlListExecutionRepository {
+class ReportingSqlListExecutionRepository extends JdbcSqlListExecutionRepository {
 
-    public JdbcReportingSqlListExecutionRepository(@Qualifier("reportingJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
+    public ReportingSqlListExecutionRepository(@Qualifier("reportingJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
         super(jdbcTemplate);
     }
 }

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcReportingSqlListExecutionRepository.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcReportingSqlListExecutionRepository.java
@@ -1,42 +1,18 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting.repository.impl;
 
+import org.opentestsystem.rdw.ingest.common.repository.JdbcSqlListExecutionRepository;
 import org.opentestsystem.rdw.ingest.common.repository.SqlListExecutionRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
 
 /**
  * Jdbc implementation of {@link SqlListExecutionRepository} on the reporting datamart
  */
 @Repository
-class JdbcReportingSqlListExecutionRepository implements SqlListExecutionRepository {
+class JdbcReportingSqlListExecutionRepository extends JdbcSqlListExecutionRepository {
 
-    @Autowired
-    @Qualifier("reportingJdbcTemplate")
-    private NamedParameterJdbcTemplate jdbcTemplate;
-
-    @Transactional
-    @Override
-    public void execute(final Iterable<String> sqls) {
-
-        for (final String sql : sqls) {
-            jdbcTemplate
-                    .getJdbcOperations()
-                    .execute(sql);
-        }
-    }
-
-    @Transactional
-    @Override
-    public void execute(final Iterable<String> sqls, final Map<String, ?> parameters) {
-
-        for (final String sql : sqls) {
-            jdbcTemplate
-                    .update(sql, parameters);
-        }
+    public JdbcReportingSqlListExecutionRepository(@Qualifier("reportingJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
+        super(jdbcTemplate);
     }
 }


### PR DESCRIPTION
There were two implementations that seemed almost identical.
And I will most likely need another one for the aggregate reports migrate. So I have decided to clean it up.