### PR TITLE
Modified migrate to not use an explicit accountability grade for HS.

### DIFF
--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -610,11 +610,8 @@ sql:
                 SET latest = true
               FROM (
                     SELECT se.id, rank() OVER (PARTITION BY se.student_id, se.subject_id, se.asmt_grade_id ORDER BY se.completed_at DESC, se.id)
-                     FROM staging_exam se JOIN grade ag on ag.id = se.asmt_grade_id JOIN grade eg ON eg.id = se.grade_id
-                     WHERE se.deleted = false AND se.type_id = 3
-                       AND (  ( ag.code NOT IN (${app.high-school.grades}) AND se.asmt_grade_id = se.grade_id )
-                           OR ( ag.code IN (${app.high-school.grades})  AND eg.code = '${app.high-school.accountability-grade}' )
-                      )
+                     FROM staging_exam se
+                     WHERE se.deleted = false AND se.type_id = 3 AND se.asmt_grade_id = se.grade_id
                    ) t
                 JOIN staging_exam e ON e.id = t.id
               WHERE t.rank = 1;

--- a/migrate-olap/src/main/resources/application.yml
+++ b/migrate-olap/src/main/resources/application.yml
@@ -1,10 +1,6 @@
 app:
   school-year: 2018
   # this uses grade ids assuming that they match grade codes
-  high-school:
-    grades: >-
-      '09','10','11','12'
-    accountability-grade: '11'
 
 management:
   security:

--- a/migrate-olap/src/main/resources/application.yml
+++ b/migrate-olap/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 app:
   school-year: 2018
-  # this uses grade ids assuming that they match grade codes
 
 management:
   security:

--- a/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
@@ -24,9 +24,9 @@ INSERT INTO asmt (id, grade_id,  type_id, subject_id, school_year, name, label, 
    (-107, 107, 3, 1, 2001, 'test-summative-2001-grade-7',  'summative-grade-8',  '2017-07-18 20:14:34.000000', -1, -99),
    (-307, 107, 3, 1, 1999, 'test-summative-1999-grade-7',  'summative-grade-8',  '2017-07-18 20:14:34.000000', -1, -99),
    (-108 ,108, 3, 1, 2001, 'test-summative-2001-grade-8',  'summative-grade-8',  '2017-07-18 20:14:34.000000', -1, -99),
-   (-109, 109, 3, 1, 2001, 'test-summative-2001-grade-9',  'summative-grade-9',  '2017-07-18 20:14:34.000000', -1, -99),
+   (-109, 111, 3, 1, 2001, 'test-summative-2001-grade-9',  'summative-grade-9',  '2017-07-18 20:14:34.000000', -1, -99),
    (-111, 111, 3, 1, 2001, 'test-summative-2001-grade-11', 'summative-grade-11', '2017-07-18 20:14:34.000000', -1, -99),
-   (-112, 112, 3, 1, 2001, 'test-summative-2001-grade-12', 'summative-grade-12', '2017-07-18 20:14:34.000000', -1, -99);
+   (-112, 111, 3, 1, 2001, 'test-summative-2001-grade-12', 'summative-grade-12', '2017-07-18 20:14:34.000000', -1, -99);
 
 INSERT INTO asmt_active_year(asmt_id, school_year) values
     (-11, 1995);

--- a/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
@@ -21,9 +21,9 @@ INSERT INTO staging_asmt (id,  grade_id, type_id, subject_id, school_year, name,
    (-308, 108, 3, 1, 2000, 'test-summative-2000-grade-8',  'summative-grade-8',  0, '2017-07-18 20:14:34.000000', -1, -99),
    (-107, 107, 3, 1, 2001, 'test-summative-2001-grade-7',  'summative-grade-8',  0, '2017-07-18 20:14:34.000000', -1, -99),
    (-108 ,108, 3, 1, 2001, 'test-summative-2001-grade-8',  'summative-grade-8',  0, '2017-07-18 20:14:34.000000', -1, -99),
-   (-109, 109, 3, 1, 2001, 'test-summative-2001-grade-9',  'summative-grade-9',  0, '2017-07-18 20:14:34.000000', -1, -99),
+   (-109, 111, 3, 1, 2001, 'test-summative-2001-grade-9',  'summative-grade-9',  0, '2017-07-18 20:14:34.000000', -1, -99),
    (-111, 111, 3, 1, 2001, 'test-summative-2001-grade-11', 'summative-grade-11',  0, '2017-07-18 20:14:34.000000', -1, -99),
-   (-112, 112, 3, 1, 2001, 'test-summative-2001-grade-12', 'summative-grade-12',  0, '2017-07-18 20:14:34.000000', -1, -99);
+   (-112, 111, 3, 1, 2001, 'test-summative-2001-grade-12', 'summative-grade-12',  0, '2017-07-18 20:14:34.000000', -1, -99);
 
 -- ------------------------------------------ Student  ------------------------------------------------------------------------------------------------
 INSERT INTO staging_student (id, gender_id, updated, update_import_id, migrate_id, deleted) VALUES

--- a/migrate-olap/src/test/resources/application-redshift.yml
+++ b/migrate-olap/src/test/resources/application-redshift.yml
@@ -4,7 +4,6 @@
 app:
   school-year: 1999
 
-# not sure if this is right
 archive:
   root: s3://rdw-ci-archive
   cloud:

--- a/migrate-olap/src/test/resources/application-redshift.yml
+++ b/migrate-olap/src/test/resources/application-redshift.yml
@@ -3,12 +3,8 @@
 # override them locally but the CI system assumes the defaults are for CI resources.
 app:
   school-year: 1999
-  # this uses grade ids assuming that they match grade codes
-  high-school:
-    grades: >-
-      '29','30','31','32'
-    accountability-grade: '31'
 
+# not sure if this is right
 archive:
   root: s3://rdw-ci-archive
   cloud:


### PR DESCRIPTION
Based on the discussion this morning I have modified migrate to include only exams that have an asmt grade equal to a student enrolled grade.