### PR TITLE
Add a status indicator to track DB connection health from the migrate…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.0.0-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-42"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-233"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-234"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/status/MigrateOlapDatabaseStatusIndicator.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/status/MigrateOlapDatabaseStatusIndicator.java
@@ -1,0 +1,77 @@
+package org.opentestsystem.rdw.ingest.migrate.olap.status;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.common.status.AbstractStatusIndicator;
+import org.opentestsystem.rdw.common.status.DiagnosticLevel;
+import org.opentestsystem.rdw.common.status.Status;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An {@link AbstractStatusIndicator} for the OLAP database status.
+ * <p>
+ * Slightly different than web diagnostic spec this adds "databaseOperations",
+ * each being a Status with "type" (READ/WRITE), and "responseTime".
+ * </p>
+ */
+@Component
+public class MigrateOlapDatabaseStatusIndicator extends AbstractStatusIndicator {
+
+    private final NamedParameterJdbcTemplate olapJdbcTemplate;
+
+    @Autowired
+    public MigrateOlapDatabaseStatusIndicator(@Qualifier("olapJdbcTemplate") final NamedParameterJdbcTemplate olapJdbcTemplate) {
+        this.olapJdbcTemplate = olapJdbcTemplate;
+    }
+
+    @Override
+    protected void doStatusCheck(final Status.Builder builder, final int level) {
+        final List<Status> statuses = new ArrayList<>();
+        statuses.add(getOlapReadStatus());
+        if (DiagnosticLevel.WriteDatabase.isLessThanOrEqualTo(level)) {
+            statuses.add(getOlapWriteStatus());
+        }
+        builder.detail("databaseOperations", statuses);
+        builder.worstRating(statuses);
+    }
+
+    @Override
+    protected boolean doLevelCheck(final int level) {
+        return DiagnosticLevel.ReadDatabase.isLessThanOrEqualTo(level);
+    }
+
+    @Override
+    public String name() {
+        return "OLAP-database-operations";
+    }
+
+    private Status getOlapReadStatus() {
+        final Status.Builder builder = Status.builder()
+                .detail("type", "READ");
+        responseTime(builder, 10000, () ->
+                olapJdbcTemplate.queryForList(
+                        "SELECT * FROM status_indicator",
+                        ImmutableMap.of()));
+        return builder.build();
+    }
+
+    private Status getOlapWriteStatus() {
+        final Status.Builder builder = Status.builder()
+                .detail("type", "WRITE");
+        responseTime(builder, 10000, () ->
+                olapJdbcTemplate.update(
+                        "UPDATE status_indicator SET updated = :now WHERE id = :id",
+                        ImmutableMap.of(
+                                "now", Timestamp.from(Instant.now()),
+                                "id", 1
+                        )));
+        return builder.build();
+    }
+}

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/status/MigrateOlapDatabaseStatusIndicatorRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/status/MigrateOlapDatabaseStatusIndicatorRST.java
@@ -1,0 +1,43 @@
+package org.opentestsystem.rdw.ingest.migrate.olap.status;
+
+import org.junit.Test;
+import org.opentestsystem.rdw.common.status.DiagnosticLevel;
+import org.opentestsystem.rdw.common.status.Status;
+import org.opentestsystem.rdw.ingest.migrate.olap.SpringBatchIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("redshift")
+@Import(MigrateOlapDatabaseStatusIndicator.class)
+public class MigrateOlapDatabaseStatusIndicatorRST extends SpringBatchIT {
+
+    @Autowired
+    private MigrateOlapDatabaseStatusIndicator indicator;
+
+    @Test
+    public void itShouldProvideStatus() {
+        final Status.Builder builder = Status.builder();
+        indicator.doStatusCheck(builder, DiagnosticLevel.WriteDatabase.ordinal());
+
+        final Status status = builder.build();
+        assertThat(status.getDetails()).hasSize(1);
+
+        final List<Status> databaseOperationsStatuses = (List<Status>) status.getDetails().get("databaseOperations");
+        assertThat(databaseOperationsStatuses).hasSize(2);
+
+        final Map<String, Status> detailsByType = databaseOperationsStatuses.stream()
+                .collect(Collectors.toMap(
+                        typeStatus -> (String) typeStatus.getDetails().get("type"),
+                        typeStatus -> typeStatus
+                ));
+        assertThat(detailsByType.get("READ").getDetails().get("responseTime")).isNotNull();
+        assertThat(detailsByType.get("WRITE").getDetails().get("responseTime")).isNotNull();
+    }
+}


### PR DESCRIPTION
…-olap service to the olap/redshift database.

This PR adds a status indicator for tracking the ability of the service to communicate with the olap/redshift database.