### PR TITLE
fix a couple bugs when importing packages

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,49 +54,49 @@ services:
     extra_hosts:
       - "dwhost:$DATAWAREHOUSE_HOST"
 
-  exam-processor:
-    image: smarterbalanced/rdw-ingest-exam-processor
-    ports:
-      - 8082:8008
-    links:
-      - config-server
-      - rabbitmq
-    environment:
-      - spring.profiles.active=local-docker
-      - CONFIG_SERVICE_ENABLED=true
-      - CONFIG_SERVICE_URL=http://config-server:8888
-    extra_hosts:
-      - "dwhost:$DATAWAREHOUSE_HOST"
-
-  package-processor:
-    image: smarterbalanced/rdw-ingest-package-processor
-    ports:
-      - 8083:8008
-    links:
-      - config-server
-      - rabbitmq
-    environment:
-      - spring.profiles.active=local-docker
-      - CONFIG_SERVICE_ENABLED=true
-      - CONFIG_SERVICE_URL=http://config-server:8888
-    extra_hosts:
-      - "dwhost:$DATAWAREHOUSE_HOST"
-
-  task-service:
-    image: smarterbalanced/rdw-ingest-task-service
-    ports:
-      - 8084:8008
-    volumes:
-      - /tmp:/tmp
-    links:
-      - config-server
-      - import-service
-    environment:
-      - spring.profiles.active=local-docker
-      - CONFIG_SERVICE_ENABLED=true
-      - CONFIG_SERVICE_URL=http://config-server:8888
-    extra_hosts:
-      - "dwhost:$DATAWAREHOUSE_HOST"
+#  exam-processor:
+#    image: smarterbalanced/rdw-ingest-exam-processor
+#    ports:
+#      - 8082:8008
+#    links:
+#      - config-server
+#      - rabbitmq
+#    environment:
+#      - spring.profiles.active=local-docker
+#      - CONFIG_SERVICE_ENABLED=true
+#      - CONFIG_SERVICE_URL=http://config-server:8888
+#    extra_hosts:
+#      - "dwhost:$DATAWAREHOUSE_HOST"
+#
+#  package-processor:
+#    image: smarterbalanced/rdw-ingest-package-processor
+#    ports:
+#      - 8083:8008
+#    links:
+#      - config-server
+#      - rabbitmq
+#    environment:
+#      - spring.profiles.active=local-docker
+#      - CONFIG_SERVICE_ENABLED=true
+#      - CONFIG_SERVICE_URL=http://config-server:8888
+#    extra_hosts:
+#      - "dwhost:$DATAWAREHOUSE_HOST"
+#
+#  task-service:
+#    image: smarterbalanced/rdw-ingest-task-service
+#    ports:
+#      - 8084:8008
+#    volumes:
+#      - /tmp:/tmp
+#    links:
+#      - config-server
+#      - import-service
+#    environment:
+#      - spring.profiles.active=local-docker
+#      - CONFIG_SERVICE_ENABLED=true
+#      - CONFIG_SERVICE_URL=http://config-server:8888
+#    extra_hosts:
+#      - "dwhost:$DATAWAREHOUSE_HOST"
 
   migrate-reporting:
     image: smarterbalanced/rdw-ingest-migrate-reporting

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,49 +54,49 @@ services:
     extra_hosts:
       - "dwhost:$DATAWAREHOUSE_HOST"
 
-#  exam-processor:
-#    image: smarterbalanced/rdw-ingest-exam-processor
-#    ports:
-#      - 8082:8008
-#    links:
-#      - config-server
-#      - rabbitmq
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-#  package-processor:
-#    image: smarterbalanced/rdw-ingest-package-processor
-#    ports:
-#      - 8083:8008
-#    links:
-#      - config-server
-#      - rabbitmq
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
-#
-#  task-service:
-#    image: smarterbalanced/rdw-ingest-task-service
-#    ports:
-#      - 8084:8008
-#    volumes:
-#      - /tmp:/tmp
-#    links:
-#      - config-server
-#      - import-service
-#    environment:
-#      - spring.profiles.active=local-docker
-#      - CONFIG_SERVICE_ENABLED=true
-#      - CONFIG_SERVICE_URL=http://config-server:8888
-#    extra_hosts:
-#      - "dwhost:$DATAWAREHOUSE_HOST"
+  exam-processor:
+    image: smarterbalanced/rdw-ingest-exam-processor
+    ports:
+      - 8082:8008
+    links:
+      - config-server
+      - rabbitmq
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
+
+  package-processor:
+    image: smarterbalanced/rdw-ingest-package-processor
+    ports:
+      - 8083:8008
+    links:
+      - config-server
+      - rabbitmq
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
+
+  task-service:
+    image: smarterbalanced/rdw-ingest-task-service
+    ports:
+      - 8084:8008
+    volumes:
+      - /tmp:/tmp
+    links:
+      - config-server
+      - import-service
+    environment:
+      - spring.profiles.active=local-docker
+      - CONFIG_SERVICE_ENABLED=true
+      - CONFIG_SERVICE_URL=http://config-server:8888
+    extra_hosts:
+      - "dwhost:$DATAWAREHOUSE_HOST"
 
   migrate-reporting:
     image: smarterbalanced/rdw-ingest-migrate-reporting

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
@@ -45,8 +45,8 @@ class JdbcRdwImportRepository implements RdwImportRepository {
     @Value("${sql.import.findOne}")
     private String sqlFindOne;
 
-    @Value("${sql.import.findOneByDigest}")
-    private String sqlFindOneByDigest;
+    @Value("${sql.import.findOneByContentAndDigest}")
+    private String sqlFindOneByContentAndDigest;
 
     @Value("${sql.import.findBy}")
     private String sqlFindBy;
@@ -88,10 +88,12 @@ class JdbcRdwImportRepository implements RdwImportRepository {
     }
 
     @Override
-    public RdwImport findOneByDigest(final String digest) {
-        final MapSqlParameterSource parameterSource = new MapSqlParameterSource().addValue("digest", digest);
+    public RdwImport findOneByContentAndDigest(final ImportContent content, final String digest) {
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource()
+                .addValue("content", content.getValue())
+                .addValue("digest", digest);
         try {
-            return jdbcTemplate.queryForObject(sqlFindOneByDigest, parameterSource, new RdwImportRowMapper());
+            return jdbcTemplate.queryForObject(sqlFindOneByContentAndDigest, parameterSource, new RdwImportRowMapper());
         } catch (final EmptyResultDataAccessException ignored) {
             return null;
         }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepository.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepository.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.repository;
 
+import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
@@ -22,7 +23,12 @@ public interface RdwImportRepository {
 
     RdwImport findOne(long id);
 
-    RdwImport findOneByDigest(String digest);
+    /**
+     * @param content content to match
+     * @param digest digest to match
+     * @return import if there is a match, null if no match
+     */
+    RdwImport findOneByContentAndDigest(ImportContent content, String digest);
 
     boolean exists(long id);
 

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -54,7 +54,7 @@ class DefaultImportService implements ImportService {
 
         final String digest = DigestUtils.md5Hex(payload).toUpperCase();
 
-        RdwImport rdwImport = repository.findOneByDigest(digest);
+        RdwImport rdwImport = repository.findOneByContentAndDigest(content, digest);
         if (rdwImport != null) {
             logger.info("Ignoring {} payload with existing digest {}", content, digest);
             return rdwImport;

--- a/import-service/src/main/resources/application.sql.yml
+++ b/import-service/src/main/resources/application.sql.yml
@@ -16,8 +16,8 @@ sql:
     findOne: >-
       SELECT * FROM import WHERE id=:id
 
-    findOneByDigest: >-
-      SELECT * FROM import WHERE digest=:digest
+    findOneByContentAndDigest: >-
+      SELECT * FROM import WHERE content=:content AND digest=:digest
 
     findBy: >-
       SELECT *

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -41,7 +41,9 @@ public class RdwImportRepositoryIT {
         assertThat(alice.getDigest()).isEqualTo("alice");
         assertThat(alice.getMessage()).isEqualTo("Hi alice");
 
-        assertThat(repository.findOneByDigest("bob").getCreator()).isEqualTo("bob");
+        assertThat(repository.findOneByContentAndDigest(ImportContent.EXAM, "bob").getCreator()).isEqualTo("bob");
+        // but not if content doesn't match
+        assertThat(repository.findOneByContentAndDigest(ImportContent.PACKAGE, "bob")).isNull();
 
         assertThat(repository.exists(map.get("alice"))).isTrue();
         assertThat(repository.exists(map.get("charlie") + 1234)).isFalse();
@@ -89,7 +91,7 @@ public class RdwImportRepositoryIT {
 
     @Test
     public void itShouldNotFindUnknownImportByDigest() {
-        assertThat(repository.findOneByDigest("probablyNotARealDigest")).isNull();
+        assertThat(repository.findOneByContentAndDigest(ImportContent.EXAM, "probablyNotARealDigest")).isNull();
     }
 
     @Test

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -68,9 +67,23 @@ public class DefaultImportServiceTest {
 
         final String digest = DigestUtils.md5Hex(body).toUpperCase();
         final RdwImport match = RdwImport.builder().build();
-        when(repository.findOneByDigest(digest)).thenReturn(match);
+        when(repository.findOneByContentAndDigest(ImportContent.EXAM, digest)).thenReturn(match);
 
         assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null)).isSameAs(match);
+    }
+
+    @Test
+    public void importShouldIgnoreExistingDigestForDifferentContent() {
+        final SbacUserDetails user = SbacUserTest.testUser();
+        final byte[] body = "<TDSReport/>".getBytes();
+        final String contentType = "application/xml";
+
+        final String digest = DigestUtils.md5Hex(body).toUpperCase();
+        final RdwImport match = RdwImport.builder().build();
+        when(repository.findOneByContentAndDigest(ImportContent.PACKAGE, digest)).thenReturn(match);
+
+        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null).getId()).isEqualTo(123);
+        verify(importSource).submitContent(body, ImportContent.EXAM, contentType, 123L);
     }
 
     @Test

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentParser.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentParser.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.opentestsystem.rdw.ingest.common.config.SbacScoreConfiguration;
@@ -62,7 +63,10 @@ class DefaultAssessmentParser implements AssessmentParser {
     public List<Assessment> parse(final byte[] assessmentPackage, final DataElementErrorCollector elementErrorCollector) {
         // at this point we need a Reader so assume UTF-8 payload
         try (final Reader reader = new InputStreamReader(new ByteArrayInputStream(assessmentPackage), Charset.forName("utf8"))) {
-            final Iterator<CSVRecord> recordIterator = CSVFormat.RFC4180.withFirstRecordAsHeader().parse(reader).iterator();
+            final Iterator<CSVRecord> recordIterator = CSVFormat.RFC4180
+                    .withFirstRecordAsHeader()
+                    .withCommentMarker('#')
+                    .parse(reader).iterator();
 
             final List<Assessment> assessments = newArrayList();
             if (!recordIterator.hasNext()) return assessments;
@@ -72,6 +76,9 @@ class DefaultAssessmentParser implements AssessmentParser {
             assessmentParserHelper.newAssessmentRecord(recordIterator.next());
             while (recordIterator.hasNext()) {
                 final CSVRecord nextRecord = recordIterator.next();
+                if (assessmentParserHelper.isSkippable(nextRecord)) {
+                    continue;
+                }
                 if (!assessmentParserHelper.sameAssessment(nextRecord)) {
                     assessments.add(assessmentParserHelper.safeBuild(elementErrorCollector));
                     assessmentParserHelper.newAssessmentRecord(nextRecord);
@@ -147,6 +154,10 @@ class DefaultAssessmentParser implements AssessmentParser {
             if (asmtSubjectId != null) asmtBuilder.item(itemParser.parse(record, errorCollector, asmtNaturalId, asmtSubjectId));
         }
 
+        boolean isSkippable(final CSVRecord record) {
+            return Iterables.all(record, value -> value == null || value.trim().isEmpty());
+        }
+
         boolean sameAssessment(final CSVRecord record) {
             return record.get(AssessmentId).trim().equals(asmtNaturalId);
         }
@@ -174,7 +185,7 @@ class DefaultAssessmentParser implements AssessmentParser {
         }
     }
 
-    private static Function<String, String> toTypeCode = value -> {
+    private static final Function<String, String> toTypeCode = value -> {
         Precondition.checkNotBlank(value);
         if ("summative".equalsIgnoreCase(value)) return "sum";
         return value.toLowerCase();

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/PackageProcessorTest.java
@@ -9,15 +9,14 @@ import org.opentestsystem.rdw.ingest.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.repository.ImportRepository;
 import org.opentestsystem.rdw.ingest.processor.service.AccommodationsProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.AssessmentPackageProcessor;
-import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.NormsProcessor;
+import org.opentestsystem.rdw.ingest.processor.service.OrganizationProcessor;
 import org.opentestsystem.rdw.messaging.RdwMessageHeaderAccessor;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -44,7 +43,7 @@ public class PackageProcessorTest {
 
 
     @Before
-    public void createProcessors() throws IOException {
+    public void createProcessors() {
         accommodationsProcessor = mock(AccommodationsProcessor.class);
         organizationProcessor = mock(OrganizationProcessor.class);
         packageProcessor = mock(AssessmentPackageProcessor.class);
@@ -59,42 +58,42 @@ public class PackageProcessorTest {
     }
 
     @Test
-    public void itShouldProcessAssessmentPackage() throws UnsupportedEncodingException {
+    public void itShouldProcessAssessmentPackage() {
         processor.processPackage(createMessage(1, PACKAGE, MediaType.TEXT_PLAIN, "/IAB_ICA_Combined.items.csv"));
         verify(packageProcessor).process(any(byte[].class), eq(1L));
         verify(importRepository).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
     }
 
     @Test
-    public void itShouldProcessAccommodations() throws UnsupportedEncodingException {
+    public void itShouldProcessAccommodations() {
         processor.processCodes(createMessage(2, CODES, MediaType.APPLICATION_XML, "/AccessibilityConfig.xml"));
         verify(accommodationsProcessor).process(any(byte[].class), eq(2L));
         verify(importRepository).updateStatusAndMessageById(2, ImportStatus.PROCESSED, null);
     }
 
     @Test
-    public void itShouldProcessOrganization() throws UnsupportedEncodingException {
+    public void itShouldProcessOrganization() {
         processor.processOrganization(createMessage(1, ORGANIZATION, MediaType.APPLICATION_JSON, "/organization.json"));
         verify(organizationProcessor).process(any(byte[].class), eq(1L));
         verify(importRepository).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
     }
 
     @Test
-    public void itShouldProcessCalpadsOrganization() throws UnsupportedEncodingException {
+    public void itShouldProcessCalpadsOrganization() {
         processor.processOrganization(createMessage(1, ORGANIZATION, MediaType.APPLICATION_JSON, "/CA_schools.csv"));
         verify(organizationProcessor).process(any(byte[].class), eq(1L));
         verify(importRepository).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
     }
 
     @Test
-    public void itShouldProcessNorms() throws UnsupportedEncodingException {
+    public void itShouldProcessNorms() {
         processor.processNorms(createMessage(1, NORMS, MediaType.TEXT_PLAIN, "/percentile/percentiles.csv"));
         verify(normsProcessor).process(any(byte[].class), eq(1L));
         verify(importRepository).updateStatusAndMessageById(1, ImportStatus.PROCESSED, null);
     }
 
     @Test
-    public void itShouldHandleNormsImportException() throws UnsupportedEncodingException {
+    public void itShouldHandleNormsImportException() {
         doThrow(new ImportException(ImportStatus.BAD_DATA, "bad-data-message"))
                 .when(normsProcessor)
                 .process(any(byte[].class), anyLong());
@@ -106,7 +105,7 @@ public class PackageProcessorTest {
 
 
     @Test
-    public void itShouldHandleImportException() throws UnsupportedEncodingException {
+    public void itShouldHandleImportException() {
         doThrow(new ImportException(ImportStatus.UNKNOWN_ASMT, "message"))
                 .when(packageProcessor)
                 .process(any(byte[].class), anyLong());
@@ -117,7 +116,7 @@ public class PackageProcessorTest {
     }
 
     @Test
-    public void itShouldHandleAnyRuntimeException() throws UnsupportedEncodingException {
+    public void itShouldHandleAnyRuntimeException() {
         doThrow(new RuntimeException("any message")).when(packageProcessor).process(any(byte[].class), anyLong());
 
         processor.processPackage(createMessage(1, PACKAGE, MediaType.TEXT_PLAIN, "/IAB_ICA_Combined.bad-asmt.csv"));

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentParserIT.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultAssessmentParserIT.java
@@ -100,7 +100,8 @@ public class DefaultAssessmentParserIT {
     @Test
     public void itShouldHandleFileWithOneRow() throws IOException {
         final DataElementErrorCollector elementErrorCollector = new DataElementErrorCollector();
-        final List<Assessment> assessments = assessmentParser.parse(ByteStreams.toByteArray(this.getClass().getResourceAsStream("/IAB_ICA_Combined.items.one.row.csv")), elementErrorCollector);
+        final List<Assessment> assessments = assessmentParser.parse(ByteStreams.toByteArray(this.getClass()
+                .getResourceAsStream("/IAB_ICA_Combined.items.one.row.csv")), elementErrorCollector);
 
         assertThat(assessments.size()).isEqualTo(1);
         assertThat(elementErrorCollector.isEmpty()).isTrue();
@@ -120,5 +121,15 @@ public class DefaultAssessmentParserIT {
         assertThat(item.getMaxPoints()).isEqualTo(10);
         assertThat(Iterables.size(item.getOtherTargets())).isEqualTo(2);
         assertThat(Iterables.size(item.getCommonCoreStandards())).isEqualTo(2);
+    }
+
+    @Test
+    public void itShouldHandleFileWithEmptyRowsAndComments() throws IOException {
+        final DataElementErrorCollector elementErrorCollector = new DataElementErrorCollector();
+        final List<Assessment> assessments = assessmentParser.parse(ByteStreams.toByteArray(this.getClass()
+                .getResourceAsStream("/IAB_ICA_Combined.items.emptyrows.csv")), elementErrorCollector);
+
+        assertThat(assessments.size()).isEqualTo(1);
+        assertThat(elementErrorCollector.isEmpty()).isTrue();
     }
 }

--- a/package-processor/src/test/resources/IAB_ICA_Combined.items.emptyrows.csv
+++ b/package-processor/src/test/resources/IAB_ICA_Combined.items.emptyrows.csv
@@ -1,0 +1,9 @@
+AssessmentId,AssessmentName,AssessmentSubject,AssessmentGrade,AssessmentType,AssessmentSubtype,AssessmentLabel,AssessmentVersion,AcademicYear,FullItemKey,BankKey,ItemId,Filename,Version,ItemType,Grade,Standard,Claim,Target,ClaimContentTarget,SecondaryClaimContentTarget,CommonCore,SecondaryCommonCore,PassageRef,ASL,Braille,LanguageBraille,DOK,Language,AllowCalculator,MathematicalPractice,MaxPoints,Glossary,ScoringEngine,Spanish,IsFieldTest,IsActive,ResponseRequired,AdminRequired,ItemPosition,MeasurementModel,Weight,ScorePoints,a,b0_b,b1_c,b2,b3,avg_b,bpref1,bpref2,bpref3,bpref4,bpref5,bpref6,bpref7,CutPoint1,ScaledLow1,ScaledHigh1,CutPoint2,ScaledLow2,ScaledHigh2,CutPoint3,ScaledLow3,ScaledHigh3,CutPoint4,ScaledLow4,ScaledHigh4,AnswerKey,NumberOfAnswerOptions,PtWritingType
+# leading comment that should be ignored
+(SBAC)SBAC-IAB-FIXED-G11E-BriefWrites-ELA-11-Winter-2016-2017,SBAC-IAB-FIXED-G11E-BriefWrites-ELA-11,ELA,11,interim,IAB,ELA IAB G11 BriefWrites,9832,2017,200-58197,200,58197,item-200-58197.xml,9832,SA,11,SBAC-ELA-v1:2-W|1-11,"2-W	","1-11	","2-W	|1-11	","2-W	|1-11	;2-W |3-11;2-W |3-11 ",5.RI.10,5.RI.10;8.L.5b;8.L.5b,,N,BRF,ENU-Braille,3,ENU,,,10,,HandScored,N,FALSE,TRUE,TRUE,TRUE,1,IRTGPC,1,2,0.55434,0.93104,0.43826,,,0.68465,(SBAC)SBAC-IAB-FIXED-G11E-BriefWrites-ELA-11-Winter-2016-2017,,SBAC-2-W|1-11,,,,,1,2.30E+03,2.49E+03,2,2.49E+03,2.58E+03,3,2.58E+03,2.68E+03,4,2.68E+03,2.80E+03,D,4,Opinion
+# trailing comment that should be ignored
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+
+


### PR DESCRIPTION
* The tabulator output often produces trailing empty records rows that are just a bunch of field delimiters ... the processor would fail which seems a little extreme.
* We've talked about allowing comments in our CSV.
* Import payloads submitted to the wrong end-point were causing bad duplicate detection. For example, if i accidentally post a package payload to the exams end-point, it properly fails to load anything. But then if i try to post the same payload to the packages end-point, it claims it is a duplicate payload. 