### PR TITLE
Added state embargo to olap migrate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'io.spring.dependency-management'
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.1.0-SNAPSHOT`
 
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.1.0-58"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-284"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.1.0-285"
 
 String dockerPrefix = "smarterbalanced"
 

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/step/OlapReportingMigrateStepsConfig.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/step/OlapReportingMigrateStepsConfig.java
@@ -215,6 +215,7 @@ public class OlapReportingMigrateStepsConfig {
     public Step extractEmbargoStep() {
         final List<String> sql = newArrayList();
         sql.add(warehouseToStagingSqlConfiguration.getEntities().get("district_embargo").getSql().get("warehouseRead"));
+        sql.add(warehouseToStagingSqlConfiguration.getEntities().get("state_embargo").getSql().get("warehouseRead"));
         return stepBuilderFactory.get(extractEmbargoStep)
                 .tasklet(new SqlListEmbargoWithParamExecutionStep(warehouseCopyRepository, sql))
                 .build();
@@ -224,6 +225,7 @@ public class OlapReportingMigrateStepsConfig {
     public Step loadEmbargoToStagingStep() {
         final List<String> sql = newArrayList();
         sql.add(warehouseToStagingSqlConfiguration.getEntities().get("district_embargo").getSql().get("stagingInsert"));
+        sql.add(warehouseToStagingSqlConfiguration.getEntities().get("state_embargo").getSql().get("stagingInsert"));
         return stepBuilderFactory.get(loadEmbargoToStagingStep)
                 .tasklet(new SqlListEmbargoExecutionStep(reportingSqlListExecutionRepository, sql))
                 .build();
@@ -233,6 +235,8 @@ public class OlapReportingMigrateStepsConfig {
     public Step updateEmbargoStep() {
         final SqlListBuilder sqlsBuilder = new SqlListBuilder(stagingToReportingSqlConfiguration.getEntities());
         sqlsBuilder.addNext("school_embargo", "update");
+        sqlsBuilder.addNext("state_embargo", "delete");
+        sqlsBuilder.addNext("state_embargo", "insert");
 
         return stepBuilderFactory.get(updateEmbargoStepName)
                 .tasklet(new SqlListExecutionStep(

--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -245,6 +245,7 @@ sql:
                   LEFT JOIN school rs ON rs.id = ss.id
                 WHERE rs.id IS NULL and ss.deleted = 0;
 
+            # it is expected that schools and embargo settings are always migrated together, therefore the embargo_enabled flag is not updated here.
             update: >-
               UPDATE school
               SET
@@ -254,7 +255,6 @@ sql:
                 external_id  = ss.external_id,
                 school_group_id  = ss.school_group_id,
                 district_group_id  = ss.district_group_id,
-                embargo_enabled = 1,
                 update_import_id = ss.update_import_id,
                 migrate_id = ss.migrate_id
               FROM staging_school ss
@@ -279,6 +279,17 @@ sql:
                 FROM school rs
                   JOIN staging_district_embargo sde ON sde.district_id = rs.district_id AND rs.embargo_enabled <> sde.aggregate;
 
+        state_embargo:
+          sql:
+            insert: >-
+                INSERT INTO state_embargo (aggregate, migrate_id)
+                   SELECT
+                     sse.aggregate,
+                     sse.migrate_id
+                   FROM staging_state_embargo sse;
+
+            delete: >-
+               DELETE FROM state_embargo;
       # ------------ district -----------------------------------------------------------------------
         district:
           sql:

--- a/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -802,3 +802,27 @@ sql:
               FORMAT AS CSV
               DELIMITER ','
               COMPUPDATE OFF
+
+
+# ------------ district_embargo  -------------------------------------------------------------------
+        state_embargo:
+          sql:
+            warehouseRead:
+              SELECT
+                IF(aggregate = 0, 0, 1) AS aggregate,
+                ? as migrate_id
+              FROM state_embargo
+               WHERE school_year = ${app.school-year}
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/state_embargo'
+                              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+                              LINES TERMINATED BY '\n'
+
+            stagingInsert:
+              COPY staging_state_embargo (
+                aggregate,
+                migrate_id)
+              FROM '${archive.root}/${migrate.aws.location}/state_embargo.part_00000'
+              CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
+              FORMAT AS CSV
+              DELIMITER ','
+              COMPUPDATE OFF

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEmbargoRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEmbargoRST.java
@@ -54,6 +54,7 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
     @After
     public void cleanUp() {
         if (archiveService.exists(location + "/embargo.part_00000")) archiveService.delete(location);
+        if (archiveService.exists(location + "/state_embargo.part_00000")) archiveService.delete(location);
         if (archiveService.exists(testFileName)) archiveService.delete(testFileName);
     }
 
@@ -194,6 +195,39 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
         verifyTableCountsAfterTest(tableTestCounts);
     }
 
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+                    "INSERT INTO state_embargo (school_year, individual, aggregate) VALUES (1999, 0, 0)"
+            }),
+
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+                    "DELETE FROM state_embargo"
+            }),
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+                    "DELETE FROM staging_state_embargo",
+                    "DELETE FROM state_embargo"
+            })
+    })
+    @Test
+    public void itShouldCopyStateEmbargo() {
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "state_embargo", 1, "1=1"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "state_embargo", 1, "aggregate = false"));
+
+        getStepExecutionContext().put(ExecutionParams.migrate,
+                Migrate.builder().id(1L).jobId(1)
+                        .status(MigrateStatus.STARTED)
+                        .firstAt(firstAt)
+                        .lastAt(lastAt)
+                        .migrateEmbargo(true)
+                        .build());
+
+        JobExecution jobExecution = launchStep(extractEmbargoStep);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+
+        jobExecution = launchStep(loadEmbargoToStagingStep);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+    }
 
     @Test
     public void extractEmbargoStepShouldFailWithNoMigrateBatch() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEmbargoRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEmbargoRST.java
@@ -204,8 +204,7 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
                     "DELETE FROM state_embargo"
             }),
             @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
-                    "DELETE FROM staging_state_embargo",
-                    "DELETE FROM state_embargo"
+                    "DELETE FROM staging_state_embargo"
             })
     })
     @Test

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpdateEmbargoRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpdateEmbargoRST.java
@@ -26,7 +26,7 @@ public class UpdateEmbargoRST extends MigrateStepRST {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
     })
     @Test
-    public void itShouldUpdate() {
+    public void itShouldUpdateSchoolDistrictEmbargo() {
         // one district (-99) has the same effective embargo setting
         // one district (-98) has a new setting and schools should change
 
@@ -35,6 +35,35 @@ public class UpdateEmbargoRST extends MigrateStepRST {
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "school", -2, "embargo_enabled = false AND id IN(-97, -98, -99)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "school", 2, "migrate_id = -99 AND id IN(-97, -98, -99)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "school", -2, "migrate_id = -10 AND id IN(-97, -98, -99)"));
+
+        getStepExecutionContext().put("batch", mock(Migrate.class));
+
+        // run the step first time
+        JobExecution jobExecution = launchStep(updateEmbargoStepName);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+
+        //repeat to verify that it is idempotent
+        jobExecution = launchStep(updateEmbargoStepName);
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+        verifyTableCountsAfterTest(tableTestCounts);
+    }
+
+    @SqlGroup({
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+                    "INSERT INTO staging_state_embargo (aggregate, migrate_id) VALUES (0, -10)",
+                    "DELETE FROM state_embargo"
+            }),
+
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+                    "DELETE FROM staging_state_embargo",
+                    "DELETE FROM state_embargo"
+            })
+    })
+    @Test
+    public void itShouldUpdateStateEmbargo() {
+        final List<TableTestCountHelper> tableTestCounts = newArrayList();
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "state_embargo", 1, "aggregate = false"));
 
         getStepExecutionContext().put("batch", mock(Migrate.class));
 

--- a/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
@@ -781,6 +781,7 @@ sql:
                LEFT JOIN school rs ON rs.id = ss.id
              WHERE rs.id IS NULL AND ss.deleted = 0;
 
+          # it is expected that schools and embargo settings are always migrated together, therefore the embargo_enabled flag is not updated here.
           update: >-
             UPDATE school rs
               JOIN staging_school ss ON ss.id = rs.id
@@ -789,7 +790,6 @@ sql:
               rs.district_id = ss.district_id,
               rs.district_group_id = ss.district_group_id,
               rs.school_group_id = ss.school_group_id,
-              rs.embargo_enabled = 0,
               rs.update_import_id = ss.update_import_id,
               rs.updated = ss.updated,
               rs.migrate_id = ss.migrate_id


### PR DESCRIPTION
I think that state aggregate queries could benefit from this flag. If not, we can remove it then.