### PR TITLE
Allow olap staging table truncation by manually starting a transaction.

### DIFF
--- a/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -2,18 +2,21 @@ sql:
   warehouseToStage:
   # ------------ Truncate ------------------------------------------------------------------
     truncateStageList:
-      - delete from staging_administration_condition
-      - delete from staging_completeness
-      - delete from staging_ethnicity
-      - delete from staging_gender
-      - delete from staging_grade
-      - delete from staging_student
-      - delete from staging_student_ethnicity
-      - delete from staging_school
-      - delete from staging_district
-      - delete from staging_asmt
-      - delete from staging_exam
-      - delete from staging_exam_claim_score
+      # Turn off autocommit to allow TRUNCATE to process
+      - BEGIN
+      - truncate staging_administration_condition
+      - truncate staging_completeness
+      - truncate staging_ethnicity
+      - truncate staging_gender
+      - truncate staging_grade
+      - truncate staging_student
+      - truncate staging_student_ethnicity
+      - truncate staging_school
+      - truncate staging_district
+      - truncate staging_asmt
+      - truncate staging_exam
+      - truncate staging_exam_claim_score
+      - END
 
     entities:
         # ------------ administration_condition  -------------------------------------------------------------------


### PR DESCRIPTION
This PR is more of an idea and talking point than a confirmed PR.

The issue with calling `TRUNCATE <tableName>;` in Redshift is that the session/connection is in auto-commit mode, which causes issues when the TRUNCATE command attempts to commit.
```
Migrate Job id 590] is complete with status [exitCode=FAILED;exitDescription=org.springframework.jdbc.UncategorizedSQLException: StatementCallback; 
uncategorized SQLException for SQL [truncate staging_administration_condition]; 
SQL state [HY000]; error code [10040]; 
[Amazon][JDBC](10040) Cannot use commit while Connection is in auto-commit mode.; 
nested exception is java.sql.SQLException: 
[Amazon][JDBC](10040) Cannot use commit while Connection is in auto-commit mode.
```
After googling around a bit, the best solution I found was to manually add a `BEGIN` transaction boundary before executing the TRUNCATE statement.  Thoughts?