### PR TITLE
refine stopping condition for migrate job runner

### DIFF
--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunner.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunner.java
@@ -44,11 +44,16 @@ public class MigrateJobRunner implements MigrateLifecycle {
 
     public void run() {
         try {
-            boolean subsequent = false;
             Optional<MigrateJobParameters> jobParameters;
-            while (checkRunJobs() && (jobParameters = getNextJobParams(subsequent)).isPresent()) {
+            while (checkRunJobs() && (jobParameters = getNextJobParams()).isPresent()) {
                 jobLauncher.run(job, jobParameters.get());
-                subsequent = true;
+
+                // don't continue if the actual size is less than the limit
+                // this allows one run with less than batch-size, to catch the leftovers
+                // (otherwise it keeps scraping the last few records, effectively defeating the batching)
+                if (jobParameters.get().getBatchSize() < batchSize) {
+                    break;
+                }
             }
         } catch (final Exception e) {
             logger.error("migrate reporting job failure [" + e.getMessage() + "]");
@@ -101,23 +106,12 @@ public class MigrateJobRunner implements MigrateLifecycle {
         return isRunning() && isEnabled();
     }
 
-    private Optional<MigrateJobParameters> getNextJobParams(final boolean subsequent) {
+    private Optional<MigrateJobParameters> getNextJobParams() {
         final MigrateImportValues migrateImportValues = importRepository
                 .getMigrateImportValues(migrateRepository.findLastMigratedAt(), batchSize);
 
         // no work to do ...
         if (migrateImportValues.getImportCount() == 0) {
-            return Optional.empty();
-        }
-
-        // no work to do ...
-        if (subsequent && migrateImportValues.getFirstAt().equals(migrateImportValues.getLastAt())) {
-            return Optional.empty();
-        }
-
-        // if this is not the first run then only return work if it is a full count
-        // (otherwise it keeps scraping the last few records, effectively defeating the micro-batching)
-        if (subsequent && migrateImportValues.getImportCount() < batchSize) {
             return Optional.empty();
         }
 

--- a/migrate-common/src/main/resources/application.sql.yml
+++ b/migrate-common/src/main/resources/application.sql.yml
@@ -43,10 +43,10 @@ sql:
 
       existsImportContentInTimeRange:
           SELECT 1 AS existsCodeImportContent
-            FROM import wi
-          WHERE wi.content = :content
-             AND ((wi.status != 0 AND wi.updated >= :first_at AND wi.updated <= :last_at) OR
-               (wi.status = 0 AND wi.created <= :last_at))
+            FROM import
+          WHERE content = :content
+             AND ((status != 0 AND updated >= :first_at AND updated <= :last_at) OR
+               (status = 0 AND created <= :last_at))
           LIMIT 1
 
   # Create records with effective embargo for ALL districts regardless of timestamps. The

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunnerTest.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunnerTest.java
@@ -34,7 +34,7 @@ public class MigrateJobRunnerTest {
 
 
     @Before
-    public void setUp() throws JobExecutionException {
+    public void setUp() {
         migrateRepository = mock(MigrateRepository.class);
         when(migrateRepository.findLastStatus()).thenReturn(MigrateStatus.COMPLETED);
         when(migrateRepository.findLastMigratedAt()).thenReturn(null);
@@ -61,27 +61,16 @@ public class MigrateJobRunnerTest {
     }
 
     @Test
-    public void isShouldStopTheLoopWhenFirstEqualsLast() throws JobExecutionException {
+    public void isShouldDoOneMoreWhenNotFullBatchFoundOnSubsequentCall() throws JobExecutionException {
         when(importRepository.getMigrateImportValues(null, batchSize))
                 .thenReturn(MigrateImportValues.builder().firstAt(firstAt).lastAt(lastAt).migrateCodes(true).importCount(batchSize).build())
-                .thenReturn(MigrateImportValues.builder().firstAt(lastAt).lastAt(lastAt).migrateCodes(true).importCount(batchSize).build());
+                .thenReturn(MigrateImportValues.builder().firstAt(lastAt).lastAt(nextLastAt).migrateCodes(true).importCount(batchSize - 1).build())
+                .thenReturn(MigrateImportValues.builder().firstAt(lastAt).lastAt(nextLastAt).migrateCodes(true).importCount(1).build());
 
         reportingJobRunner.run();
 
         verify(importRepository, times(2)).getMigrateImportValues(null, batchSize);
-        verify(jobLauncher, times(1)).run(same(job), any(JobParameters.class));
-    }
-
-    @Test
-    public void isShouldStopTheLoopWhenNotFullBatchFoundOnSubsequentCall() throws JobExecutionException {
-        when(importRepository.getMigrateImportValues(null, batchSize))
-                .thenReturn(MigrateImportValues.builder().firstAt(firstAt).lastAt(lastAt).migrateCodes(true).importCount(batchSize).build())
-                .thenReturn(MigrateImportValues.builder().firstAt(lastAt).lastAt(nextLastAt).migrateCodes(true).importCount(batchSize - 1).build());
-
-        reportingJobRunner.run();
-
-        verify(importRepository, times(2)).getMigrateImportValues(null, batchSize);
-        verify(jobLauncher, times(1)).run(same(job), any(JobParameters.class));
+        verify(jobLauncher, times(2)).run(same(job), any(JobParameters.class));
     }
 
     @Test
@@ -105,15 +94,28 @@ public class MigrateJobRunnerTest {
     @Test
     public void itShouldNotLaunchJobIfPaused() throws JobExecutionException {
         reportingJobRunner.stop();
+        assertThat(reportingJobRunner.isRunning()).isFalse();
+
         reportingJobRunner.run();
         verify(jobLauncher, never()).run(same(job), any(JobParameters.class));
+
+        // and test that start gets it running again
+        reportingJobRunner.start();
+        assertThat(reportingJobRunner.isRunning()).isTrue();
     }
 
     @Test
     public void itShouldNotLaunchJobIfDisabled() throws JobExecutionException {
-        when(migrateRepository.findLastStatus()).thenReturn(MigrateStatus.FAILED);
+        when(migrateRepository.findLastStatus())
+                .thenReturn(MigrateStatus.FAILED)
+                .thenReturn(MigrateStatus.ABANDONED);
+
         reportingJobRunner.run();
         assertThat(reportingJobRunner.isEnabled()).isFalse();
         verify(jobLauncher, never()).run(same(job), any(JobParameters.class));
+
+        // and test that it re-enables itself
+        reportingJobRunner.run();
+        assertThat(reportingJobRunner.isEnabled()).isTrue();
     }
 }


### PR DESCRIPTION
We want the migrate job runner to run as long as it has full batches, and then one more partial batch to catch any stragglers. But then it shouldn't continue processing partial batches because that would defeat the purpose of batching things as it processes exams as they trickle in.

The previous incarnation was a bit more complicated than it had to be. Admittedly, this does change the behavior a bit: every run will do a partial batch on the last iteration where before it would only do a partial batch on the first iteration.  