### PR TITLE
fix warnings about non-validated beans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,14 +101,14 @@ subprojects {
         }
     }
 
+    // this is for creating metadata
+    compileJava.dependsOn(processResources)
+
     /***********************************************************
      * Docker setup for all sub-projects that need it
      ***********************************************************/
     if (!it.hasProperty('skipDocker')) {
         apply plugin: 'com.bmuschko.docker-remote-api'
-
-        // this is for creating metadata
-        compileJava.dependsOn(processResources)
 
         classes.dependsOn(createBuildInfoFile)
 

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/config/SbacScoreConfiguration.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/config/SbacScoreConfiguration.java
@@ -2,20 +2,14 @@ package org.opentestsystem.rdw.ingest.common.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import javax.validation.constraints.NotNull;
-
 /**
  * SBAC scores configuration
  */
 @ConfigurationProperties(prefix = "sbac")
 public class SbacScoreConfiguration {
-    @NotNull
     private Score scaleScore;
-    @NotNull
     private Score thetaScore;
-    @NotNull
     private Score itemScore;
-
 
     public Score getScaleScore() {
         return scaleScore;
@@ -43,9 +37,7 @@ public class SbacScoreConfiguration {
 
     @ConfigurationProperties
     public static class Score {
-        @NotNull
         private double min;
-        @NotNull
         private double max;
 
         public double getMin() {

--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/EntitySqls.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/EntitySqls.java
@@ -1,20 +1,13 @@
 package org.opentestsystem.rdw.ingest.common.model;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.Map;
 
 /**
  * This model contains SQL statements keyed by name.
  */
 public class EntitySqls {
-    @Valid
-    @NotNull
-    @Size(min=1)
     public Map<String, String> sql;
 
-    @NotNull
     public Map<String, String> getSql() {
         return sql;
     }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/configuration/GroupProcessingSqlConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/configuration/GroupProcessingSqlConfiguration.java
@@ -1,11 +1,9 @@
 package org.opentestsystem.rdw.ingest.group.configuration;
 
-import org.hibernate.validator.constraints.NotEmpty;
 import org.opentestsystem.rdw.ingest.common.model.EntitySqls;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import javax.validation.Valid;
 import java.util.Map;
 
 /**
@@ -16,8 +14,6 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "sql.process-batch")
 public class GroupProcessingSqlConfiguration {
 
-    @Valid
-    @NotEmpty
     public Map<String, EntitySqls> entities;
 
     public Map<String, EntitySqls> getEntities() {

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/config/MigrateStagingToReportingSqlConfiguration.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/config/MigrateStagingToReportingSqlConfiguration.java
@@ -5,8 +5,6 @@ import org.opentestsystem.rdw.ingest.common.model.EntitySqls;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Size;
 import java.util.Map;
 
 /**
@@ -17,8 +15,6 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "sql.migrate")
 public class MigrateStagingToReportingSqlConfiguration {
 
-    @Valid
-    @Size(min = 1)
     public Map<String, EntitySqls> entities;
 
     public Map<String, EntitySqls> getEntities() {

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/config/MigrateWarehouseToStagingSqlConfiguration.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/config/MigrateWarehouseToStagingSqlConfiguration.java
@@ -3,9 +3,6 @@ package org.opentestsystem.rdw.migrate.common.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
 
@@ -19,8 +16,6 @@ import static com.google.common.collect.Lists.newArrayList;
 @ConfigurationProperties(prefix = "sql.warehouseToStage")
 public class MigrateWarehouseToStagingSqlConfiguration {
 
-    @Valid
-    @Size(min = 1)
     public Map<String, WarehouseToStageEntitySqls> entities;
 
     public Map<String, WarehouseToStageEntitySqls> getEntities() {
@@ -36,11 +31,9 @@ public class MigrateWarehouseToStagingSqlConfiguration {
      */
     @ConfigurationProperties
     public static class WarehouseToStageEntitySqls {
-        @Valid
-        @Size(min = 1)
+
         public Map<String, String> sql;
 
-        @NotNull
         public Map<String, String> getSql() {
             return sql;
         }


### PR DESCRIPTION
I'm not thrilled with this but ...

The customer notices when there are warnings in the log. And there are a bunch of messages regarding beans with java validation annotations that don't have the `@Validate` annotation to go with them. I tried the obvious: added `@Validate` annotation. But then tests started failing and the running applications wouldn't start up due to validation failures. So, near as i can tell, the java validation annotations were never being honored. I couldn't get things working properly in my self-imposed time box of 4 hours so i decided to just remove the annotations.

If we ever get some free time perhaps we can revisit this to figure out how to convince Spring to do what we want here. I'm sure there's a way, just kind of fed up with it.