### PR TITLE
Reduce RST spring environment overhead

### DIFF
--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingApplication.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingApplication.java
@@ -6,13 +6,20 @@ import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSql
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.aws.autoconfigure.cache.ElastiCacheAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.mail.MailSenderAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 /**
  * Spring boot application class
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = {
+        ElastiCacheAutoConfiguration.class,
+        MailSenderAutoConfiguration.class,
+        ContextStackAutoConfiguration.class
+})
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
 @Import({YamlPropertiesConfigurator.class,
         StatusConfiguration.class,

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/SpringBatchIT.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/SpringBatchIT.java
@@ -4,6 +4,7 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -14,7 +15,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ContextConfiguration(classes = {SpringBatchIT.BatchTestConfig.class})
+@ContextConfiguration(classes = {
+        TestConfiguration.class,
+        SpringBatchIT.BatchTestConfig.class
+})
 @ActiveProfiles("test")
 public abstract class SpringBatchIT {
 

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/TestAppConfig.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/TestAppConfig.java
@@ -2,12 +2,9 @@ package org.opentestsystem.rdw.ingest.migrate.olap;
 
 
 import org.opentestsystem.rdw.ingest.migrate.olap.repository.DataSourceConfiguration;
-import org.opentestsystem.rdw.ingest.migrate.olap.step.OlapReportingMigrateStepsConfig;
-import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
-import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -16,14 +13,12 @@ import org.springframework.context.annotation.Import;
  * This configures an application context that has just enough to test spring batch.
  */
 @Configuration
-@EnableAutoConfiguration
 @ComponentScan({"org.opentestsystem.rdw.ingest.migrate.olap.step", "org.opentestsystem.rdw.ingest.migrate.olap.repository.impl"})
-@Import({MigrateOlapReportingConfiguration.class,
-        OlapReportingMigrateStepsConfig.class,
+@Import({
+        ConfigurationPropertiesAutoConfiguration.class,
         YamlPropertiesConfigurator.class,
+        MigrateOlapReportingConfiguration.class,
         DataSourceConfiguration.class,
-        MigrateWarehouseToStagingSqlConfiguration.class,
-        MigrateStagingToReportingSqlConfiguration.class,
         ArchiveServiceConfiguration.class
 })
 @EnableBatchProcessing


### PR DESCRIPTION
These changes make a minor improvement to RST execution speed, but the suite still takes ~15 minutes to run on my local machine.  After sampling CPU usage during one of the tests, it appears that the vast majority of time is spent waiting on Aurora and Redshift.  I'm not sure if that can be sped up at all.  At least, not without a drastic change like switching to a developer-local mock AWS stack: https://github.com/localstack/localstack