### PR TITLE
Feature/dwr 1065 add art integration tests

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,9 @@ dependencies {
 
     compile 'com.google.code.gson:gson'
 
+    // used for json parsing
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.7'
+
     testCompile 'org.springframework:spring-test'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/util/JsonOrganizationParser.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/util/JsonOrganizationParser.java
@@ -1,4 +1,4 @@
-package org.opentestsystem.rdw.ingest.processor.service.impl;
+package org.opentestsystem.rdw.ingest.common.util;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8,7 +8,6 @@ import org.opentestsystem.rdw.ingest.common.model.DistrictGroup;
 import org.opentestsystem.rdw.ingest.common.model.Organization;
 import org.opentestsystem.rdw.ingest.common.model.School;
 import org.opentestsystem.rdw.ingest.common.model.SchoolGroup;
-import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/util/OrganizationParser.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/util/OrganizationParser.java
@@ -1,7 +1,6 @@
-package org.opentestsystem.rdw.ingest.processor.service.impl;
+package org.opentestsystem.rdw.ingest.common.util;
 
 import org.opentestsystem.rdw.ingest.common.model.School;
-import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 
 import java.util.Collection;
 

--- a/package-processor/build.gradle
+++ b/package-processor/build.gradle
@@ -30,16 +30,3 @@ dependencies {
     compile project(':rdw-ingest-common')
     testCompile project(path: ':rdw-ingest-common', configuration: 'tests')
 }
-
-task libraryJar(type: Jar, dependsOn: classes) {
-    classifier = 'library'
-    from sourceSets.main.output
-}
-configurations {
-    library {
-        extendsFrom testRuntime
-    }
-}
-artifacts {
-    library libraryJar
-}

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/CalpadsSchoolsParser.java
@@ -4,6 +4,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.opentestsystem.rdw.ingest.common.model.District;
 import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.OrganizationParser;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultOrganizationProcessor.java
@@ -2,6 +2,8 @@ package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.common.util.JsonOrganizationParser;
+import org.opentestsystem.rdw.ingest.common.util.OrganizationParser;
 import org.opentestsystem.rdw.ingest.processor.repository.SchoolRepository;
 import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParserTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/JsonOrganizationParserTest.java
@@ -6,6 +6,7 @@ import org.opentestsystem.rdw.ingest.common.model.District;
 import org.opentestsystem.rdw.ingest.common.model.School;
 import org.opentestsystem.rdw.ingest.common.model.SchoolGroup;
 import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
+import org.opentestsystem.rdw.ingest.common.util.JsonOrganizationParser;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
 
 import java.io.IOException;

--- a/task-service/build.gradle
+++ b/task-service/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compile project(':rdw-ingest-common')
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
-    testCompile project(':rdw-ingest-package-processor')
 
     // fixes java 8 time marshaling
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.7'

--- a/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/repository/ArtClientAST.java
+++ b/task-service/src/test/java/org/opentestsystem/rdw/ingest/tasking/repository/ArtClientAST.java
@@ -10,7 +10,7 @@ import org.opentestsystem.rdw.ingest.common.model.School;
 import org.opentestsystem.rdw.ingest.common.model.SchoolGroup;
 import org.opentestsystem.rdw.ingest.common.util.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.common.util.ParserHelper;
-import org.opentestsystem.rdw.ingest.processor.service.impl.JsonOrganizationParser;
+import org.opentestsystem.rdw.ingest.common.util.JsonOrganizationParser;
 import org.opentestsystem.rdw.ingest.tasking.UpdateOrganizationsConfiguration;
 import org.opentestsystem.rdw.ingest.tasking.service.impl.DefaultUpdateOrganizationsService;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Moved to JsonOrganizationParser and it's interface out to rdw-ingest-common so that ArtClientAST can get it through common instead of depending on rdw-package-processor.