### PR TITLE
Feature/delete exam by import

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfiguration.java
@@ -96,7 +96,7 @@ public class ExamProcessorConfiguration {
 
     private void processDelete(final long importId, final long deletedImportId) {
         try {
-            reportProcessor.processDelete(importId, deletedImportId);
+            reportProcessor.processDelete(deletedImportId, importId);
             importRepository.updateStatusAndMessageById(importId, ImportStatus.PROCESSED, null);
 
         } catch (final ImportException e) {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfiguration.java
@@ -1,11 +1,12 @@
 package org.opentestsystem.rdw.ingest.processor;
 
+import org.opentestsystem.rdw.common.model.trt.TDSReport;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.repository.ImportRepository;
 import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
+import org.opentestsystem.rdw.ingest.processor.stream.ExamProcessorSink;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
-import org.opentestsystem.rdw.common.model.trt.TDSReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ import java.io.ByteArrayInputStream;
 import static org.opentestsystem.rdw.common.model.trt.XmlUtils.tdsReportFromXml;
 
 
-@EnableBinding(Sink.class)
+@EnableBinding(ExamProcessorSink.class)
 public class ExamProcessorConfiguration {
     private static final Logger logger = LoggerFactory.getLogger(ExamProcessorConfiguration.class);
 
@@ -34,12 +35,11 @@ public class ExamProcessorConfiguration {
     }
 
     @ServiceActivator(inputChannel = Sink.INPUT)
-    public void process(final Message<?> message) {
+    public void processUpsert(final Message<?> message) {
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
         final byte[] payload = (byte[]) message.getPayload();
         final long importId = accessor.getImportId();
-
-        logger.debug("received {} import {}", accessor.getContent(), importId);
+        logger.debug("received {} upsert, import {}", accessor.getContent(), importId);
 
         try {
             final TDSReport report = toTDSReport(new ByteArrayInputStream(payload), importId);
@@ -48,16 +48,31 @@ public class ExamProcessorConfiguration {
                 return;
             }
 
-            process(report, importId);
+            processUpsert(report, importId);
         } catch (final Exception e) {
             logger.warn("failed with an unexpected import error: " + e.getMessage());
             importRepository.updateStatusAndMessageById(importId, ImportStatus.INVALID, e.getMessage());
         }
     }
 
-    private void process(final TDSReport tdsReport, final long importId) {
+    @ServiceActivator(inputChannel = ExamProcessorSink.DELETE)
+    public void processDelete(final Message<?> message) {
+        final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
+        final long deletedImportId = (Long) message.getPayload();
+        final long importId = accessor.getImportId();
+        logger.debug("received {} delete, import {}", accessor.getContent(), importId);
+
         try {
-            reportProcessor.process(tdsReport, importId);
+            processDelete(importId, deletedImportId);
+        } catch (final Exception e) {
+            logger.warn("failed with an unexpected import error: " + e.getMessage());
+            importRepository.updateStatusAndMessageById(importId, ImportStatus.INVALID, e.getMessage());
+        }
+    }
+
+    private void processUpsert(final TDSReport tdsReport, final long importId) {
+        try {
+            reportProcessor.processUpsert(tdsReport, importId);
             importRepository.updateStatusAndMessageById(importId, ImportStatus.PROCESSED, null);
 
         } catch (final ImportException e) {
@@ -77,5 +92,19 @@ public class ExamProcessorConfiguration {
             importRepository.updateStatusAndMessageById(importId, ImportStatus.BAD_DATA, e.getMessage());
         }
         return null;
+    }
+
+    private void processDelete(final long importId, final long deletedImportId) {
+        try {
+            reportProcessor.processDelete(importId, deletedImportId);
+            importRepository.updateStatusAndMessageById(importId, ImportStatus.PROCESSED, null);
+
+        } catch (final ImportException e) {
+            logger.info("failed with an import error: " + e.getMessage());
+            importRepository.updateStatusAndMessageById(importId, e.getStatus(), e.getMessage());
+        } catch (final Exception e) {
+            logger.warn("failed with an unexpected import error: " + e.getMessage());
+            importRepository.updateStatusAndMessageById(importId, ImportStatus.BAD_DATA, e.getMessage());
+        }
     }
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/ExamRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/ExamRepository.java
@@ -14,4 +14,12 @@ public interface ExamRepository {
      * @return the id of the newly created exam
      */
     long upsert(Exam exam, long importId);
+
+    /**
+     * Delete the exam created by the deleted import id.
+     *
+     * @param deletedImportId   The deleted import id
+     * @param importId          The processing import id
+     */
+    void deleteByImportId(long deletedImportId, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
@@ -71,6 +71,9 @@ class JdbcExamRepository implements ExamRepository {
     @Value("${sql.exam.findOne}")
     private String sqlFindOne;
 
+    @Value("${sql.exam.deleteByImportId}")
+    private String sqlDeleteByImportId;
+
     @Value("${sql.exam.accommodation.create}")
     private String sqlExamAccommodationCreate;
 
@@ -95,6 +98,14 @@ class JdbcExamRepository implements ExamRepository {
         } else {
             return updateExamAndChildren(exam, existing, importId);
         }
+    }
+
+    @Override
+    public void deleteByImportId(final long deletedImportId, final long importId) {
+        final SqlParameterSource parameterSource = new MapSqlParameterSource()
+                .addValue("deleted_import_id", deletedImportId)
+                .addValue("import_id", importId);
+        jdbcTemplate.update(sqlDeleteByImportId, parameterSource);
     }
 
     private long updateExamAndChildren(final Exam submitted, final Exam existing, final long importId) {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/StudentExamWriter.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/StudentExamWriter.java
@@ -19,4 +19,12 @@ public interface StudentExamWriter {
      * @param importId the import id associated with the exam
      */
     void upsert(Student student, Exam exam, long importId);
+
+    /**
+     * Delete the exam created by the deleted import id.
+     *
+     * @param deletedImportId   The deleted import id
+     * @param importId          The processing import id
+     */
+    void delete(long deletedImportId, long importId);
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/TDSReportProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/TDSReportProcessor.java
@@ -7,12 +7,22 @@ import org.opentestsystem.rdw.ingest.common.model.ImportException;
  * An interface for parsing, validating and persisting TDS Report
  */
 public interface TDSReportProcessor {
+
     /**
-     * Process the given {@link TDSReport}
+     * Process the given {@link TDSReport} as an upsert
      *
      * @param report   the report to process
      * @param importId the import id from the import request
      * @throws ImportException if the report was not fully processed
      */
-    void process(TDSReport report, long importId) throws ImportException;
+    void processUpsert(TDSReport report, long importId) throws ImportException;
+
+    /**
+     * Delete the Exam record created by the Import to be deleted.
+     *
+     * @param deletedImportId   The import id to be deleted
+     * @param importId          The processing import id
+     * @throws ImportException  if there is a problem processing the request
+     */
+    void processDelete(long deletedImportId, long importId) throws ImportException;
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamWriter.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamWriter.java
@@ -47,6 +47,11 @@ class DefaultStudentExamWriter implements StudentExamWriter {
         }
         if (!groupIds.isEmpty()) studentGroupRepository.addStudentToGroups(studentId, groupIds, importId);
     }
+
+    @Override
+    public void delete(final long deletedImportId, final long importId) {
+        examRepository.deleteByImportId(deletedImportId, importId);
+    }
 }
 
 

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
@@ -36,7 +36,7 @@ class DefaultTDSReportProcessor implements TDSReportProcessor {
     }
 
     @Override
-    public void process(final TDSReport report, final long importId) throws ImportException {
+    public void processUpsert(final TDSReport report, final long importId) throws ImportException {
         try {
             final Examinee examinee = report.getExaminee();
             if (examinee == null) throw new IllegalArgumentException("Examinee may not be null");
@@ -50,5 +50,10 @@ class DefaultTDSReportProcessor implements TDSReportProcessor {
         } catch (final IllegalArgumentException e) {
             throw new ImportException(BAD_DATA, e.getMessage());
         }
+    }
+
+    @Override
+    public void processDelete(final long deletedImportId, final long importId) throws ImportException {
+        writer.delete(deletedImportId, importId);
     }
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/stream/ExamProcessorSink.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/stream/ExamProcessorSink.java
@@ -1,0 +1,19 @@
+package org.opentestsystem.rdw.ingest.processor.stream;
+
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.messaging.SubscribableChannel;
+
+/**
+ *
+ */
+public interface ExamProcessorSink {
+
+    String DELETE = "delete";
+
+    @Input(Sink.INPUT)
+    SubscribableChannel upsert();
+
+    @Input(DELETE)
+    SubscribableChannel delete();
+}

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/stream/ExamProcessorSink.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/stream/ExamProcessorSink.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.messaging.SubscribableChannel;
 
 /**
- *
+ * This sink contains the input channels for the exam processor application.
  */
 public interface ExamProcessorSink {
 

--- a/exam-processor/src/main/resources/application.sql.yml
+++ b/exam-processor/src/main/resources/application.sql.yml
@@ -101,7 +101,8 @@ sql:
         eng_prof_lvl = :eng_prof_lvl,
         t3_program_type = :t3_program_type,
         language_code = :language_code,
-        prim_disability_type = :prim_disability_type
+        prim_disability_type = :prim_disability_type,
+        deleted = 0
       WHERE id = :id
 
     findOne: >-
@@ -136,6 +137,14 @@ sql:
       WHERE asmt_id = :asmt_id
         AND oppId = :opportunity_id
         AND student_id = :student_id
+
+    deleteByImportId: >-
+      UPDATE exam
+      SET
+        deleted = 1,
+        update_import_id = :import_id
+      WHERE
+        import_id = :deleted_import_id
 
     examClaimScore:
       create: >-

--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
         input:
           destination: EXAM
           group: default
+        delete:
+          destination: EXAM_DELETE
+          group: default
 
   datasource:
     url: "\

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfigurationTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfigurationTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -48,7 +49,7 @@ public class ExamProcessorConfigurationTest {
 
     @Test
     public void itShouldProcessMessageWithXmlContent() throws UnsupportedEncodingException {
-        processor.process(message);
+        processor.processUpsert(message);
         verify(importRepository, times(1)).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
     }
 
@@ -56,19 +57,28 @@ public class ExamProcessorConfigurationTest {
     public void itShouldHandleImportException() throws UnsupportedEncodingException {
         doThrow(new ImportException(ImportStatus.UNKNOWN_ASMT, "message"))
                 .when(tdsReportProcessor)
-                .process(any(TDSReport.class), any(long.class));
+                .processUpsert(any(TDSReport.class), any(long.class));
 
-        processor.process(message);
+        processor.processUpsert(message);
 
         verify(importRepository, times(1)).updateStatusAndMessageById(1, ImportStatus.UNKNOWN_ASMT, "message");
     }
 
     @Test
     public void itShouldHandleAnyException() throws UnsupportedEncodingException {
-        doThrow(new RuntimeException("any message")).when(tdsReportProcessor).process(any(TDSReport.class), any(long.class));
+        doThrow(new RuntimeException("any message")).when(tdsReportProcessor).processUpsert(any(TDSReport.class), any(long.class));
 
-        processor.process(message);
+        processor.processUpsert(message);
 
         verify(importRepository, times(1)).updateStatusAndMessageById(1, ImportStatus.BAD_DATA, "any message");
+    }
+
+    @Test
+    public void itShouldProcessADeleteMessage() throws Exception {
+        message = new GenericMessage<>(123L, message.getHeaders());
+        processor.processDelete(message);
+
+        verify(tdsReportProcessor).processDelete(eq(1L), eq(123L));
+        verify(importRepository).updateStatusAndMessageById(1L, ImportStatus.PROCESSED, null);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfigurationTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorConfigurationTest.java
@@ -78,7 +78,7 @@ public class ExamProcessorConfigurationTest {
         message = new GenericMessage<>(123L, message.getHeaders());
         processor.processDelete(message);
 
-        verify(tdsReportProcessor).processDelete(eq(1L), eq(123L));
+        verify(tdsReportProcessor).processDelete( eq(123L), eq(1L));
         verify(importRepository).updateStatusAndMessageById(1L, ImportStatus.PROCESSED, null);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
@@ -535,4 +535,20 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                 new MapSqlParameterSource().addValue("id", examId));
         assertThat(updatedValues).isEmpty();
     }
+
+    @Test
+    public void itShouldDeleteAnExamByImportId() {
+        final Exam exam = builder.build();
+        exam.getStudentExamAttributes().setStudentId(-11);
+        final long examId = repository.upsert(exam, -1);
+
+        repository.deleteByImportId(-1, -2);
+
+        final Map<String, Object> updatedValues = namedParameterTemplate.queryForMap(
+                "select * from exam where id = :id",
+                new MapSqlParameterSource().addValue("id", examId));
+
+        assertThat(updatedValues.get("deleted")).isEqualTo(1);
+        assertThat(updatedValues.get("update_import_id")).isEqualTo(-2L);
+    }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamWriterTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamWriterTest.java
@@ -116,4 +116,10 @@ public class DefaultStudentExamWriterTest {
         verify(studentGroupRepository).existsStudentInGroup(-99, 22);
         verifyNoMoreInteractions(studentGroupRepository);
     }
+
+    @Test
+    public void itShouldDelegateDeletingToRepository() {
+        writer.delete(123L, 456L);
+        verify(examRepository).deleteByImportId(123L, 456L);
+    }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
@@ -68,7 +68,7 @@ public class DefaultTDSReportProcessorIT {
                 "SBAC-ICA-FIXED-G6M-COMBINED-2017.xml"
         }) {
             final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/" + sample));
-            processor.process(tdsReport, importId);
+            processor.processUpsert(tdsReport, importId);
 
             assertThat(countRowsInTable(jdbcTemplate, "exam")).isEqualTo(beforeIabExamCount + beforeOtherExamCount + 1);
             assertThat(countRowsInTable(jdbcTemplate, "exam_item")).isEqualTo(beforeItemCount + tdsReport.getOpportunity().getItem().size());
@@ -102,7 +102,7 @@ public class DefaultTDSReportProcessorIT {
     public void itShouldHandleLargeItemResponses() {
         // this sample has an item response >64k; before the fix it would throw a data violation exception
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.largeitem.xml"));
-        processor.process(tdsReport, importId);
+        processor.processUpsert(tdsReport, importId);
     }
 
 //    // this is a test that loads external TDSReports that can't be checked in with source

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
@@ -72,7 +72,7 @@ public class DefaultTDSReportProcessorTest {
         final Student student = mock(Student.class);
         when(examineeProcessor.parseStudent(examinee, 2016, 99)).thenReturn(student);
 
-        processor.process(tdsReport, importId);
+        processor.processUpsert(tdsReport, importId);
         verify(writer, times((1))).upsert(student, exam, importId);
     }
 
@@ -80,7 +80,7 @@ public class DefaultTDSReportProcessorTest {
     public void itShouldThrowExceptionForNullExaminee() throws ParseException {
         when(tdsReport.getExaminee()).thenReturn(null);
 
-        processor.process(tdsReport, importId);
+        processor.processUpsert(tdsReport, importId);
     }
 
     @Test(expected = ImportException.class)
@@ -88,6 +88,12 @@ public class DefaultTDSReportProcessorTest {
 
         when(tdsReport.getExaminee()).thenThrow(mock(IllegalArgumentException.class));
 
-        processor.process(tdsReport, importId);
+        processor.processUpsert(tdsReport, importId);
+    }
+
+    @Test
+    public void itShouldDelegateDeletingToTheWriter() {
+        processor.processDelete(123L, 456L);
+        verify(writer).delete(123L, 456L);
     }
 }


### PR DESCRIPTION
This PR is the second half of deleting exams by import id.
See PR #350 for the API endpoint that publishes a delete message to the EXAM_DELETE channel.

This PR accepts the EXAM_DELETE message, updates the exam.deleted column to 1, and marks the processing Import record as PROCESSED.