### PR TITLE
fix a bug detecting overlap

### DIFF
--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcPercentileRepository.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcPercentileRepository.java
@@ -137,7 +137,7 @@ class JdbcPercentileRepository implements PercentileRepository {
     }
 
     @Override
-    public Integer findIdByKey(final Integer assessmentId, LocalDate startDate, final LocalDate endDate) {
+    public Integer findIdByKey(final Integer assessmentId, final LocalDate startDate, final LocalDate endDate) {
 
         try {
             return jdbcTemplate.queryForObject(sqlPercentileFindIdByKey,

--- a/package-processor/src/main/resources/application.sql.yml
+++ b/package-processor/src/main/resources/application.sql.yml
@@ -215,7 +215,7 @@ sql:
       SELECT id FROM percentile WHERE asmt_id=:asmt_id AND start_date=:start_date AND end_date=:end_date
 
     findIdsByDateOverlap: >-
-      SELECT id FROM percentile WHERE asmt_id=:asmt_id AND (:end_date > start_date AND end_date > :start_date)
+      SELECT id FROM percentile WHERE asmt_id=:asmt_id AND (:end_date >= start_date AND end_date >= :start_date)
 
     percentileScore:
       create: >-

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcPercentileRepositoryIT.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcPercentileRepositoryIT.java
@@ -1,0 +1,61 @@
+package org.opentestsystem.rdw.ingest.processor.repository.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.ingest.common.test.CachingTest;
+import org.opentestsystem.rdw.ingest.processor.repository.PercentileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TODO - this test suite was added to demonstrate a single bug during a time-crunch
+ * TODO   it needs to be fleshed out to test all methods on the repository interface
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+@CachingTest
+@ActiveProfiles("test")
+@SqlGroup({
+    @Sql(scripts = {"classpath:/PreloadAsmt.sql"}),
+    @Sql(statements = {
+        "INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest');",
+        "INSERT INTO percentile (id, asmt_id, start_date, end_date, count, mean, min_score, max_score, deleted, import_id, update_import_id) VALUES \n" +
+            "(-79, -99, '2017-09-01', '2017-12-31', 1000, 2500, 2200, 2700, 0, -99, -99), \n" +
+            "(-78, -99, '2018-01-01', '2018-02-28', 1000, 2520, 2200, 2700, 0, -99, -99), \n" +
+            "(-77, -99, '2018-03-01', '2018-06-30', 1000, 2540, 2200, 2700, 0, -99, -99);"
+    })
+})
+public class JdbcPercentileRepositoryIT {
+
+    @Autowired
+    private PercentileRepository repository;
+
+    @Test
+    public void itShouldFindById() {
+        assertThat(repository.findIdByKey(-99, LocalDate.of(2018, 1, 1), LocalDate.of(2018, 2, 28))).isEqualTo(-78);
+    }
+
+    @Test
+    public void itShouldDetectOverlaps() {
+        assertThat(repository.findIdsByDateOverlap(-99, LocalDate.of(2018, 2, 1), LocalDate.of(2018, 2, 14))).contains(-78);
+        assertThat(repository.findIdsByDateOverlap(-99, LocalDate.of(2018, 2, 1), LocalDate.of(2018, 3, 14))).contains(-78, -77);
+        assertThat(repository.findIdsByDateOverlap(-99, LocalDate.of(2017, 6, 1), LocalDate.of(2018, 6, 30))).contains(-79, -78, -77);
+    }
+
+    @Test
+    public void itShouldDetectOneDayOverlap() {
+        assertThat(repository.findIdsByDateOverlap(-99, LocalDate.of(2017, 6, 1), LocalDate.of(2017, 9, 1))).contains(-79);
+        assertThat(repository.findIdsByDateOverlap(-99, LocalDate.of(2018, 2, 28), LocalDate.of(2018, 3, 1))).contains(-78, -77);
+    }
+
+}


### PR DESCRIPTION
The percentile date range is intended to be inclusive on both ends. So 9/1/2017 - 12/31/2017, 1/1/2018 - 3/31/2018. The query was not detecting overlaps of one day.

@chdietz i'm tagging you here just to verify my supposition above. Thanks.