### PR TITLE
log exceptions as errors instead of info

### DIFF
--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentExamWriter.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentExamWriter.java
@@ -26,7 +26,6 @@ import static com.google.common.collect.Lists.newArrayList;
 @Profile("mtTest")
 @Component
 public class MultiThreadedStudentExamWriter extends MultiThreadedTest {
-    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedStudentExamWriter.class);
 
     @Autowired
     private StudentExamWriter examWriter;
@@ -44,7 +43,7 @@ public class MultiThreadedStudentExamWriter extends MultiThreadedTest {
     private Student student;
 
     @Override
-    protected void setUp() {
+    protected void before() {
         final int schoolId = createSchool();
 
         final StudentGroup group1 = newGroup("name1", schoolId);
@@ -99,15 +98,8 @@ public class MultiThreadedStudentExamWriter extends MultiThreadedTest {
     }
 
     @Override
-    protected Runnable newRunnable() {
-        return () -> {
-            try {
-                examWriter.upsert(student, examBuilder.oppId(new Float(Math.random()).toString()).build(), 1);
-            } catch (final Exception ex) {
-                logger.info("Exception:" + ex.getMessage());
-                passed = false;
-            }
-        };
+    protected void work() {
+        examWriter.upsert(student, examBuilder.oppId(new Float(Math.random()).toString()).build(), 1);
     }
 
     @Override

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentGroupAddStudent.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentGroupAddStudent.java
@@ -4,8 +4,6 @@ import org.opentestsystem.rdw.ingest.processor.model.Student;
 import org.opentestsystem.rdw.ingest.processor.model.StudentGroup;
 import org.opentestsystem.rdw.ingest.processor.repository.StudentGroupRepository;
 import org.opentestsystem.rdw.ingest.processor.repository.StudentRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -19,8 +17,6 @@ import static com.google.common.collect.Lists.newArrayList;
 @Profile("mtTest")
 @Component
 public class MultiThreadedStudentGroupAddStudent extends MultiThreadedTest {
-    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedStudentGroupAddStudent.class);
-
     @Autowired
     private StudentGroupRepository repository;
 
@@ -31,7 +27,7 @@ public class MultiThreadedStudentGroupAddStudent extends MultiThreadedTest {
     private long studentId;
 
     @Override
-    protected void setUp() {
+    protected void before() {
         final int schoolId = createSchool();
 
         groupIds.add(repository.upsert(newGroup("test", schoolId), 1).getId());
@@ -52,15 +48,8 @@ public class MultiThreadedStudentGroupAddStudent extends MultiThreadedTest {
     }
 
     @Override
-    protected Runnable newRunnable() {
-        return () -> {
-            try {
-                repository.addStudentToGroups(studentId, groupIds, 1);
-            } catch (final Exception ex) {
-                logger.info("Exception:" + ex.getMessage());
-                passed = false;
-            }
-        };
+    protected void work() {
+        repository.addStudentToGroups(studentId, groupIds, 1);
     }
 
     private StudentGroup newGroup(final String name, final int schoolId) {

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentGroupUpsert.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentGroupUpsert.java
@@ -2,8 +2,6 @@ package org.opentestsystem.rdw.ingest.processor.multithreaded;
 
 import org.opentestsystem.rdw.ingest.processor.model.StudentGroup;
 import org.opentestsystem.rdw.ingest.processor.repository.StudentGroupRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -13,15 +11,13 @@ import java.time.Instant;
 @Profile("mtTest")
 @Component
 public class MultiThreadedStudentGroupUpsert extends MultiThreadedTest {
-    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedStudentGroupUpsert.class);
-
     @Autowired
     private StudentGroupRepository repository;
 
     private StudentGroup group;
 
     @Override
-    protected void setUp() {
+    protected void before() {
         final int schoolId = createSchool();
 
         group = StudentGroup.builder()
@@ -35,14 +31,7 @@ public class MultiThreadedStudentGroupUpsert extends MultiThreadedTest {
     }
 
     @Override
-    protected Runnable newRunnable() {
-        return () -> {
-            try {
-                repository.upsert(group, 1);
-            } catch (final Exception ex) {
-                logger.info("Exception:" + ex.getMessage());
-                passed = false;
-            }
-        };
+    protected void work() {
+        repository.upsert(group, 1);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentRepo.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedStudentRepo.java
@@ -2,8 +2,6 @@ package org.opentestsystem.rdw.ingest.processor.multithreaded;
 
 import org.opentestsystem.rdw.ingest.processor.model.Student;
 import org.opentestsystem.rdw.ingest.processor.repository.StudentRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -15,15 +13,13 @@ import static com.google.common.collect.Lists.newArrayList;
 @Profile("mtTest")
 @Component
 public class MultiThreadedStudentRepo extends MultiThreadedTest {
-    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedStudentRepo.class);
-
     @Autowired
     private StudentRepository repository;
 
     private Student student;
 
     @Override
-    protected void setUp() {
+    protected void before() {
         student = Student.builder()
                 .ssid("6666666669")
                 .firstName("FirstName6")
@@ -39,14 +35,7 @@ public class MultiThreadedStudentRepo extends MultiThreadedTest {
     }
 
     @Override
-    protected Runnable newRunnable() {
-        return () -> {
-            try {
-                repository.upsert(student, 1);
-            } catch (Exception ex) {
-                logger.info("Exception:" + ex.getMessage());
-                passed = false;
-            }
-        };
+    protected void work() {
+        repository.upsert(student, 1);
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/multithreaded/MultiThreadedTest.java
@@ -1,6 +1,8 @@
 package org.opentestsystem.rdw.ingest.processor.multithreaded;
 
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -18,6 +20,7 @@ import static com.google.common.collect.Lists.newArrayList;
  * A base class for running multi-threaded testing involving jdbc
  */
 public abstract class MultiThreadedTest {
+    protected static final Logger logger = LoggerFactory.getLogger(MultiThreadedTest.class);
 
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
@@ -25,22 +28,19 @@ public abstract class MultiThreadedTest {
     protected volatile boolean passed = true;
 
     /**
-     * The test itself. Each test must provide its own implementation
-     *
-     * @return newly created {@link Runnable} to test
+     * Hook to prepare the test data if needed; base class does nothing
      */
-    protected abstract Runnable newRunnable();
+    protected void before() { }
 
     /**
-     * A hook to prepare the test data if needed
+     * Each test must provide an implementation of the work done during the test
      */
-    protected void setUp() {
-        //override with anything that is needed for the test
-    }
+    protected abstract void work();
 
-    protected void after() {
-        //override with anything that is needed for the test
-    }
+    /**
+     * Hook to teardown the test; base class does nothing
+     */
+    protected void after() { }
 
     /**
      * A multithreaded test runner
@@ -48,7 +48,7 @@ public abstract class MultiThreadedTest {
      * @return a flag indicating a pass or fail
      */
     public boolean run(final int threadCount) throws InterruptedException {
-        setUp();
+        before();
 
         final ExecutorService pool = Executors.newFixedThreadPool(threadCount);
         final Runnable test = newRunnable();
@@ -62,6 +62,18 @@ public abstract class MultiThreadedTest {
         cleanUp();
         return passed;
     }
+
+    protected Runnable newRunnable() {
+        return () -> {
+            try {
+                work();
+            } catch (final Exception ex) {
+                logger.error(this.getClass().getSimpleName() + ": " + ex.getMessage());
+                passed = false;
+            }
+        };
+    }
+
 
     protected int createSchool() {
         final KeyHolder keyHolder = new GeneratedKeyHolder();


### PR DESCRIPTION
The errors were being lost in all the other log messages.
I also pulled out the common `newRunnable` code.