### PR TITLE
add curl and jq to image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ subprojects {
             label([maintainer: 'Fairway Technologies'])
             copyFile("${jar.archivePath.name}", "${jar.archivePath.name}")
             exposePort(8008, 8080)
-            runCommand("apk add --no-cache tini")
+            runCommand("apk -U add --no-cache tini curl jq")
             entryPoint("/sbin/tini", "--")
             environmentVariable("MAX_HEAP_SIZE", "-Xmx384m")
             instruction('CMD exec java $MAX_HEAP_SIZE $JAVA_OPTS -jar ' + "${jar.archivePath.name}")


### PR DESCRIPTION
In our run book and troubleshooting docs we often suggest hitting a service's actuator end-points. This requires either port-forwarding or exec'ing into the pod, e.g.
```
$ kubectl exec -it import-service-xxx /bin/sh
# apk -U add curl jq
# curl http://localhost:8008/env | jq
# exit
```
This is a bit tedious. If curl were in the image, then the instructions become simpler and less error-prone:
```
$ kubectl exec -it import-service-xxx curl http://localhost:8008/env | jq
```

This change adds about 3.5MB to the image (e.g. 113MB -> 117MB), although about half of that is the apk update which i could remove. That is, "apk add -U ..." vs. "apk add ..."

Thoughts?