### PR TITLE
DWR-1215 Olap migrate loads the latest exam per student/asmt/year combination.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-58"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-278"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-280"
 
 String dockerPrefix = "smarterbalanced"
 

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/step/OlapReportingMigrateStepsConfig.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/step/OlapReportingMigrateStepsConfig.java
@@ -127,7 +127,8 @@ public class OlapReportingMigrateStepsConfig {
     @Bean
     public Step upsertFactStudentExamStep() {
         final SqlListBuilder sqlsBuilder = new SqlListBuilder(stagingToReportingSqlConfiguration.getEntities());
-        sqlsBuilder.addNext("fact_student_exam", "update")
+        sqlsBuilder.addNext("fact_student_exam", "updateStagingLatestExam")
+                .addNext("fact_student_exam", "update")
                 .addNext("fact_student_exam", "insert");
 
         return stepBuilderFactory.get(upsertFactStudentExamStepName)

--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -406,7 +406,7 @@ sql:
                              JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
                                                                 AND m.num = 4) scs ON scs.exam_id = e.id
                        ) AS claim4 ON claim4.exam_id = se.id
-                WHERE se.latest = true AND se.deleted = 0 AND fe.id IS NULL;
+                WHERE se.latest = true AND fe.id IS NULL;
 
             update: >-
                 UPDATE fact_student_exam
@@ -482,7 +482,7 @@ sql:
                              JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
                                                                 AND m.num = 4) scs ON scs.exam_id = e.id
                        ) AS claim4 ON claim4.exam_id = se.id
-                WHERE se.deleted = 0 AND se.latest = true AND (se.completed_at > fe.completed_at OR se.id = fe.id)
+                WHERE se.latest = true AND (se.completed_at > fe.completed_at OR se.id = fe.id)
 
             delete: >-
               DELETE FROM fact_student_exam

--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -282,6 +282,19 @@ sql:
       # ------------ fact_student_exam -----------------------------------------------------------------------
         fact_student_exam:
           sql:
+            updateStagingLatestExam: >-
+              UPDATE staging_exam
+                SET latest = true
+              FROM (
+                     SELECT
+                       id,
+                       rank()
+                       OVER (PARTITION BY student_id, asmt_id, school_year ORDER BY completed_at DESC, id)
+                     FROM staging_exam where deleted = false
+                   ) t
+                JOIN staging_exam e ON e.id = t.id
+              WHERE t.rank = 1;
+
             insert: >-
               INSERT INTO fact_student_exam (
                 id,
@@ -352,54 +365,56 @@ sql:
                   se.migrate_id
                 FROM staging_exam se
                   JOIN asmt ra ON ra.id = se.asmt_id
-                  LEFT JOIN fact_student_exam fe on fe.id = se.id
-                  LEFT JOIN (
-                              SELECT DISTINCT s.exam_id
-                                ,s.scale_score
-                                ,s.scale_score_std_err
-                                ,s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 1
-                            ) AS claim1 ON claim1.exam_id = se.id
-                  LEFT JOIN (
-                              SELECT DISTINCT s.exam_id
-                                ,s.scale_score
-                                ,s.scale_score_std_err
-                                ,s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 2
-                            ) AS claim2 ON claim2.exam_id = se.id
-                  LEFT JOIN (
-                              SELECT DISTINCT s.exam_id
-                                ,s.scale_score
-                                ,s.scale_score_std_err
-                                ,s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 3
-                            ) AS claim3 ON claim3.exam_id = se.id
-                  LEFT JOIN (
-                              SELECT DISTINCT s.exam_id
-                                ,s.scale_score
-                                ,s.scale_score_std_err
-                                ,s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 4
-                            ) AS claim4 ON claim4.exam_id = se.id
-                WHERE se.deleted = 0 AND fe.id IS NULL;
+                  LEFT JOIN fact_student_exam fe ON fe.student_id = se.student_id and fe.asmt_id = se.asmt_id and fe.school_year = se.school_year
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                            JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                    AND m.num = 1) scs ON scs.exam_id = e.id
+                       ) AS claim1 ON claim1.exam_id = se.id
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                             JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                AND m.num = 2) scs ON scs.exam_id = e.id
+                       ) AS claim2 ON claim2.exam_id = se.id
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                             JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                AND m.num = 3) scs ON scs.exam_id = e.id
+                       ) AS claim3 ON claim3.exam_id = se.id
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                             JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                AND m.num = 4) scs ON scs.exam_id = e.id
+                       ) AS claim4 ON claim4.exam_id = se.id
+                WHERE se.latest = true AND se.deleted = 0 AND fe.id IS NULL;
 
             update: >-
                 UPDATE fact_student_exam
                 SET
+                  id                          = se.id,
                   school_id                   = se.school_id,
-                  student_id                  = se.student_id,
-                  asmt_id                     = se.asmt_id,
                   grade_id                    = se.grade_id,
                   asmt_grade_id               = ra.grade_id,
-                  school_year                 = se.school_year,
                   iep                         = se.iep,
                   lep                         = se.lep,
                   section504                  = se.section504,
@@ -426,48 +441,48 @@ sql:
                   migrate_id                  = se.migrate_id
                  FROM staging_exam se
                   JOIN asmt ra ON ra.id = se.asmt_id
-                  LEFT JOIN fact_student_exam fe ON fe.id = se.id
-                  LEFT JOIN (
-                              SELECT
-                                s.exam_id,
-                                s.scale_score,
-                                s.scale_score_std_err,
-                                s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 1
-                            ) AS claim1 ON claim1.exam_id = se.id
-                  LEFT JOIN (
-                              SELECT
-                                s.exam_id,
-                                s.scale_score,
-                                s.scale_score_std_err,
-                                s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 2
-                            ) AS claim2 ON claim2.exam_id = se.id
-                  LEFT JOIN (
-                              SELECT
-                                s.exam_id,
-                                s.scale_score,
-                                s.scale_score_std_err,
-                                s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 3
-                            ) AS claim3 ON claim3.exam_id = se.id
-                  LEFT JOIN (
-                              SELECT
-                                s.exam_id,
-                                s.scale_score,
-                                s.scale_score_std_err,
-                                s.category
-                              FROM staging_exam_claim_score s
-                                INNER JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
-                                                                         AND m.num = 4
-                            ) AS claim4 ON claim4.exam_id = se.id
-                WHERE se.id = fact_student_exam.id AND se.deleted = 0;
+                  JOIN fact_student_exam fe ON fe.student_id = se.student_id and fe.asmt_id = se.asmt_id and fe.school_year = se.school_year
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                            JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                    AND m.num = 1) scs ON scs.exam_id = e.id
+                       ) AS claim1 ON claim1.exam_id = se.id
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                             JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                AND m.num = 2) scs ON scs.exam_id = e.id
+                       ) AS claim2 ON claim2.exam_id = se.id
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                             JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                AND m.num = 3) scs ON scs.exam_id = e.id
+                       ) AS claim3 ON claim3.exam_id = se.id
+                  JOIN (
+                         SELECT e.id as exam_id
+                           ,scs.scale_score
+                           ,scs.scale_score_std_err
+                           ,scs.category
+                         FROM staging_exam e
+                           LEFT JOIN (SELECT s.exam_id, s.scale_score, s.scale_score_std_err, s.category FROM staging_exam_claim_score s
+                             JOIN exam_claim_score_mapping m ON m.subject_claim_score_id = s.subject_claim_score_id
+                                                                AND m.num = 4) scs ON scs.exam_id = e.id
+                       ) AS claim4 ON claim4.exam_id = se.id
+                WHERE se.deleted = 0 AND se.latest = true AND (se.completed_at > fe.completed_at OR se.id = fe.id)
 
             delete: >-
               DELETE FROM fact_student_exam
@@ -481,7 +496,7 @@ sql:
               INSERT INTO asmt_active_year (asmt_id, school_year)
                 SELECT asmt_id, school_year
                 FROM
-                  ( SELECT DISTINCT f.asmt_id as asmt_id,  f.asmt_grade_id AS grade_id, f.school_year,  a.subject_id, a.type_id FROM fact_student_exam f JOIN asmt a ON a.id = f.asmt_id
+                  ( SELECT DISTINCT f.asmt_id as asmt_id, f.asmt_grade_id AS grade_id, f.school_year, a.subject_id, a.type_id FROM fact_student_exam f JOIN asmt a ON a.id = f.asmt_id
                     UNION
                     SELECT a.id AS asmt_id, a.grade_id, a.school_year, a.subject_id, a.type_id FROM asmt a
                   ) t ;

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
@@ -137,7 +137,7 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
         assertThat(icaFacts.get("asmt_id")).isEqualTo(-11L);
         assertThat(icaFacts.get("grade_id")).isEqualTo(-98);
         assertThat(icaFacts.get("asmt_grade_id")).isEqualTo(-98);
-        assertThat(icaFacts.get("school_year")).isEqualTo(1999);
+        assertThat(icaFacts.get("school_year")).isEqualTo(1998);
         assertThat((boolean) icaFacts.get("iep")).isTrue();
         assertThat((boolean) icaFacts.get("lep")).isTrue();
         assertThat((boolean) icaFacts.get("section504")).isFalse();

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertAsmtsStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertAsmtsStepRST.java
@@ -91,7 +91,7 @@ public class UpsertAsmtsStepRST extends MigrateStepRST {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
     })
     @Test
-    public void itShouldInsertButNoteDelete() {
+    public void itShouldInsertButNotDelete() {
 
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "asmt", 0, "id IN (-99)"));

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertFactExamsRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertFactExamsRST.java
@@ -34,7 +34,14 @@ public class UpsertFactExamsRST extends MigrateStepRST {
     @Test
     public void itShouldInsert() {
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
+
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 2, "1=1"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 2, "id in (-88, -87, -86)"));
+
+        //test for the latest exam use cases
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 1, "id = -86"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 0, "id = -85"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 0, "id in (-82, -83)"));
 
         getStepExecutionContext().put("batch", mock(Migrate.class));
 
@@ -63,9 +70,14 @@ public class UpsertFactExamsRST extends MigrateStepRST {
     public void itShouldUpdate() {
 
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", -1, "id = -88 and claim1_scale_score=-2000"));
 
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", -1, " id = -88 and claim1_scale_score=-2000"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 1, " id = -88 and claim1_scale_score=2000"));
+        //test for the latest exam use cases
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 0, "id in (-82, -83)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 1, "id = -88 and claim1_scale_score=2000 and scale_score = 2135"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", -1, "id = -100"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 1, "id = -84"));
+
         getStepExecutionContext().put("batch", mock(Migrate.class));
 
         // run the step first time
@@ -91,7 +103,7 @@ public class UpsertFactExamsRST extends MigrateStepRST {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
     })
     @Test
-    public void itShouldNoteDelete() {
+    public void itShouldNotDelete() {
 
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "fact_student_exam", 0, "id in (-88)"));

--- a/migrate-olap/src/test/resources/OlapAndStagingEntitiesTeardown.sql
+++ b/migrate-olap/src/test/resources/OlapAndStagingEntitiesTeardown.sql
@@ -8,7 +8,7 @@ DELETE FROM staging_school where id < 0;
 DELETE FROM staging_district where id in (-99, -98, -1);
 
 -- ------------------------------------------ Asmt ---------------------------------------------------------------------------------------------------------
-DELETE FROM staging_asmt where id in (-11, -99, -98);
+DELETE FROM staging_asmt where id in (-11, -99, -98, -97);
 
 -- ------------------------------------------ Student and Groups  ------------------------------------------------------------------------------------------------
 DELETE FROM staging_student_ethnicity where student_id in ( -11, -33, -89, -88, -87, -86);
@@ -26,5 +26,5 @@ DELETE FROM school where id in (-99, -98, -1);
 DELETE FROM district where id in (-99, -98, -1);
 
 -- ------------------------------------------ Asmt ---------------------------------------------------------------------------------------------------------
-DELETE FROM asmt where id in ( -11, -99, -98, -19);
+DELETE FROM asmt where id in ( -11, -99, -98, -19, -97);
 DELETE FROM asmt_active_year where asmt_id in ( -11, -99, -98, -19);

--- a/migrate-olap/src/test/resources/OlapAndStagingEntitiesTeardown.sql
+++ b/migrate-olap/src/test/resources/OlapAndStagingEntitiesTeardown.sql
@@ -1,7 +1,7 @@
 -- CLEAN UP staging
 -- ------------------------------------------  Exams ---------------------------------------------------------------------------------------------
-DELETE FROM staging_exam_claim_score where exam_id in  (-88, -87, -86, -85, -84);
-DELETE FROM staging_exam where id in (-88, -87, -86, -85, -84);
+DELETE FROM staging_exam_claim_score where exam_id in  (-88, -87, -86, -85, -84, -83);
+DELETE FROM staging_exam where id in (-88, -87, -86, -85, -84, -83, -14, -13, -17);
 
 -- ------------------------------------------ School/Districts --------------------------------------------------------------------------------------------------
 DELETE FROM staging_school where id < 0;
@@ -12,14 +12,14 @@ DELETE FROM staging_asmt where id in (-11, -99, -98);
 
 -- ------------------------------------------ Student and Groups  ------------------------------------------------------------------------------------------------
 DELETE FROM staging_student_ethnicity where student_id in ( -11, -33, -89, -88, -87, -86);
-DELETE FROM staging_student where id in ( -11, -33, -89, -88, -87, -86);
+DELETE FROM staging_student where id in ( -11, -33, -89, -88, -87, -86, -18);
 
 -- CLEAN UP reporting
-DELETE FROM fact_student_exam where id in (-88, -87, -86, -85, -84, -100);
+DELETE FROM fact_student_exam where id in (-88, -87, -86, -85, -84, -83, -100, -82);
 
 -- ------------------------------------------ Student   ------------------------------------------------------------------------------------------------
 DELETE FROM student_ethnicity where student_id in ( -11, -33, -89, -88, -87, -86);
-DELETE FROM student where id in ( -11, -33, -89, -88, -87, -86);
+DELETE FROM student where id in ( -11, -33, -89, -88, -87, -86, -18);
 
 -- ------------------------------------------ School/Districts --------------------------------------------------------------------------------------------------
 DELETE FROM school where id in (-99, -98, -1);

--- a/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
@@ -9,8 +9,8 @@ INSERT INTO school (id, district_id, name, update_import_id, migrate_id) VALUES
 
 -- ------------------------------------------ Asmt ---------------------------------------------------------------------------------------------------------
 INSERT INTO asmt (id, grade_id,  type_id, subject_id, school_year, name, label, update_import_id, migrate_id) VALUES
-   (-11, -98, 1, 1, 1999, 'SBAC-IAB-FIXED-G4M-OA-MATH-4', 'SBAC-IAB-FIXED-G4M-OA-MATH-4', -1, -1),
-   (-99, -99, 1, 3, 1999, 'test', 'test', -1, -1);
+   (-11, -98, 3, 1, 1999, 'test-summative-1999-98', 'summative-grade-98', -1, -1),
+   (-99, -99, 1, 2, 1999, 'test', 'test', -1, -1);
 
 INSERT INTO asmt_active_year(asmt_id, school_year) values
     (-11, 1995);
@@ -18,19 +18,22 @@ INSERT INTO asmt_active_year(asmt_id, school_year) values
 -- ------------------------------------------ Student and Groups  ------------------------------------------------------------------------------------------------
 INSERT INTO student (id, gender_id, update_import_id, migrate_id) VALUES
    (-11, -99, -1, -1),
-   (-89, -99, -1, -1);
+   (-89, -99, -1, -1),
+   (-18, -99, -1, -1);
 
 INSERT INTO student_ethnicity(student_id, ethnicity_id) values
     (-89,  -99);
 
 -- ------------------------------------------ Exams ---------------------------------------------------------------------------------------------
-INSERT INTO  fact_student_exam (id, school_year, asmt_id, asmt_grade_id, completeness_id,
-                                    administration_condition_id, performance_level,
-                                    scale_score, scale_score_std_err, grade_id, student_id, school_id,
+INSERT INTO  fact_student_exam (id, school_year, asmt_id, student_id, completed_at,
+                                    asmt_grade_id, completeness_id, administration_condition_id, performance_level,
+                                    scale_score, scale_score_std_err, grade_id, school_id,
                                     iep, lep, section504, economic_disadvantage, migrant_status,
                                     claim1_scale_score, claim1_scale_score_std_err,claim1_category,
                                     claim2_scale_score, claim2_scale_score_std_err,claim2_category,
                                     claim3_scale_score, claim3_scale_score_std_err,claim3_category,
                                     claim4_scale_score, claim4_scale_score_std_err,claim4_category,
-                                    completed_at, update_import_id, migrate_id) VALUES
-  (-88, 1999, -99, -99, -99, -99, 1, 2145, 0.17, -98, -89, -1, true, true, false, false, true,  -2000, 0.11, 1, -2100, 0.12, 2, -2500, 0.13, 3, -3000, .15, 4, '2016-08-14 19:05:33.000000', -1, -1);
+                                    update_import_id, migrate_id) VALUES
+  (-88,  1999, -99, -89, '2016-08-14 19:05:33.000000', -99, -99, -99, 1, 2145, 0.17, -98, -1, true, true, false, false, true,  -2000, 0.11, 1, -2100, 0.12, 2, -2500, 0.13, 3, -3000, .15, 4, -1, -1),
+  (-100, 1998, -11, -18, '2016-05-14 19:05:33.000000', -99, -99, -99, 1, 2145, 0.17, -98, -1, true, true, false, false, true,  -2000, 0.11, 1, -2100, 0.12, 2, -2500, 0.13, 3, -3000, .15, 4, -1, -1),
+  (-82 , 1998, -11, -89, '2016-09-14 19:05:33.000000', -99, -99, -99, 1, 2005, 0.17, -98, -1, true, true, false, false, true,  -2000, 0.11, 1, -2100, 0.12, 2, -2500, 0.13, 3, -3000, .15, 4, -1, -1);

--- a/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
@@ -8,13 +8,11 @@ INSERT INTO staging_school (id, district_id, name, deleted, update_import_id, mi
   (-98, -98, 'Sample School -98', 0, -1, -99);
 
 -- ------------------------------------------ Asmt ---------------------------------------------------------------------------------------------------------
-
 INSERT INTO staging_asmt (id,  grade_id, type_id, subject_id, school_year, name, label, deleted, update_import_id, migrate_id) VALUES
-   (-99, -99, 1, 1, 1999, 'SBAC-IAB-FIXED-G4M-OA-MATH-4', 'SBAC-IAB-FIXED-G4M-OA-MATH-4', 0, -1, -99),
-   (-98, -98, 1, 3, 1999, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'SBAC-ICA-FIXED-G5E-COMBINED-2017',  0, -1, -99);
+   (-99, -99, 1, 2, 1999, 'test-ica-1999-99', 'ica-1999-99', 0, -1, -99),
+   (-98, -98, 3, 1, 2000, 'test-summative-2000-98', 'summative-2000-98',  0, -1, -99);
 
 -- ------------------------------------------ Student  ------------------------------------------------------------------------------------------------
-
 INSERT INTO staging_student (id, ssid, last_or_surname, first_name, middle_name, gender_id, update_import_id, migrate_id, deleted) VALUES
   (-89, '89', 'LastName2', 'FirstName2', 'MiddleName2', -98, -1, -99, 0),
   (-88, '88', 'LastName2', 'FirstName2', 'MiddleName2', -98, -1, -99, 0),
@@ -29,17 +27,31 @@ INSERT INTO staging_student_ethnicity(student_id, ethnicity_id, migrate_id) valu
     (-86,  -99, -99);
 
 -- ------------------------------------------  Exams ------------------------------------------------------------------------------------------------
-INSERT INTO  staging_exam ( id, type_id, school_year, asmt_id,  completeness_id,
-                            administration_condition_id, performance_level, scale_score, scale_score_std_err, deleted, migrate_id,
-                            grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage,
-                            completed_at, migrant_status, update_import_id) VALUES
-  (-88, 1, 1999, -99, -99, -99, 1, 2145, 0.17,  0, -88, -98, -89, -1, 1, 1, 0, 0, '2016-08-14 19:05:33.967000', 1, -1),
-  (-87, 1, 1999, -11, -99, -99, 1, 2145, 0.17,  0, -88, -98, -11, -1, 1, 1, 0, 0, '2016-08-14 19:06:07.966000', 1, -1),
-  (-86, 1, 1999, -11, -99, -99, 1, 2145, 0.17,  0, -88, -98, -11, -1, 1, 1, 0, 0, '2016-08-14 19:06:07.966000', 1, -1);
+INSERT INTO  staging_exam ( id, type_id, school_year, asmt_id, student_id, completed_at,
+                            completeness_id, administration_condition_id, performance_level, scale_score, scale_score_std_err,
+                            deleted, migrate_id, grade_id, school_id, iep, lep, section504, economic_disadvantage, migrant_status, update_import_id) VALUES
+   -- same exams as in olap but with updated (older) completed_at, scale_score and claim score
+  (-88, 1, 1999, -99, -89, '2016-08-12 19:05:00.000000', -99, -99, 1, 2135, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+
+  -- exams with the same completed at, should not happen in real life but happens with the `data generator`
+  (-87, 1, 1998, -11, -11, '2016-08-14 19:06:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+  (-17, 1, 1998, -11, -11, '2016-08-14 19:06:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+
+   --  exams for the same school_year, asmt_id and student_id with diff completed_at, no matching entry in the olap
+  (-86, 1, 1999, -11, -11, '2016-08-14 19:06:07.966000', -99, -99, 1, 2135, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+  (-85, 1, 1999, -11, -11, '2016-08-14 19:05:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+
+    --  newer exams than in olap for the same student, asmt and school year
+  (-84, 1, 1998, -11, -18, '2016-08-14 19:06:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+  (-14, 1, 1998, -11, -18, '2016-07-14 19:06:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+
+    --  older exams than in olap for the same student, asmt and school year
+  (-83, 1, 1998, -11, -89, '2016-05-14 19:06:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1),
+  (-13, 1, 1998, -11, -89, '2016-04-14 19:06:07.966000', -99, -99, 1, 2145, 0.17,  0, -88, -98, -1, 1, 1, 0, 0,  1, -1);
 
 INSERT INTO staging_exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category, migrate_id) VALUES
-   (-1, -88, 1, 2000, 0.19, 1, -99),
+   (-1,  -88, 1, 2000, 0.19, 1, -99),
    (-10, -88, 2, 3000, 0.19, 1, -99),
    (-11, -88, 3, 4000, 0.19, 1, -99),
-   (-2, -87, 1, 2014, 0.19, 1, -99),
-   (-3, -86, 1, 2014, 0.19, 1, -99);
+   (-2,  -87, 1, 2014, 0.19, 1, -99),
+   (-3,  -86, 1, 2014, 0.19, 1, -99);

--- a/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
@@ -17,12 +17,12 @@ INSERT INTO school (id, district_id, district_group_id, school_group_id, name, n
   (-99, -99, NULL, NULL, 'Sample School -99', 'natural_id-99', 1, -1, -1, '2017-07-18 20:14:34.966000', '2017-07-18 20:14:34.000000'),
   (-98, -98, -98, -98, 'Sample School -98', 'natural_id-98', 0, -2, -2, '2017-07-18 20:13:34.000000', '2017-07-18 20:13:34.000000');
 
-INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, deleted, import_id, update_import_id, created, updated) VALUES
-  (-11, '(SBAC)SBAC-ICA-ASMT TEST-11', -98, 1, 1, 1999, 'SBAC-ICA-FIXED-G4M-OA-MATH-4', 'test', '9835', 0, -5000, -5000, '2017-05-18 19:05:33.967000', '2017-05-18 20:06:34.966000'),
-  (-99, '(SBAC)SBAC-ICA-ASMT TEST', -99, 3, 1, 1999, 'SBAC-ICA-FIXED-G4M-OA-MATH-4', 'ICA', '9835', 1, -5000, -20, '2017-07-18 19:05:34.966000', '2017-07-18 19:05:34.966000'),
-  (-98, 'SBAC)SBAC-ICA-ASMT TEST-5', -98, 1, 2, 1999, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'ICA', '9831', 0, -20, -20, '2017-07-18 19:05:34.966000', '2017-07-18 19:05:34.966000'),
-  (-97, 'SBAC)SBAC-IAB-ASMT TEST', -98, 2, 2, 1999, 'SBAC-IAB-FIXED-G5E-COMBINED-2017', 'Grade 5 ELA', '9831', 0, -20, -20, '2017-07-18 19:05:34.966000', '2017-07-18 19:05:34.966000');
-
+INSERT INTO asmt
+  (id, type_id, natural_id,                    grade_id, subject_id, school_year, name, label, version, deleted, import_id, update_import_id, created, updated) VALUES
+  (-11, 1,     'ica-1999-grade-98-subject-1',       -98,   1,        1999,        'ica-1999-grade-98-subject-1',        'test',       '9835', 0,   -5000, -5000, '2017-05-18 19:05:33.967000', '2017-05-18 20:06:34.966000'),
+  (-99, 3,     'summative-1999-grade-99-subject-1', -99,   1,        1999,        'summative-1999-grade-99-subject-1',  'summative',  '9835', 1,   -5000,   -20, '2017-07-18 19:05:34.966000', '2017-07-18 19:05:34.966000'),
+  (-98, 1,     'ica-1999-grade-98-subject-2',       -98,   2,        1999,        'ica-1999-grade-98-subject-2',        'ica',        '9831', 0,     -20,   -20, '2017-07-18 19:05:34.966000', '2017-07-18 19:05:34.966000'),
+  (-97, 2,     'iab-1999-grade-98-subject-2',       -98,   2,        1999,        'iab-1999-grade-98-subject-2',        'iab',        '9831', 0,     -20,   -20, '2017-07-18 19:05:34.966000', '2017-07-18 19:05:34.966000');
 
 INSERT INTO student (id, ssid, last_or_surname, first_name, middle_name, gender_id, first_entry_into_us_school_at, lep_entry_at,
                                     lep_exit_at, birthday, import_id, update_import_id, deleted, created, updated) VALUES
@@ -40,20 +40,20 @@ INSERT INTO student_ethnicity(student_id, ethnicity_id) values
   (-86,  -98),
   (-86,  -99);
 
-INSERT INTO  exam ( id, type_id, school_year, asmt_id, asmt_version, opportunity, completeness_id,
-                    administration_condition_id, session_id, performance_level, scale_score, scale_score_std_err, completed_at,
+INSERT INTO  exam ( id, type_id, school_year, asmt_id, student_id, completed_at,
+                    asmt_version, opportunity, completeness_id,
+                    administration_condition_id, session_id, performance_level, scale_score, scale_score_std_err,
                     import_id, update_import_id, deleted, created, updated,
-                    grade_id, student_id, school_id, iep, lep, section504, economic_disadvantage,
+                    grade_id, school_id, iep, lep, section504, economic_disadvantage,
                     migrant_status, eng_prof_lvl, t3_program_type, language_code, prim_disability_type) VALUES
-  (-88, 3, 1999, -99,  null, 1, 1, 1, 'session', 1, 2145, 20.17, '2016-08-14 19:05:33.967000', -5000, -88, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:06:07.966000', -98, -89, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-87, 1, 1999, -11,  null, 1, 1, 1, 'session', 1, 2106, 21.17, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-86, 2, 1999, -97,  null, 1, 1, 1, 'session', 1, 2135, 30.17, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-85, 1, 1999, -11,  null, 1, 1, 1, 'session', 1, 2125, 40.17, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-88, 3, 1999, -99, -89, '2016-08-14 19:05:33.967000', null, 1, 1, 1, 'session', 1, 2145, 20.17, -5000, -88, 1, '2017-05-18 19:05:33.967000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-87, 1, 1998, -11, -11, '2016-08-14 19:06:07.966000', null, 1, 1, 1, 'session', 1, 2106, 21.17,  -88, -88, 0,   '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-86, 2, 1999, -97, -11, '2016-08-14 19:06:07.966000', null, 1, 1, 1, 'session', 1, 2135, 30.17,  -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-85, 1, 1999, -11, -11, '2016-08-14 19:06:07.966000', null, 1, 1, 1, 'session', 1, 2125, 40.17,  -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
 
-  (-15, 3, 1999, -99,  null, 1, 1, 1, 'session', 1, null, 40.17, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-16, 1, 1999, -98,  null, 1, 1, 1, 'session', 1, 2125, null,  '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
-  (-17, 1, 1999, -98,  null, 1, 1, 1, 'session', null, 2125, 40.17, '2016-08-14 19:06:07.966000', -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -11, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null);
-
+  (-15, 3, 1999, -99, -11, '2016-08-14 19:06:07.966000', null, 1, 1, 1, 'session', 1, null, 40.17,  -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-16, 1, 1999, -98, -11, '2016-08-14 19:06:07.966000', null, 1, 1, 1, 'session', 1, 2125, null, -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null),
+  (-17, 1, 1999, -98, -11, '2016-08-14 19:06:07.966000', null, 1, 1, 1, 'session', null, 2125, 40.17,  -88, -88, 0, '2017-07-18 19:06:07.966000', '2017-07-18 19:06:07.966000', -98, -1, 1, 1, 0, 0, 1, 'eng_prof_lvl', 't3_program_type', 'eng', null);
 
 INSERT INTO exam_claim_score (id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category) VALUES
    (-1, -88, 1, 2014, 0.19, 1),

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertAsmtsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertAsmtsIT.java
@@ -116,7 +116,7 @@ public class UpsertAsmtsIT extends SpringBatchStepIT {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
     })
     @Test
-    public void itShouldInsertButNoteDelete() {
+    public void itShouldInsertButNotDelete() {
 
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         tableTestCounts.add(new TableTestCountHelper(reportingJdbcTemplate, "asmt", 0, "id IN (-99)"));

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
@@ -103,7 +103,7 @@ public class UpsertExamsIT extends SpringBatchStepIT {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
     })
     @Test
-    public void itShouldNoteDelete() {
+    public void itShouldNotDelete() {
 
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         tableTestCounts.add(new TableTestCountHelper(reportingJdbcTemplate, "exam_available_accommodation", 0, "exam_id in (-88)"));


### PR DESCRIPTION
Just to explain the approach:

In order to find the latest exams, the logic I am applying is:
1. Find the latest exam in the staging table and mark it as such.
2. Find an overlap between the found latest exams in staging and in the fact table using [student_id, asmt_id and exam school_year], and updated the found matches, but only if the latest in staging is AFTER the one in the fact table OR it is exactly the same exam.
3. Insert new exams. To find new exams, instead of using LEFT JOIN by exam id, LEFT JOIN by [student_id, asmt_id and exam school_year].

While the SQLs for loading the fact table looks overwhelmingly complex, the execution time has not changed that much.  The load from AWS dev was 1 min longer, 63 min total; the average time for upsertFactStudentExamStep changed from 5.6316 seconds to 8.0. 