### PR TITLE
DWR-1092 Refactor application.yml for storing sbac score ranges.

### DIFF
--- a/common/src/main/resources/application-ingest-common.yml
+++ b/common/src/main/resources/application-ingest-common.yml
@@ -1,0 +1,10 @@
+sbac:
+  scaleScore:
+    min: 1500
+    max: 3500
+  thetaScore:
+    min: -5
+    max: 5
+  itemScore:
+    min: -1
+    max: 20

--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -45,19 +45,11 @@ spring:
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
 
+  profiles:
+    include: ingest-common
+
 jdbc:
   retry:
     default:
       max-attempts: 4
       delay: 30
-
-sbac:
-  scaleScore:
-    min: 1500
-    max: 3500
-  thetaScore:
-    min: -5
-    max: 5
-  itemScore:
-    min: -1
-    max: 20

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -23,6 +23,9 @@ spring:
           destination: PACKAGE
           group: default
 
+  profiles:
+    include: ingest-common
+
   datasource:
     url: "\
       jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse}\
@@ -45,14 +48,3 @@ spring:
     default-property-inclusion: non_null
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
-
-sbac:
-  scaleScore:
-    min: 1500
-    max: 3500
-  thetaScore:
-    min: -5
-    max: 5
-  itemScore:
-    min: -1
-    max: 20


### PR DESCRIPTION
SbacScoreConfiguration is defined in the `ingest-common` but is used by both `ingest-exam-processor` and `ingest-package-processor`. This refactoring moves the yml settings into one file in the `ingest-common` project.