### PR TITLE
Fix issues discovered during data validation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.0.0-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-42"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-229"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-233"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -292,6 +292,7 @@ sql:
                 claim4_scale_score,
                 claim4_scale_score_std_err,
                 claim4_category,
+                completed_at,
                 update_import_id,
                 migrate_id
               )
@@ -325,6 +326,7 @@ sql:
                   claim4.scale_score as claim4_scale_score,
                   claim4.scale_score_std_err as claim4_scale_score_std_err,
                   claim4.category as claim4_category,
+                  se.completed_at,
                   se.update_import_id,
                   se.migrate_id
                 FROM staging_exam se
@@ -398,6 +400,7 @@ sql:
                   claim4_scale_score          = claim4.scale_score,
                   claim4_scale_score_std_err  = claim4.scale_score_std_err,
                   claim4_category             = claim4.category,
+                  completed_at                = se.completed_at,
                   update_import_id            = se.update_import_id,
                   migrate_id                  = se.migrate_id
                  FROM staging_exam se

--- a/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -25,7 +25,8 @@ sql:
                   code
                 FROM administration_condition
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/administration_condition'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_administration_condition (id, code)
@@ -44,7 +45,8 @@ sql:
                   code
                 FROM completeness
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/completeness'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_completeness (id, code)
@@ -63,7 +65,8 @@ sql:
                   code
                 FROM ethnicity
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/ethnicity'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_ethnicity (id, code)
@@ -82,7 +85,8 @@ sql:
                   code
                 FROM gender
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/gender'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_gender (id, code)
@@ -102,7 +106,8 @@ sql:
                   name
                 FROM grade
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/grade'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_grade (id, code, name)
@@ -129,7 +134,8 @@ sql:
              FROM student ws
               WHERE ws.created > ? AND ws.created <= ?
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/student'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_student(
@@ -164,7 +170,8 @@ sql:
              FROM student ws
               WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/student_update'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_student(
@@ -195,7 +202,8 @@ sql:
                 JOIN student ws ON ws.id = student_ethnicity.student_id
               WHERE ws.created > ? AND ws.created <= ? AND ws.deleted = 0
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/student_ethnicity'
-              FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                              LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_student_ethnicity(
@@ -219,7 +227,8 @@ sql:
                 JOIN student ws ON ws.id = student_ethnicity.student_id
               WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created AND ws.deleted = 0
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/student_ethnicity_update'
-              FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                              LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_student_ethnicity (
@@ -250,7 +259,8 @@ sql:
               WHERE wa.type_id = 1
                 AND wa.created > ? AND wa.created <= ?
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/asmt'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_asmt(
@@ -285,7 +295,8 @@ sql:
              FROM asmt wa
               WHERE wa.type_id = 1 AND wa.updated > ? AND wa.updated <= ? AND wa.updated <> wa.created
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/asmt_update'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_asmt(
@@ -318,7 +329,8 @@ sql:
              FROM school ws
               WHERE ws.created > ? AND ws.created <= ?
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/school'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_school(
@@ -347,7 +359,8 @@ sql:
              FROM school ws
               WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/school_update'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_school(
@@ -374,7 +387,8 @@ sql:
              FROM district wd
               WHERE EXISTS( SELECT id FROM school  WHERE created > ? AND created <= ? AND deleted = 0 AND district_id = wd.id)
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/district'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_district(
@@ -397,7 +411,8 @@ sql:
              FROM district wd
               WHERE EXISTS( SELECT id FROM school WHERE updated > ? AND updated <= ? AND updated <> created AND deleted = 0 AND district_id = wd.id)
              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/district_update'
-             FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                             LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_district(
@@ -432,13 +447,15 @@ sql:
                   scale_score,
                   scale_score_std_err,
                   performance_level,
+                  completed_at,
                   deleted,
                   update_import_id,
                  ? as migrate_id
                 FROM exam we
                   WHERE we.created > ? AND we.created <= ? AND type_id = 1
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_exam(
@@ -459,6 +476,7 @@ sql:
                   scale_score,
                   scale_score_std_err,
                   performance_level,
+                  completed_at,
                   deleted,
                   update_import_id,
                   migrate_id)
@@ -489,13 +507,15 @@ sql:
                   scale_score,
                   scale_score_std_err,
                   performance_level,
+                  completed_at,
                   deleted,
                   update_import_id,
                  ? as migrate_id
                FROM exam we
                 WHERE we.updated > ? AND we.updated <= ? AND we.updated <> we.created AND type_id = 1
                INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_update'
-               FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+               FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+               LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_exam(
@@ -516,6 +536,7 @@ sql:
                   scale_score,
                   scale_score_std_err,
                   performance_level,
+                  completed_at,
                   deleted,
                   update_import_id,
                   migrate_id)
@@ -541,7 +562,8 @@ sql:
                   JOIN exam we ON we.id = exam_claim_score.exam_id
                 WHERE we.created > ? AND we.created <= ? AND we.deleted = 0 AND we.type_id = 1
                 INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_claim_score'
-                FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+                FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_exam_claim_score(
@@ -573,7 +595,8 @@ sql:
                   JOIN exam we ON we.id = exam_claim_score.exam_id
                WHERE we.updated > ? AND we.updated <= ? AND we.updated <> we.created AND we.deleted = 0  AND type_id = 1
                INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_claim_score_update'
-               FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n'
+               FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+               LINES TERMINATED BY '\n'
 
             stagingInsert: >-
                 COPY staging_exam_claim_score(

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.migrate.olap;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.After;
 import org.junit.Test;
 import org.opentestsystem.rdw.archive.ArchiveService;
@@ -15,8 +16,10 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.context.jdbc.SqlGroup;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,5 +114,49 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
 
         assertThat(jobExecution.getExitStatus()).isEqualTo(COMPLETED);
         verifyTableCountsAfterTest(tableTestCounts);
+
+        verifyExamFactMigration();
+    }
+
+    /**
+     * Verify an exemplar Exam was properly, fully migrated.
+     * See WarehouseEntitiesSetup.sql for expected values
+     */
+    private void verifyExamFactMigration() {
+        final Map<String, Object> icaFacts = olapJdbcTemplate.queryForMap(
+                "SELECT * FROM fact_student_ica_exam WHERE id = :id",
+                ImmutableMap.of("id", -87));
+
+        assertThat(icaFacts.get("school_id")).isEqualTo(-1);
+        assertThat(icaFacts.get("student_id")).isEqualTo(-11L);
+        assertThat(icaFacts.get("asmt_id")).isEqualTo(-11L);
+        assertThat(icaFacts.get("grade_id")).isEqualTo(-98);
+        assertThat(icaFacts.get("asmt_grade_id")).isEqualTo(-98);
+        assertThat(icaFacts.get("school_year")).isEqualTo(1999);
+        assertThat((boolean) icaFacts.get("iep")).isTrue();
+        assertThat((boolean) icaFacts.get("lep")).isTrue();
+        assertThat((boolean) icaFacts.get("section504")).isFalse();
+        assertThat((boolean) icaFacts.get("economic_disadvantage")).isFalse();
+        assertThat((boolean) icaFacts.get("migrant_status")).isTrue();
+        assertThat(icaFacts.get("completeness_id")).isEqualTo(1);
+        assertThat(icaFacts.get("administration_condition_id")).isEqualTo(1);
+        assertThat(icaFacts.get("scale_score")).isNull();
+        assertThat(icaFacts.get("scale_score_std_err")).isNull();
+        assertThat(icaFacts.get("performance_level")).isEqualTo(1);
+        assertThat(icaFacts.get("claim1_scale_score")).isEqualTo(2014D);
+        assertThat(icaFacts.get("claim1_scale_score_std_err")).isEqualTo(0.19D);
+        assertThat(icaFacts.get("claim1_category")).isEqualTo(1);
+        assertThat(icaFacts.get("claim2_scale_score")).isNull();
+        assertThat(icaFacts.get("claim2_scale_score_std_err")).isNull();
+        assertThat(icaFacts.get("claim2_category")).isNull();
+        assertThat(icaFacts.get("claim3_scale_score")).isNull();
+        assertThat(icaFacts.get("claim3_scale_score_std_err")).isNull();
+        assertThat(icaFacts.get("claim3_category")).isNull();
+        assertThat(icaFacts.get("claim4_scale_score")).isNull();
+        assertThat(icaFacts.get("claim4_scale_score_std_err")).isNull();
+        assertThat(icaFacts.get("claim4_category")).isNull();
+        assertThat(((Timestamp)icaFacts.get("completed_at")).toInstant()).isEqualTo(Instant.parse("2016-08-14T19:06:08.00Z"));
+        assertThat((long) icaFacts.get("migrate_id")).isGreaterThan(0);
+        assertThat(icaFacts.get("update_import_id")).isEqualTo(-88L);
     }
 }

--- a/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
@@ -29,5 +29,5 @@ INSERT INTO  fact_student_ica_exam (id, school_year, asmt_id, asmt_grade_id, com
                                     claim2_scale_score, claim2_scale_score_std_err,claim2_category,
                                     claim3_scale_score, claim3_scale_score_std_err,claim3_category,
                                     claim4_scale_score, claim4_scale_score_std_err,claim4_category,
-                                    update_import_id, migrate_id) VALUES
-  (-88, 1999, -99, -98, -99, -99, 1, 2145, 0.17, -98, -89, -1, 1, 1, 0, 0, 1,  -2000, 0.11, 1, -2100, 0.12, 2, -2500, 0.13, 3, -3000, .15, 4, -1, -1);
+                                    completed_at, update_import_id, migrate_id) VALUES
+  (-88, 1999, -99, -98, -99, -99, 1, 2145, 0.17, -98, -89, -1, true, true, false, false, true,  -2000, 0.11, 1, -2100, 0.12, 2, -2500, 0.13, 3, -3000, .15, 4, '2016-08-14 19:05:33.000000', -1, -1);

--- a/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
@@ -32,10 +32,10 @@ INSERT INTO staging_student_ethnicity(student_id, ethnicity_id, migrate_id) valu
 INSERT INTO  staging_exam ( id, type_id, school_year, asmt_id,  completeness_id,
                             administration_condition_id, performance_level, scale_score, scale_score_std_err, deleted, migrate_id,
                             grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage,
-                            migrant_status, update_import_id) VALUES
-  (-88, 1, 1999, -99, -99, -99, 1, 2145, 0.17,  0, -88, -98, -89, -1, 1, 1, 0, 0, 1, -1),
-  (-87, 1, 1999, -11, -99, -99, 1, 2145, 0.17,  0, -88, -98, -11, -1, 1, 1, 0, 0, 1, -1),
-  (-86, 1, 1999, -11, -99, -99, 1, 2145, 0.17,  0, -88, -98, -11, -1, 1, 1, 0, 0, 1, -1);
+                            completed_at, migrant_status, update_import_id) VALUES
+  (-88, 1, 1999, -99, -99, -99, 1, 2145, 0.17,  0, -88, -98, -89, -1, 1, 1, 0, 0, '2016-08-14 19:05:33.967000', 1, -1),
+  (-87, 1, 1999, -11, -99, -99, 1, 2145, 0.17,  0, -88, -98, -11, -1, 1, 1, 0, 0, '2016-08-14 19:06:07.966000', 1, -1),
+  (-86, 1, 1999, -11, -99, -99, 1, 2145, 0.17,  0, -88, -98, -11, -1, 1, 1, 0, 0, '2016-08-14 19:06:07.966000', 1, -1);
 
 INSERT INTO staging_exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category, migrate_id) VALUES
    (-1, -88, 1, 2000, 0.19, 1, -99),

--- a/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
@@ -27,8 +27,8 @@ INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, na
 INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at,
                                     lep_exit_at, birthday, import_id, update_import_id, deleted, created, updated) VALUES
   (-11, '11', 'LastName-preload', 'FirstName-preload', 'MiddleName-preload', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -5000, -5000, 0, '2017-05-18 19:05:33.967000', '2017-05-18 20:06:34.966000'),
-  (-89, '89', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -5000, -89, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:06:00.966000'),
-  (-88, '88', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000'),
+  (-89, '89', '漢字', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -5000, -89, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:06:00.966000'),
+  (-88, '88', 'Last, Name2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000'),
   (-87, '87', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -87, -87, 0, '2017-07-18 19:09:33.966000', '2017-07-18 19:09:33.966000'),
   (-86, '86', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', -86, -86, 0, '2017-07-18 19:09:3.966000', '2017-07-18 19:09:33.966000'),
   (-33, '33', 'LastName2', 'FirstName2', 'MiddleName2', -98, '2012-08-14', '2012-11-13', null, '2000-01-01', 2000, 2000, 0, '2017-07-18 20:16:33.966000', '2017-07-18 20:16:33.966000');
@@ -45,10 +45,10 @@ INSERT INTO  exam ( id, type_id, school_year, asmt_id, asmt_version, opportunity
                     import_id, update_import_id, deleted, created, updated,
                     grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage,
                     migrant_status, eng_prof_lvl, t3_program_type, language_code, prim_disability_type) VALUES
-  (-88, 1, 1999, -99,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14', -5000, -88, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:06:07.966000', -98, -89, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-87, 1, 1999, -11,  null, 1, 1, 1, 'session', 1, null, null, '2016-08-14', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-86, 2, 1999, -97,  null, 1, 1, 1, 'session', 1, null, null, '2016-08-14', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-85, 1, 1999, -11,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null);
+  (-88, 1, 1999, -99,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14 19:05:33.967000', -5000, -88, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:06:07.966000', -98, -89, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-87, 1, 1999, -11,  null, 1, 1, 1, 'session', 1, null, null, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-86, 2, 1999, -97,  null, 1, 1, 1, 'session', 1, null, null, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-85, 1, 1999, -11,  null, 1, 1, 1, 'session', 1, 2145, 0.17, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null);
 
 
 INSERT INTO exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES


### PR DESCRIPTION
Migrate completed_at timestamp field to olap exam staging and fact schemas.

While performing data validation, there was one issue discovered w.r.t. exporting/importing VARCHAR fields containing commas.  The fix is to tell Aurora to optionally enclose fields in quotes.