### PR TITLE
make application configuration consistent

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ApplicationConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ApplicationConfiguration.java
@@ -1,0 +1,15 @@
+package org.opentestsystem.rdw.ingest.processor;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        ExamProcessor.class,
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class
+})
+public class ApplicationConfiguration {
+}

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessor.java
@@ -18,17 +18,16 @@ import java.io.ByteArrayInputStream;
 
 import static org.opentestsystem.rdw.common.model.trt.XmlUtils.tdsReportFromXml;
 
-
 @EnableBinding(Sink.class)
-public class ExamProcessorConfiguration {
-    private static final Logger logger = LoggerFactory.getLogger(ExamProcessorConfiguration.class);
+public class ExamProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(ExamProcessor.class);
 
     private final TDSReportProcessor reportProcessor;
     private final ImportRepository importRepository;
 
     @Autowired
-    public ExamProcessorConfiguration(final TDSReportProcessor reportProcessor,
-                                      final ImportRepository importRepository) {
+    public ExamProcessor(final TDSReportProcessor reportProcessor,
+                         final ImportRepository importRepository) {
         this.reportProcessor = reportProcessor;
         this.importRepository = importRepository;
     }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorApplication.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorApplication.java
@@ -1,11 +1,8 @@
 package org.opentestsystem.rdw.ingest.processor;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 /**
@@ -14,7 +11,6 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication
 @EnableCaching
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import( { ExamProcessorConfiguration.class, YamlPropertiesConfigurator.class, StatusConfiguration.class } )
 public class ExamProcessorApplication {
 
     public static void main(final String[] args) {

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class ExamProcessorConfigurationTest {
+public class ExamProcessorTest {
 
-    private ExamProcessorConfiguration processor;
+    private ExamProcessor processor;
     private TDSReportProcessor tdsReportProcessor;
     private ImportRepository importRepository;
     private Message message;
@@ -34,7 +34,7 @@ public class ExamProcessorConfigurationTest {
     public void createProcessor() throws IOException {
         tdsReportProcessor = mock(TDSReportProcessor.class);
         importRepository = mock(ImportRepository.class);
-        processor = new ExamProcessorConfiguration(tdsReportProcessor, importRepository);
+        processor = new ExamProcessor(tdsReportProcessor, importRepository);
 
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(null);
         accessor.setContent(ImportContent.EXAM.name());

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/ApplicationConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/ApplicationConfiguration.java
@@ -1,0 +1,15 @@
+package org.opentestsystem.rdw.ingest.group;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        GroupProcessor.class,
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class
+})
+public class ApplicationConfiguration {
+}

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessor.java
@@ -5,7 +5,7 @@ import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.group.repository.StudentGroupBatchRepository;
-import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
+import org.opentestsystem.rdw.ingest.group.service.GroupMessageProcessor;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,18 +18,17 @@ import org.springframework.messaging.Message;
 
 import java.nio.charset.StandardCharsets;
 
-
 @EnableBinding(Sink.class)
-public class GroupProcessorConfiguration {
-    private static final Logger logger = LoggerFactory.getLogger(GroupProcessorConfiguration.class);
+public class GroupProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(GroupProcessor.class);
 
-    private final GroupProcessor groupProcessor;
+    private final GroupMessageProcessor groupMessageProcessor;
     private final StudentGroupBatchRepository batchRepository;
 
     @Autowired
-    public GroupProcessorConfiguration(final GroupProcessor groupProcessor,
-                                       final StudentGroupBatchRepository batchRepository) {
-        this.groupProcessor = groupProcessor;
+    public GroupProcessor(final GroupMessageProcessor groupMessageProcessor,
+                          final StudentGroupBatchRepository batchRepository) {
+        this.groupMessageProcessor = groupMessageProcessor;
         this.batchRepository = batchRepository;
     }
 
@@ -44,7 +43,7 @@ public class GroupProcessorConfiguration {
             logger.debug("Received payload: {}", (payload.length() > 80 ? payload.substring(0, 80) + "..." : payload));
 
             final GroupMessage gm = new Gson().fromJson(payload, GroupMessage.class);
-            groupProcessor.process(gm);
+            groupMessageProcessor.process(gm);
             batchRepository.updateBatch(gm.getUploadId(), ImportStatus.PROCESSED);
         } catch (final ImportException e) {
             logger.warn("failed with an unexpected import error: " + e.getMessage());

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorApplication.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessorApplication.java
@@ -1,10 +1,7 @@
 package org.opentestsystem.rdw.ingest.group;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 /**
@@ -12,11 +9,6 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import({
-        GroupProcessorConfiguration.class,
-        YamlPropertiesConfigurator.class,
-        StatusConfiguration.class
-})
 public class GroupProcessorApplication {
 
     public static void main(final String[] args) {

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/GroupMessageProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/GroupMessageProcessor.java
@@ -6,7 +6,7 @@ import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
 /**
  * An interface for processing an uploaded CSV for groups
  */
-public interface GroupProcessor {
+public interface GroupMessageProcessor {
 
     /**
      * Processes an upload message

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessor.java
@@ -5,7 +5,7 @@ import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.group.service.BatchingGroupImportService;
 import org.opentestsystem.rdw.ingest.group.service.BatchingUserImportService;
-import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
+import org.opentestsystem.rdw.ingest.group.service.GroupMessageProcessor;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingLoadService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingReferenceService;
 import org.opentestsystem.rdw.ingest.group.service.ProcessingStandardizationService;
@@ -15,8 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class DefaultGroupProcessor implements GroupProcessor {
-    private static final Logger logger = LoggerFactory.getLogger(DefaultGroupProcessor.class);
+public class DefaultGroupMessageProcessor implements GroupMessageProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultGroupMessageProcessor.class);
 
     private final ProcessingStandardizationService standardizationService;
     private final ProcessingReferenceService referenceService;
@@ -25,11 +25,11 @@ public class DefaultGroupProcessor implements GroupProcessor {
     private final BatchingGroupImportService groupImportService;
 
     @Autowired
-    public DefaultGroupProcessor(final ProcessingStandardizationService standardizationService,
-                                 final ProcessingReferenceService referenceService,
-                                 final BatchingUserImportService userImportService,
-                                 final ProcessingLoadService loadService,
-                                 final BatchingGroupImportService groupImportService) {
+    public DefaultGroupMessageProcessor(final ProcessingStandardizationService standardizationService,
+                                        final ProcessingReferenceService referenceService,
+                                        final BatchingUserImportService userImportService,
+                                        final ProcessingLoadService loadService,
+                                        final BatchingGroupImportService groupImportService) {
         this.standardizationService = standardizationService;
         this.referenceService = referenceService;
         this.userImportService = userImportService;

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/GroupProcessorTest.java
@@ -9,7 +9,7 @@ import org.opentestsystem.rdw.ingest.common.model.GroupMessage;
 import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.group.repository.StudentGroupBatchRepository;
-import org.opentestsystem.rdw.ingest.group.service.GroupProcessor;
+import org.opentestsystem.rdw.ingest.group.service.GroupMessageProcessor;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
@@ -24,21 +24,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class GroupProcessorConfigurationTest {
+public class GroupProcessorTest {
 
     @Mock
-    private GroupProcessor groupProcessor;
+    private GroupMessageProcessor groupMessageProcessor;
 
     @Mock
     private StudentGroupBatchRepository repository;
 
     private Message message;
     private GroupMessage groupMessage;
-    private GroupProcessorConfiguration processor;
+    private GroupProcessor processor;
 
     @Before
     public void createProcessor() throws IOException {
-        processor = new GroupProcessorConfiguration(groupProcessor, repository);
+        processor = new GroupProcessor(groupMessageProcessor, repository);
         groupMessage = GroupMessage.builder().digest("abcdef").uploadId(123L).build();
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(null);
         accessor.setImportId(123L);
@@ -52,21 +52,21 @@ public class GroupProcessorConfigurationTest {
 
         processor.process(message);
 
-        verify(groupProcessor, times(1)).process(groupMessage);
+        verify(groupMessageProcessor, times(1)).process(groupMessage);
         verify(repository).updateBatch(123L, ImportStatus.PROCESSED);
     }
 
     @Test
     public void itShouldHandleAnyException() throws UnsupportedEncodingException {
-        doThrow(new RuntimeException("any message")).when(groupProcessor).process(any(GroupMessage.class));
+        doThrow(new RuntimeException("any message")).when(groupMessageProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
-        verify(groupProcessor, times(1)).process(groupMessage);
+        verify(groupMessageProcessor, times(1)).process(groupMessage);
     }
 
     @Test
     public void itShouldUpdateBatchStatusOnImportExceptionIfIdIsKnown() throws Exception {
-        doThrow(new ImportException(ImportStatus.INVALID, "any message")).when(groupProcessor).process(any(GroupMessage.class));
+        doThrow(new ImportException(ImportStatus.INVALID, "any message")).when(groupMessageProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
         verify(repository).updateBatch(123L, ImportStatus.INVALID, "any message");
@@ -74,7 +74,7 @@ public class GroupProcessorConfigurationTest {
 
     @Test
     public void itShouldUpdateBatchStatusOnExceptionIfIdIsKnown() throws Exception {
-        doThrow(new RuntimeException("Bad Juju")).when(groupProcessor).process(any(GroupMessage.class));
+        doThrow(new RuntimeException("Bad Juju")).when(groupMessageProcessor).process(any(GroupMessage.class));
         processor.process(message);
 
         verify(repository).updateBatch(123L, ImportStatus.BAD_DATA, "Bad Juju");

--- a/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessorTest.java
+++ b/group-processor/src/test/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessorTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultGroupProcessorTest {
+public class DefaultGroupMessageProcessorTest {
 
     @Mock
     private ProcessingStandardizationService standardizationService;
@@ -42,11 +42,11 @@ public class DefaultGroupProcessorTest {
     private BatchingGroupImportService groupImportService;
 
     private GroupMessage message;
-    private DefaultGroupProcessor processor;
+    private DefaultGroupMessageProcessor processor;
 
     @Before
     public void setup() {
-        processor = new DefaultGroupProcessor(standardizationService, referenceService, userImportService, loadService, groupImportService);
+        processor = new DefaultGroupMessageProcessor(standardizationService, referenceService, userImportService, loadService, groupImportService);
 
         message = GroupMessage.builder()
                 .digest("ABCD")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/ApplicationConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/ApplicationConfiguration.java
@@ -1,0 +1,14 @@
+package org.opentestsystem.rdw.ingest;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class
+})
+public class ApplicationConfiguration {
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/ImportServiceApplication.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/ImportServiceApplication.java
@@ -1,13 +1,10 @@
 package org.opentestsystem.rdw.ingest;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.aws.autoconfigure.cache.ElastiCacheAutoConfiguration;
 import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
 import org.springframework.cloud.aws.autoconfigure.mail.MailSenderAutoConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication(exclude = {
@@ -16,7 +13,6 @@ import org.springframework.context.annotation.PropertySource;
         ContextStackAutoConfiguration.class
 })
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import({ YamlPropertiesConfigurator.class, StatusConfiguration.class })
 public class ImportServiceApplication {
 
 	public static void main(final String[] args) {

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/ApplicationConfiguration.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/ApplicationConfiguration.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.ingest.migrate.olap;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
+import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class,
+        MigrateWarehouseToStagingSqlConfiguration.class,
+        MigrateStagingToReportingSqlConfiguration.class
+})
+public class ApplicationConfiguration {
+}

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingApplication.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingApplication.java
@@ -1,15 +1,10 @@
 package org.opentestsystem.rdw.ingest.migrate.olap;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
-import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.aws.autoconfigure.cache.ElastiCacheAutoConfiguration;
 import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
 import org.springframework.cloud.aws.autoconfigure.mail.MailSenderAutoConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 /**
@@ -21,11 +16,6 @@ import org.springframework.context.annotation.PropertySource;
         ContextStackAutoConfiguration.class
 })
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import({YamlPropertiesConfigurator.class,
-        StatusConfiguration.class,
-        MigrateWarehouseToStagingSqlConfiguration.class,
-        MigrateStagingToReportingSqlConfiguration.class
-})
 public class MigrateOlapReportingApplication {
 
     public static void main(final String[] args) throws Exception {

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/ApplicationConfiguration.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/ApplicationConfiguration.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.ingest.migrate.reporting;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
+import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class,
+        MigrateWarehouseToStagingSqlConfiguration.class,
+        MigrateStagingToReportingSqlConfiguration.class
+})
+public class ApplicationConfiguration {
+}

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingApplication.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingApplication.java
@@ -1,12 +1,7 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
-import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 /**
@@ -15,11 +10,6 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import({YamlPropertiesConfigurator.class,
-        StatusConfiguration.class,
-        MigrateWarehouseToStagingSqlConfiguration.class,
-        MigrateStagingToReportingSqlConfiguration.class
-})
 public class MigrateReportingApplication {
 
     public static void main(final String[] args) throws Exception {

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ApplicationConfiguration.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/ApplicationConfiguration.java
@@ -1,0 +1,15 @@
+package org.opentestsystem.rdw.ingest.processor;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        PackageProcessor.class,
+        StatusConfiguration.class,
+        YamlPropertiesConfigurator.class
+})
+public class ApplicationConfiguration {
+}

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessor.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessor.java
@@ -16,8 +16,8 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 
 @EnableBinding(ImportPayloadSink.class)
-public class PackageProcessorConfiguration {
-    private static final Logger logger = LoggerFactory.getLogger(PackageProcessorConfiguration.class);
+public class PackageProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(PackageProcessor.class);
 
     private final ImportRepository importRepository;
     private final AssessmentPackageProcessor packageProcessor;
@@ -25,10 +25,10 @@ public class PackageProcessorConfiguration {
     private final OrganizationProcessor organizationProcessor;
 
     @Autowired
-    public PackageProcessorConfiguration(final ImportRepository importRepository,
-                                         final AssessmentPackageProcessor packageProcessor,
-                                         final AccommodationsProcessor accommodationsProcessor,
-                                         final OrganizationProcessor organizationProcessor) {
+    public PackageProcessor(final ImportRepository importRepository,
+                            final AssessmentPackageProcessor packageProcessor,
+                            final AccommodationsProcessor accommodationsProcessor,
+                            final OrganizationProcessor organizationProcessor) {
         this.importRepository = importRepository;
         this.packageProcessor = packageProcessor;
         this.accommodationsProcessor = accommodationsProcessor;

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorApplication.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorApplication.java
@@ -1,11 +1,8 @@
 package org.opentestsystem.rdw.ingest.processor;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 /**
@@ -14,10 +11,6 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication
 @EnableCaching
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import({ PackageProcessorConfiguration.class,
-          StatusConfiguration.class,
-          YamlPropertiesConfigurator.class
-})
 public class PackageProcessorApplication {
 
     public static void main(final String[] args) {

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorTest.java
@@ -31,9 +31,9 @@ import static org.opentestsystem.rdw.ingest.common.model.ImportContent.ORGANIZAT
 import static org.opentestsystem.rdw.ingest.common.model.ImportContent.PACKAGE;
 
 
-public class PackageProcessorConfigurationTest {
+public class PackageProcessorTest {
 
-    private PackageProcessorConfiguration processor;
+    private PackageProcessor processor;
     private ImportRepository importRepository;
     private AccommodationsProcessor accommodationsProcessor;
     private OrganizationProcessor organizationProcessor;
@@ -46,7 +46,7 @@ public class PackageProcessorConfigurationTest {
         organizationProcessor = mock(OrganizationProcessor.class);
         packageProcessor = mock(AssessmentPackageProcessor.class);
         importRepository = mock(ImportRepository.class);
-        processor = new PackageProcessorConfiguration(
+        processor = new PackageProcessor(
                 importRepository,
                 packageProcessor,
                 accommodationsProcessor,

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/ApplicationConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/ApplicationConfiguration.java
@@ -1,0 +1,14 @@
+package org.opentestsystem.rdw.ingest.tasking;
+
+import org.opentestsystem.rdw.common.status.StatusConfiguration;
+import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        YamlPropertiesConfigurator.class,
+        StatusConfiguration.class
+})
+public class ApplicationConfiguration {
+}

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/TaskServiceApplication.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/TaskServiceApplication.java
@@ -1,10 +1,7 @@
 package org.opentestsystem.rdw.ingest.tasking;
 
-import org.opentestsystem.rdw.common.status.StatusConfiguration;
-import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -15,7 +12,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication()
 @EnableScheduling
 @PropertySource(value = "classpath:build-info.properties", ignoreResourceNotFound = true)
-@Import({YamlPropertiesConfigurator.class, StatusConfiguration.class,})
 public class TaskServiceApplication {
 
     public static void main(final String[] args) throws Exception {


### PR DESCRIPTION
After looking over Will's shoulder yesterday when he was pushing things around to make IT's work in reporting, it seemed worthwhile to make a similar change in RDW_Ingest: separate the application configuration from the main application class. The test runner will then not see the application configuration unless you explicitly tell it to. That makes the DI in the tests cleaner.

While i was in there i renamed a couple classes that had configuration in their name but aren't. That was left over from using Spring Stream's naming convention for processors and it has been bugging me for months.