### PR TITLE
Prevent loading both a JdbcRetryConfiguration and RetryConfiguration

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/DataSourceConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/DataSourceConfiguration.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -19,7 +18,6 @@ import javax.sql.DataSource;
  */
 @Configuration
 @EnableTransactionManagement
-@EnableRetry
 @ComponentScan("org.opentestsystem.rdw.ingest.common")
 @Import(JdbcRetryConfiguration.class)
 public class DataSourceConfiguration {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/JdbcRetryConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/JdbcRetryConfiguration.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.ingest.processor.repository;
 
 import org.springframework.aop.support.AbstractPointcutAdvisor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
@@ -16,6 +17,7 @@ import org.springframework.core.annotation.Order;
  * hardcoded value that is equal to {@link Integer#MAX_VALUE} and then the order becomes random
  */
 @Configuration
+@EnableAspectJAutoProxy(proxyTargetClass = false)
 public class JdbcRetryConfiguration extends org.springframework.retry.annotation.RetryConfiguration {
 
     @Override

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
@@ -97,7 +97,7 @@ class JdbcExamRepository implements ExamRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}"))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
     @Transactional
     public long upsert(final Exam exam, final long importId) {
         if (exam.isDeleted()) throw new IllegalArgumentException("deleted exam is not supported for upsert");

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcExamRepository.java
@@ -97,7 +97,7 @@ class JdbcExamRepository implements ExamRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplierExpression = "${jdbc.retry.default.multiplier}", random = true))
     @Transactional
     public long upsert(final Exam exam, final long importId) {
         if (exam.isDeleted()) throw new IllegalArgumentException("deleted exam is not supported for upsert");

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
@@ -50,7 +50,7 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplierExpression = "${jdbc.retry.default.multiplier}", random = true))
     @Transactional
     public StudentGroup upsert(final StudentGroup group, final long importId) {
         final int studentId = (int) new SimpleJdbcCall(jdbcTemplate)
@@ -103,7 +103,7 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplierExpression = "${jdbc.retry.default.multiplier}", random = true))
     @Transactional
     public void addStudentToGroups(final long studentId, final List<Integer> groupIds, final long importId) {
         jdbcTemplate.batchUpdate(sqlAddStudentMembership, new BatchPreparedStatementSetter() {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentGroupRepository.java
@@ -50,7 +50,7 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}"))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
     @Transactional
     public StudentGroup upsert(final StudentGroup group, final long importId) {
         final int studentId = (int) new SimpleJdbcCall(jdbcTemplate)
@@ -103,9 +103,9 @@ class JdbcStudentGroupRepository implements StudentGroupRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}"))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
     @Transactional
-    public void addStudentToGroups(final long studentId, final List<Integer> groupIds, long importId) {
+    public void addStudentToGroups(final long studentId, final List<Integer> groupIds, final long importId) {
         jdbcTemplate.batchUpdate(sqlAddStudentMembership, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(final PreparedStatement ps, final int i) throws SQLException {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentRepository.java
@@ -50,7 +50,7 @@ class JdbcStudentRepository implements StudentRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}"))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
     @Transactional
     public int upsert(final Student student, final long importId) {
         final Map<String, Object> retParams = new SimpleJdbcCall(jdbcTemplate)

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentRepository.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcStudentRepository.java
@@ -50,7 +50,7 @@ class JdbcStudentRepository implements StudentRepository {
     }
 
     @Override
-    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplier = 2, random = true))
+    @Retryable(maxAttemptsExpression = "${jdbc.retry.default.max-attempts}", backoff = @Backoff(delayExpression = "${jdbc.retry.default.delay}", multiplierExpression = "${jdbc.retry.default.multiplier}", random = true))
     @Transactional
     public int upsert(final Student student, final long importId) {
         final Map<String, Object> retParams = new SimpleJdbcCall(jdbcTemplate)

--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -53,3 +53,4 @@ jdbc:
     default:
       max-attempts: 4
       delay: 30
+      multiplier: 2


### PR DESCRIPTION
We were loading both the RetryConfiguration and a JdbcRetryConfiguration (which extends RetryConfiguration.)  This was causing Spring to set two cutpoints on @Retryable-annotated methods leading to nested retries.

This fix removes the @EnableRetry annotation in favor of loading only the JdbcRetryConfiguration.  

This lead to failures in the MultiThreadedApplicationTest.  We were running 10 threads updating the same data simultaneously with a static backoff of X milliseconds and 4 retries.  Every X milliseconds 1 or 2 executions would complete successfully while the others failed due to transaction conflicts.  16 attempts allowed all 10 threads to complete eventually, 4 attempts did not.

To fix the issue I changed the backoff to an exponential backoff with randomized wait times to spread the attempts out over time and allow all 10 threads to complete within 4 retries.