### PR TITLE
Bump the schema version that has missing column in audit table

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-53"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-245"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-246"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/ExamRepositoryIT.java
@@ -135,6 +135,7 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                         .responsibleSchoolId(-12)
                         .section504(true)
                         .t3ProgramType("t3")
+                        .examineeId(-1111L)
                         .build());
 
         final List<ExamClaim> claims = newArrayList();
@@ -721,7 +722,34 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
         assertThat(countRowsInTableWhere(jdbcTemplate, "audit_exam", " exam_id = " + originalExamId)).isEqualTo(0);
 
         final Exam secondExam = builder
-                .completenessId(2)
+                .completenessId(1)
+                .administrationConditionId(2)
+                .schoolYear(2018)
+                .deleted(false)
+                .statusDate(Instant.parse("2011-01-01T14:30:00Z"))
+                .deliverMode("mode")
+                .handScoreProject(-99L)
+                .contract("contract")
+                .testReason("testReason")
+                .assessmentAdminStartedAt(LocalDate.of(2011, 1, 7))
+                .startedAt(Instant.parse("2011-01-02T14:30:00Z"))
+                .forceSubmittedAt((Instant.parse("2011-01-03T14:30:00Z")))
+                .status("status")
+                .itemCount(9L)
+                .fieldTestCount(7L)
+                .pauseCount(1L)
+                .gracePeriodRestarts(2L)
+                .abnormalStarts(3L)
+                .testWindowId("testWindowId")
+                .testAdministratorId("testAdministratorId")
+                .responsibleOrganizationName("responsibleOrganizationName")
+                .testAdministratorName("testAdministratorName")
+                .sessionPlatformUserAgent("sessionPlatformUserAgent")
+                .testDeliveryServer("testDeliveryServer")
+                .testDeliveryDb("testDeliveryDb")
+                .windowOpportunityCount("999")
+                .thetaScore(0.99)
+                .thetaScoreStdErr(0.009)
                 .build();
         final long secondExamId = repository.upsert(secondExam, -2);
         final Map<String, Object> secondExamValues = namedParameterTemplate.queryForMap(
@@ -730,6 +758,9 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
         final Map<String, Object> firstAuditValues = namedParameterTemplate.queryForMap(
                 "SELECT * FROM audit_exam WHERE exam_id = :exam_id",
                 new MapSqlParameterSource().addValue("exam_id", originalExamId));
+
+        // At least one comparison between audit and actual must have no null values in actual to assure all columns are audited.
+        secondExamValues.forEach((k, v) -> assertThat(v).isNotNull());
 
         assertThat(originalExamId).isEqualTo(secondExamId);
         assertThat(countRowsInTableWhere(jdbcTemplate, "audit_exam", " exam_id = " + originalExamId)).isEqualTo(1);
@@ -834,7 +865,6 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
 
     @Test
     public void itShouldAuditExamAvailableAccommodations() {
-        // todo: Need at one test per audit table where audited record has no null values to ensure no missing columns in trigger sql and audit table.
         // Enable and disable of triggers is an operational concern, this test must have them on.
         jdbcTemplate.update("UPDATE setting s SET s.value = 'TRUE' WHERE s.name = 'AUDIT_TRIGGER_ENABLE';");
         assertThat(countRowsInTableWhere(jdbcTemplate, "setting s", " s.name = 'AUDIT_TRIGGER_ENABLE' and s.value = 'TRUE'")).isEqualTo(1);
@@ -868,6 +898,10 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                 "SELECT * FROM exam_available_accommodation WHERE exam_id = :exam_id AND accommodation_id IN (-98, -97)",
                 new MapSqlParameterSource().addValue("exam_id", originalExamId));
         assertThat(secondExamAccList.size()).isEqualTo(2);
+
+        // At least one comparison between audit and actual must have no null values in actual to assure all columns are audited.
+        secondExamAccList.get(0).forEach((k, v) -> assertThat(v).isNotNull());
+
         accommodations.clear();
         accommodations.add(-99);
         accommodations.add(-96);
@@ -916,7 +950,6 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                             .addValue("exam_id", originalExamId)
                             .addValue("accommodation_id", examAccValues.get("accommodation_id")));
 
-            examAccValues.remove("created"); // todo remove after adding column to audit table
             assertThat(auditAccValues.remove("id")).isNotNull();
             assertThat(auditAccValues.remove("action")).isEqualTo("delete");
             assertThat(auditAccValues.remove("audited")).isNotNull();
@@ -951,6 +984,10 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                 "SELECT * FROM exam_item WHERE exam_id = :exam_id AND item_id IN (-2, -4)",
                 new MapSqlParameterSource().addValue("exam_id", originalExamId));
         assertThat(originalExamItemListToUpdate.size()).isEqualTo(2);
+
+        // At least one comparison between audit and actual must have no null values in actual to assure all columns are audited.
+        originalExamItemListToDelete.get(0).forEach((k, v) -> assertThat(v).isNotNull());
+        originalExamItemListToUpdate.get(0).forEach((k, v) -> assertThat(v).isNotNull());
 
         final Exam secondExam = builder
                 .examItems(createItemsForAudit(ImmutableMap.<Integer, Integer>builder().put(-2, 2).put(-4, 2).build()))
@@ -1032,7 +1069,6 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                             .addValue("exam_id", originalExamId)
                             .addValue("item_id", examItemValues.get("item_id")));
 
-            examItemValues.remove("created"); // todo remove after adding column to audit table
             assertThat(auditItemValues.remove("id")).isNotNull();
             assertThat(auditItemValues.remove("action")).isEqualTo(action);
             assertThat(auditItemValues.remove("audited")).isNotNull();
@@ -1102,6 +1138,10 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                 new MapSqlParameterSource().addValue("exam_id", originalExamId));
         assertThat(thirdExamClaimScoreListToDelete.size()).isEqualTo(1);
 
+        // At least one comparison between audit and actual must have no null values in actual to assure all columns are audited.
+        thirdExamClaimScoreListToUpdate.get(0).forEach((k, v) -> assertThat(v).isNotNull());
+        thirdExamClaimScoreListToDelete.get(0).forEach((k, v) -> assertThat(v).isNotNull());
+
         final Exam fourthExam = builder
                 .examClaims(createClaimsForAudit(ImmutableMap.<Integer, Integer>builder().put(-2, 2).put(-3, 2).put(-4, 1).build()))
                 .build();
@@ -1143,7 +1183,6 @@ public class ExamRepositoryIT extends RepositoryBackedIT {
                             .addValue("exam_id", originalExamId)
                             .addValue("subject_claim_score_id", examClaimScoreValues.get("subject_claim_score_id")));
 
-            examClaimScoreValues.remove("created"); // todo remove after adding column to audit table
             assertThat(auditClaimScoreValues.remove("id")).isNotNull();
             assertThat(auditClaimScoreValues.remove("action")).isEqualTo(action);
             assertThat(auditClaimScoreValues.remove("audited")).isNotNull();


### PR DESCRIPTION
Address and remove todo's in IT around created column
Now that all columns exist in audit table add test that no nulls for at least one actual to audit compare,
has no null in actual to ensure no columns are left off the insert in the trigger.