### PR TITLE
change dockerfile to use tini and honor a couple environment variable…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,13 +121,12 @@ subprojects {
         }
 
         // Task to create Dockerfile based on (http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html)
-        // We prefer to use a non-shell entry point so that signals get passed through properly. But that precludes
-        // the use of environment variables for setting JAVA_OPTS. So, we include the critical ones here, allowing
-        // subprojects to override them like this:
+        // Add tini to help with things (https://github.com/krallin/tini).
+        // Use environment variables so the orchestration environment can adjust max heap and other java opts.
+        // Sub-projects can adjust their default max heap size by setting the environment variable, e.g.
         // createDockerfile {
-        //   ext.java_opts = ["-Xmx512m"]
+        //   environmentVariable("MAX_HEAP_SIZE", "-Xmx512m")
         // }
-        // The orchestration environment can completely override the entry point if necessary.
         task createDockerfile(type: Dockerfile) {
             destFile = project.file('build/docker/Dockerfile')
             from('openjdk:8-jre-alpine')
@@ -135,14 +134,10 @@ subprojects {
             label([maintainer: 'Fairway Technologies'])
             copyFile("${jar.archivePath.name}", "${jar.archivePath.name}")
             exposePort(8008, 8080)
-            ext.java_opts = ["-Xmx256m"]
-            entryPoint {
-                List<String> entryPointArgs = ["java"]
-                entryPointArgs.addAll(ext.java_opts)
-                entryPointArgs.add("-jar")
-                entryPointArgs.add("${jar.archivePath.name}")
-                entryPointArgs.toArray()
-            }
+            runCommand("apk add --no-cache tini")
+            entryPoint("/sbin/tini", "--")
+            environmentVariable("MAX_HEAP_SIZE", "-Xmx384m")
+            instruction('CMD exec java $MAX_HEAP_SIZE $JAVA_OPTS -jar ' + "${jar.archivePath.name}")
         }
 
         task buildImage(type:DockerBuildImage, dependsOn:[build, createDockerfile]) {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - config-server
       - rabbitmq
     environment:
-      - spring.profiles.active=local-docker
+      - SPRING_PROFILES_ACTIVE=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
     extra_hosts:
@@ -62,7 +62,7 @@ services:
       - config-server
       - rabbitmq
     environment:
-      - spring.profiles.active=local-docker
+      - SPRING_PROFILES_ACTIVE=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
     extra_hosts:
@@ -76,7 +76,7 @@ services:
       - config-server
       - rabbitmq
     environment:
-      - spring.profiles.active=local-docker
+      - SPRING_PROFILES_ACTIVE=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
     extra_hosts:
@@ -92,7 +92,7 @@ services:
       - config-server
       - import-service
     environment:
-      - spring.profiles.active=local-docker
+      - SPRING_PROFILES_ACTIVE=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
     extra_hosts:
@@ -105,7 +105,7 @@ services:
     links:
       - config-server
     environment:
-      - spring.profiles.active=local-docker
+      - SPRING_PROFILES_ACTIVE=local-docker
       - CONFIG_SERVICE_ENABLED=true
       - CONFIG_SERVICE_URL=http://config-server:8888
     extra_hosts:

--- a/migrate-reporting/build.gradle
+++ b/migrate-reporting/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'org.springframework.boot'
 
+// migrate is a bit of a memory hog; for batch size 2000, -Xmx512m is a good heap size
+// (for a batch size of 4000, this should be set to at least -Xmx768m)
+createDockerfile {
+    environmentVariable("MAX_HEAP_SIZE", "-Xmx512m")
+}
+
 dependencies {
     // handy for creating metadata with @ConfigurationProperties
     optional "org.springframework.boot:spring-boot-configuration-processor"
@@ -23,10 +29,4 @@ dependencies {
     compile 'mysql:mysql-connector-java'
 
     testCompile project(path: ':rdw-ingest-migrate-common', configuration: 'tests')
-}
-
-// migrate is a bit of a memory hog; for batch size 2000, -Xmx512m is a good heap size
-// (for a batch size of 4000, this should be set to at least -Xmx768m)
-createDockerfile {
-    ext.java_opts = ["-Xmx512m"]
 }


### PR DESCRIPTION
…s for controlling java options.

I won't be making changes to our default deployments: for most ingest apps the container request is 500M which is about 1.3x 384m so that's good for now.