### PR TITLE
Add a DELETE API to the import-service exams endpoints

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -137,6 +138,15 @@ class DefaultImportService implements ImportService {
             return Optional.empty();
         }
         return Optional.of(archiveService.readResource(location(rdwImport)));
+    }
+
+    @Override
+    public void deleteImport(final long importId, final ImportContent content) {
+        final RdwImport rdwImport = repository.findOne(importId);
+        if (rdwImport == null || rdwImport.getContent() != content) {
+            throw new NoSuchElementException("Import: " + importId + " Type: " + content.name() + " not found.");
+        }
+        source.submitDelete(importId, content);
     }
 
     private static String location(final RdwImport rdwImport) {

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -141,12 +141,20 @@ class DefaultImportService implements ImportService {
     }
 
     @Override
-    public void deleteImport(final long importId, final ImportContent content) {
-        final RdwImport rdwImport = repository.findOne(importId);
-        if (rdwImport == null || rdwImport.getContent() != content) {
+    public void deleteImport(final SbacUserDetails user,
+                             final long importId,
+                             final ImportContent content) {
+        final RdwImport importToDelete = repository.findOne(importId);
+        if (importToDelete == null || importToDelete.getContent() != content) {
             throw new NoSuchElementException("Import: " + importId + " Type: " + content.name() + " not found.");
         }
-        source.submitDelete(importId, content);
+
+        final RdwImport deleteImport = repository.create(RdwImport.builder()
+                .content(content)
+                .status(ImportStatus.ACCEPTED)
+                .creator(user.getUsername())
+                .build());
+        source.submitDelete(deleteImport.getId(), importToDelete.getId(), content);
     }
 
     private static String location(final RdwImport rdwImport) {

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -32,6 +32,7 @@ class DefaultImportService implements ImportService {
     private static final String ContentTypeProperty = "Content-Type";
     private static final String UsernameProperty = "username";
     private static final String TenancyChainProperty = "tenancy-chain";
+    private static final String DeleteContentType = "delete";
 
     private final RdwImportRepository repository;
     private final ArchiveService archiveService;
@@ -151,6 +152,8 @@ class DefaultImportService implements ImportService {
 
         final RdwImport deleteImport = repository.create(RdwImport.builder()
                 .content(content)
+                .contentType(DeleteContentType)
+                .digest(String.valueOf(importId))
                 .status(ImportStatus.ACCEPTED)
                 .creator(user.getUsername())
                 .build());

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.service;
 
+import com.google.common.base.Joiner;
 import org.opentestsystem.rdw.ingest.common.model.ImportContent;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +30,9 @@ import static org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor.wrap;
 @Service
 @EnableBinding
 class DefaultImportSource implements ImportSource {
+    static final String OperationHeader = "X-Operation";
+    static final String OperationDelete = "DELETE";
+    private static final Joiner ChannelJoiner = Joiner.on("_").skipNulls();
 
     private BinderAwareChannelResolver resolver;
     private MessageChannel outputChannel;
@@ -57,6 +61,16 @@ class DefaultImportSource implements ImportSource {
         outputChannel.send(MessageBuilder.createMessage(body, accessor.getMessageHeaders()));
     }
 
+    @Override
+    public void submitDelete(final long importId, final ImportContent content) {
+        final RdwMessageHeaderAccessor accessor = wrap(null)
+                .setReceivedNow()
+                .setContent(content.toString())
+                .setImportId(importId);
+        accessor.setHeader(OperationHeader, OperationDelete);
+        outputChannel.send(MessageBuilder.createMessage(importId, accessor.getMessageHeaders()));
+    }
+
     @Bean(name = "sourceChannel")
     public MessageChannel outputChannel() {
         return new DirectChannel();
@@ -69,7 +83,8 @@ class DefaultImportSource implements ImportSource {
             @Override
             protected List<Object> getChannelKeys(final Message<?> message) {
                 final RdwMessageHeaderAccessor accessor = wrap(message);
-                return Collections.singletonList(accessor.getContent());
+                final String operation = (String) accessor.getHeader(OperationHeader);
+                return Collections.singletonList(ChannelJoiner.join(accessor.getContent(), operation));
             }
         };
         router.setChannelResolver(resolver);

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportSource.java
@@ -62,13 +62,13 @@ class DefaultImportSource implements ImportSource {
     }
 
     @Override
-    public void submitDelete(final long importId, final ImportContent content) {
+    public void submitDelete(final long importId, final long deletedImportId, final ImportContent content) {
         final RdwMessageHeaderAccessor accessor = wrap(null)
                 .setReceivedNow()
                 .setContent(content.toString())
                 .setImportId(importId);
         accessor.setHeader(OperationHeader, OperationDelete);
-        outputChannel.send(MessageBuilder.createMessage(importId, accessor.getMessageHeaders()));
+        outputChannel.send(MessageBuilder.createMessage(deletedImportId, accessor.getMessageHeaders()));
     }
 
     @Bean(name = "sourceChannel")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
@@ -67,4 +67,10 @@ public interface ImportService {
      * @return the import payload data, absent if import not found
      */
     Optional<byte[]> getPayload(long id);
+
+    /**
+     * @param importId  import resource id
+     * @param content   the import content type
+     */
+    void deleteImport(long importId, ImportContent content);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
@@ -69,8 +69,11 @@ public interface ImportService {
     Optional<byte[]> getPayload(long id);
 
     /**
+     * Delete the resource(s) created by the given import id.
+     *
+     * @param user      user credentials
      * @param importId  import resource id
      * @param content   the import content type
      */
-    void deleteImport(long importId, ImportContent content);
+    void deleteImport(SbacUserDetails user, long importId, ImportContent content);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportSource.java
@@ -16,4 +16,12 @@ interface ImportSource {
      * @param importId id of import resource associated with this content
      */
     void submitContent(byte[] body, ImportContent content, String contentType, Long importId);
+
+    /**
+     * Submit the given import for deletion.
+     *
+     * @param importId  The import id
+     * @param content   The import content type
+     */
+    void submitDelete(long importId, ImportContent content);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportSource.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportSource.java
@@ -20,8 +20,9 @@ interface ImportSource {
     /**
      * Submit the given import for deletion.
      *
-     * @param importId  The import id
-     * @param content   The import content type
+     * @param importId          The processing import id
+     * @param deletedImportId   The import id to delete
+     * @param content           The import content type
      */
-    void submitDelete(long importId, ImportContent content);
+    void submitDelete(long importId, long deletedImportId, ImportContent content);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
@@ -8,7 +8,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -54,6 +56,12 @@ class ExamController extends ScopedImportController {
     @GetMapping("/imports")
     public List<RdwImportResource> getImports(final RdwImportQuery query) {
         return super.getImports(query);
+    }
+
+    @DeleteMapping("/imports/{importId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteImport(@PathVariable("importId") final long importId) {
+        super.deleteImport(importId);
     }
 
     @PostMapping("/imports/resubmit")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
@@ -60,8 +60,9 @@ class ExamController extends ScopedImportController {
 
     @DeleteMapping("/imports/{importId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteImport(@PathVariable("importId") final long importId) {
-        super.deleteImport(importId);
+    public void deleteImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
+                             @PathVariable("importId") final long importId) {
+        super.deleteImport(sbacUser, importId);
     }
 
     @PostMapping("/imports/resubmit")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
@@ -98,7 +98,8 @@ abstract class ScopedImportController {
         return content == query.getContent() ? query : query.copy().content(content).build();
     }
 
-    protected void deleteImport(final long importId) {
-        service.deleteImport(importId, content);
+    protected void deleteImport(final SbacUserDetails user,
+                                final long importId) {
+        service.deleteImport(user, importId, content);
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
@@ -97,4 +97,8 @@ abstract class ScopedImportController {
     private RdwImportQuery ensureQueryForContent(final RdwImportQuery query) {
         return content == query.getContent() ? query : query.copy().content(content).build();
     }
+
+    protected void deleteImport(final long importId) {
+        service.deleteImport(importId, content);
+    }
 }

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -52,6 +52,9 @@ spring:
         EXAM:
           producer:
             requiredGroups: default
+        EXAM_DELETE:
+          producer:
+            requiredGroups: default
         ORGANIZATION:
           producer:
             requiredGroups: default

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
@@ -6,25 +6,26 @@ import org.junit.Test;
 import org.opentestsystem.rdw.archive.ArchiveService;
 import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.auth.SbacUserTest;
-import org.opentestsystem.rdw.ingest.common.model.ImportContent;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Properties;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.EXAM;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.ORGANIZATION;
 
 public class DefaultImportServiceTest {
 
@@ -54,10 +55,10 @@ public class DefaultImportServiceTest {
         final String contentType = "application/xml";
         final String batch = "batch123";
 
-        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, singletonMap("batch", batch)).getBatch())
+        assertThat(service.importContent(user, body, EXAM, contentType, singletonMap("batch", batch)).getBatch())
                 .isEqualTo(batch);
 
-        verify(importSource).submitContent(body, ImportContent.EXAM, contentType, 123L);
+        verify(importSource).submitContent(body, EXAM, contentType, 123L);
     }
 
     @Test
@@ -70,7 +71,7 @@ public class DefaultImportServiceTest {
         final RdwImport match = RdwImport.builder().build();
         when(repository.findOneByDigest(digest)).thenReturn(match);
 
-        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null)).isSameAs(match);
+        assertThat(service.importContent(user, body, EXAM, contentType, null)).isSameAs(match);
     }
 
     @Test
@@ -92,7 +93,7 @@ public class DefaultImportServiceTest {
         final RdwImportQuery query = RdwImportQuery.builder().status(ImportStatus.ACCEPTED).build();
         final RdwImport rdwImport = RdwImport.builder()
                 .id(123L)
-                .content(ImportContent.EXAM)
+                .content(EXAM)
                 .digest("12345678")
                 .build();
         final String contentType = "text/plain";
@@ -109,7 +110,7 @@ public class DefaultImportServiceTest {
 
         assertThat(service.resubmitImports(query)).isEqualTo(1);
 
-        verify(importSource).submitContent(eq(payload), eq(ImportContent.EXAM), eq(contentType), eq(123L));
+        verify(importSource).submitContent(eq(payload), eq(EXAM), eq(contentType), eq(123L));
     }
 
     @Test
@@ -124,5 +125,33 @@ public class DefaultImportServiceTest {
     @Test(expected = IllegalArgumentException.class)
     public void itShouldFailWithAnEmptyQuery() {
         service.resubmitImports(RdwImportQuery.builder().build());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldThrowIfDeletingANonExistentImport() {
+        when(repository.findOne(123L)).thenReturn(null);
+        service.deleteImport(123, EXAM);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void itShouldThrowIfDeletingAMismatchedImport() {
+        final RdwImport organizationImport = RdwImport.builder()
+                .id(123L)
+                .content(ORGANIZATION)
+                .build();
+        when(repository.findOne(123L)).thenReturn(organizationImport);
+        service.deleteImport(123, EXAM);
+    }
+
+    @Test
+    public void itShouldSubmitAnImportDeletion() {
+        final RdwImport examImport = RdwImport.builder()
+                .id(123L)
+                .content(EXAM)
+                .build();
+        when(repository.findOne(123L)).thenReturn(examImport);
+        service.deleteImport(123, EXAM);
+
+        verify(importSource).submitDelete(123L, EXAM);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
@@ -129,29 +129,32 @@ public class DefaultImportServiceTest {
 
     @Test(expected = NoSuchElementException.class)
     public void itShouldThrowIfDeletingANonExistentImport() {
+        final SbacUserDetails user = SbacUserTest.testUser();
         when(repository.findOne(123L)).thenReturn(null);
-        service.deleteImport(123, EXAM);
+        service.deleteImport(user,123, EXAM);
     }
 
     @Test(expected = NoSuchElementException.class)
     public void itShouldThrowIfDeletingAMismatchedImport() {
+        final SbacUserDetails user = SbacUserTest.testUser();
         final RdwImport organizationImport = RdwImport.builder()
                 .id(123L)
                 .content(ORGANIZATION)
                 .build();
         when(repository.findOne(123L)).thenReturn(organizationImport);
-        service.deleteImport(123, EXAM);
+        service.deleteImport(user,123, EXAM);
     }
 
     @Test
     public void itShouldSubmitAnImportDeletion() {
+        final SbacUserDetails user = SbacUserTest.testUser();
         final RdwImport examImport = RdwImport.builder()
-                .id(123L)
+                .id(456L)
                 .content(EXAM)
                 .build();
-        when(repository.findOne(123L)).thenReturn(examImport);
-        service.deleteImport(123, EXAM);
+        when(repository.findOne(456L)).thenReturn(examImport);
+        service.deleteImport(user,456, EXAM);
 
-        verify(importSource).submitDelete(123L, EXAM);
+        verify(importSource).submitDelete(123L, 456L, EXAM);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportSourceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportSourceTest.java
@@ -4,29 +4,42 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.opentestsystem.rdw.ingest.common.model.ImportContent;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.http.MediaType;
+import org.springframework.integration.channel.NullChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.EXAM;
+import static org.opentestsystem.rdw.ingest.service.DefaultImportSource.OperationDelete;
+import static org.opentestsystem.rdw.ingest.service.DefaultImportSource.OperationHeader;
 
 @RunWith(SpringRunner.class)
 public class DefaultImportSourceTest {
 
     private DefaultImportSource importSource;
     private MessageChannel channel;
+    private BinderAwareChannelResolver channelResolver;
 
     @Before
     public void createImportSource() {
         channel = mock(MessageChannel.class);
 
+        final MessageChannel routedChannel = new NullChannel();
+        channelResolver = mock(BinderAwareChannelResolver.class);
+        when(channelResolver.resolveDestination(anyString()))
+                .thenReturn(routedChannel);
+
         importSource = new DefaultImportSource();
         importSource.setOutputChannel(channel);
+        importSource.setResolver(channelResolver);
     }
 
     @Test
@@ -34,7 +47,7 @@ public class DefaultImportSourceTest {
         final byte[] body = "<TDSReport/>".getBytes();
         final long importId = 123L;
 
-        importSource.submitContent(body, ImportContent.EXAM, "application/xml", importId);
+        importSource.submitContent(body, EXAM, "application/xml", importId);
 
         final ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
         verify(channel).send(messageArgumentCaptor.capture());
@@ -43,5 +56,26 @@ public class DefaultImportSourceTest {
         assertThat(message.getPayload()).isEqualTo(body);
         assertThat(accessor.getContentType()).isEqualTo(MediaType.APPLICATION_XML);
         assertThat(accessor.getImportId()).isEqualTo(importId);
+
+        importSource.router().handleMessage(message);
+        verify(channelResolver).resolveDestination(EXAM.name());
+    }
+
+    @Test
+    public void itShouldSubmitADeleteMessage() {
+        final long importId = 123L;
+
+        importSource.submitDelete(importId, EXAM);
+
+        final ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(channel).send(messageArgumentCaptor.capture());
+        final Message message = messageArgumentCaptor.getValue();
+        final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
+        assertThat(message.getPayload()).isEqualTo(importId);
+        assertThat(accessor.getHeader(OperationHeader)).isEqualTo(OperationDelete);
+        assertThat(accessor.getImportId()).isEqualTo(importId);
+
+        importSource.router().handleMessage(message);
+        verify(channelResolver).resolveDestination(EXAM.name() + "_" + OperationDelete);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportSourceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportSourceTest.java
@@ -64,14 +64,15 @@ public class DefaultImportSourceTest {
     @Test
     public void itShouldSubmitADeleteMessage() {
         final long importId = 123L;
+        final long deletedImportId = 456L;
 
-        importSource.submitDelete(importId, EXAM);
+        importSource.submitDelete(importId, deletedImportId, EXAM);
 
         final ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
         verify(channel).send(messageArgumentCaptor.capture());
         final Message message = messageArgumentCaptor.getValue();
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
-        assertThat(message.getPayload()).isEqualTo(importId);
+        assertThat(message.getPayload()).isEqualTo(deletedImportId);
         assertThat(accessor.getHeader(OperationHeader)).isEqualTo(OperationDelete);
         assertThat(accessor.getImportId()).isEqualTo(importId);
 

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.ingest.web;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.opentestsystem.rdw.ingest.common.model.ImportContent;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
@@ -19,6 +18,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.NoSuchElementException;
+
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -27,11 +28,14 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.common.model.ImportContent.EXAM;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -59,7 +63,7 @@ public class ExamControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
+        when(importService.importContent(any(), eq(body), eq(EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
         mvc.perform(fileUpload(EXAMS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
@@ -77,7 +81,7 @@ public class ExamControllerIT {
     public void itShouldUseServiceToImportExamRawBody() throws Exception {
         final byte[] body = "<TDSReport/>".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
+        when(importService.importContent(any(), eq(body), eq(EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
         mvc.perform(post(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
@@ -146,7 +150,7 @@ public class ExamControllerIT {
         final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
         verify(importService).resubmitImports(argumentCaptor.capture());
         final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
+        assertThat(query.getContent()).isEqualTo(EXAM);
         assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
     }
 
@@ -173,7 +177,24 @@ public class ExamControllerIT {
         final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
         verify(importService).resubmitImports(argumentCaptor.capture());
         final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
+        assertThat(query.getContent()).isEqualTo(EXAM);
         assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
+    }
+
+    @Test
+    public void itShouldDeleteAnExamImport() throws Exception {
+        mvc.perform(delete(EXAMS_URI + "/123").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isNoContent());
+
+        verify(importService).deleteImport(123L, EXAM);
+    }
+
+    @Test
+    public void itShouldReturnNotFoundIfImportDoesNotExist() throws Exception {
+        doThrow(new NoSuchElementException("Go Fish"))
+                .when(importService).deleteImport(123L, EXAM);
+
+        mvc.perform(delete(EXAMS_URI + "/123").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isNotFound());
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.ingest.web;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
@@ -186,13 +187,13 @@ public class ExamControllerIT {
         mvc.perform(delete(EXAMS_URI + "/123").header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().isNoContent());
 
-        verify(importService).deleteImport(123L, EXAM);
+        verify(importService).deleteImport(any(SbacUserDetails.class), eq(123L), eq(EXAM));
     }
 
     @Test
     public void itShouldReturnNotFoundIfImportDoesNotExist() throws Exception {
         doThrow(new NoSuchElementException("Go Fish"))
-                .when(importService).deleteImport(123L, EXAM);
+                .when(importService).deleteImport(any(SbacUserDetails.class), eq(123L), eq(EXAM));
 
         mvc.perform(delete(EXAMS_URI + "/123").header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().isNotFound());


### PR DESCRIPTION
This PR adds a DELETE `/exams/imports/{importId}' endpoint to the ExamController in the import-service.  The endpoint verifies the existence of a RDWImport with content EXAM and the given Id, then submits a message with the importId to the new EXAM_DELETE channel.
This will be followed up by a PR in the exam-processor that is responsible for soft-deleting the Exam identified by the importId.