### PR TITLE
add Authority awareness to import service security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
             dependency "org.opentestsystem.rdw.common:rdw-common-archive:${rdwCommonVersion}"
             dependency "org.opentestsystem.rdw.common:rdw-common-messaging:${rdwCommonVersion}"
             dependency "org.opentestsystem.rdw.common:rdw-common-model:${rdwCommonVersion}"
+            dependency "org.opentestsystem.rdw.common:rdw-common-security:${rdwCommonVersion}"
             dependency "org.opentestsystem.rdw.common:rdw-common-status:${rdwCommonVersion}"
             dependency "org.opentestsystem.rdw.common:rdw-common-utils:${rdwCommonVersion}"
 

--- a/import-service/build.gradle
+++ b/import-service/build.gradle
@@ -28,10 +28,14 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-archive'
     compile 'org.opentestsystem.rdw.common:rdw-common-messaging'
     compile 'org.opentestsystem.rdw.common:rdw-common-model'
+    compile 'org.opentestsystem.rdw.common:rdw-common-security'
     compile 'org.opentestsystem.rdw.common:rdw-common-status'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
     compile 'mysql:mysql-connector-java'
 
     // fixes java 8 time marshaling
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.7'
+
+    // for CachingTest amongst other things
+    testCompile project(path: ':rdw-ingest-common', configuration: 'tests')
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthorityService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthorityService.java
@@ -1,0 +1,20 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.opentestsystem.rdw.utils.TenancyChain;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Set;
+
+/**
+ * This service knows how to convert from SBAC grants to spring security authorities.
+ */
+interface AuthorityService {
+
+    /**
+     * Extract authorities from roles granted by a tenancy chain.
+     *
+     * @param tenancyChain tenancy chain with grants
+     * @return set of authorities granted by the tenancy chain
+     */
+    Set<GrantedAuthority> getAuthorities(TenancyChain tenancyChain);
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/CachingPermissionService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/CachingPermissionService.java
@@ -1,0 +1,31 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.opentestsystem.rdw.security.service.PermissionService;
+import org.opentestsystem.rdw.security.service.PermissionServiceException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Wrap the basic permission service to cache the results since role/permissions don't change often.
+ */
+@Primary
+@Service
+class CachingPermissionService implements PermissionService {
+
+    private final PermissionService permissionService;
+
+    public CachingPermissionService(@Qualifier("basicPermissionService") final PermissionService permissionService) {
+        this.permissionService = permissionService;
+    }
+
+    @Cacheable("permissionsByRole")
+    public Map<String, Collection<String>> getPermissionsByRole() throws PermissionServiceException {
+        return permissionService.getPermissionsByRole();
+    }
+}
+

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/DefaultAuthorityService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/DefaultAuthorityService.java
@@ -1,0 +1,113 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import com.google.common.collect.ImmutableSet;
+import org.opentestsystem.rdw.security.service.PermissionService;
+import org.opentestsystem.rdw.security.service.PermissionServiceException;
+import org.opentestsystem.rdw.utils.Grant;
+import org.opentestsystem.rdw.utils.TenancyChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.opentestsystem.rdw.ingest.auth.SecurityConfigurer.permissionToAuthorityName;
+import static org.opentestsystem.rdw.ingest.auth.SecurityConfigurer.roleToAuthorityName;
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * This service is responsible for converting tenancy chain grants to spring authorities.
+ */
+@Service
+class DefaultAuthorityService implements AuthorityService {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultAuthorityService.class);
+
+    private final PermissionService permissionService;
+    private final String client;
+    private final String state;
+
+    @Autowired
+    public DefaultAuthorityService(final PermissionService permissionService,
+                                   final @Value("${app.client}") String client,
+                                   final @Value("${app.state.code}") String state) {
+        this.permissionService = permissionService;
+        this.client = client;
+        this.state = state;
+    }
+
+    /**
+     * Extract roles from tenancy chain, convert to permissions and create granted authorities using
+     * default mappers that apply prefixes "ROLE_"/"PERM_" and create a {@link SimpleGrantedAuthority}.
+     *
+     * @param tenancyChain tenancy chain with grants
+     * @return set of authorities granted by the tenancy chain
+     * @see DefaultAuthorityService#getAuthorities(Collection, Function, Function)
+     */
+    public Set<GrantedAuthority> getAuthorities(final TenancyChain tenancyChain) {
+        return getAuthorities(tenancyChain.getGrants(), simpleRoleAuthorityMapper, simplePermissionAuthorityMapper);
+    }
+
+    /**
+     * Extract roles from grants, convert to permissions and create granted authorities using
+     * the provided mappers. Only roles and permissions associated with this component are
+     * converted, other roles/permissions in the grants are ignored.
+     *
+     * @param grants grants to convert to authorities
+     * @param roleMapper function to convert role string to granted authority
+     * @param permissionMapper function to convert permission string to granted authority
+     * @return set of authorities granted by the grants
+     * @see DefaultAuthorityService#getAuthorities(TenancyChain)
+     */
+    public Set<GrantedAuthority> getAuthorities(final Collection<Grant> grants,
+                                                final Function<String, ? extends GrantedAuthority> roleMapper,
+                                                final Function<String, ? extends GrantedAuthority> permissionMapper) {
+        final ImmutableSet.Builder<GrantedAuthority> authorities = ImmutableSet.builder();
+
+        final Map<String, Collection<String>> permissionsByRole = getPermissionsByRole();
+        for (final Grant grant : grants) {
+            // skip grants that don't match client and state
+            if ((hasText(client) && hasText(grant.getClientId()) && !client.equalsIgnoreCase(grant.getClientId()))
+             || (hasText(state) && hasText(grant.getStateId()) && !state.equalsIgnoreCase(grant.getStateId()))) {
+                logger.debug("Skipping grant for other client/state {}", grant.toString());
+                continue;
+            }
+
+            if (permissionsByRole.containsKey(grant.getRole())) {
+                authorities.add(roleMapper.apply(grant.getRole()));
+                for (final String permission : permissionsByRole.get(grant.getRole())) {
+                    authorities.add(permissionMapper.apply(permission));
+                }
+            }
+        }
+
+        return authorities.build();
+    }
+
+    /**
+     * A role mapper that prepends "ROLE_" and creates a {@link SimpleGrantedAuthority}
+     */
+    public static Function<String, SimpleGrantedAuthority> simpleRoleAuthorityMapper =
+            role -> new SimpleGrantedAuthority(roleToAuthorityName(role));
+
+    /**
+     * A permission mapper that prepends "PERM_" and creates a {@link SimpleGrantedAuthority}
+     */
+    public static Function<String, SimpleGrantedAuthority> simplePermissionAuthorityMapper =
+            permission -> new SimpleGrantedAuthority(permissionToAuthorityName(permission));
+
+
+    private Map<String, Collection<String>> getPermissionsByRole() {
+        try {
+            return permissionService.getPermissionsByRole();
+        } catch (final PermissionServiceException exception) {
+            throw new RuntimeException("Failed to get permissions", exception);
+        }
+    }
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/DefaultAuthorityService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/DefaultAuthorityService.java
@@ -59,15 +59,17 @@ class DefaultAuthorityService implements AuthorityService {
      * the provided mappers. Only roles and permissions associated with this component are
      * converted, other roles/permissions in the grants are ignored.
      *
+     * NOTE: this was originally coded to be exposed but is now just a helper method.
+     *
      * @param grants grants to convert to authorities
      * @param roleMapper function to convert role string to granted authority
      * @param permissionMapper function to convert permission string to granted authority
      * @return set of authorities granted by the grants
      * @see DefaultAuthorityService#getAuthorities(TenancyChain)
      */
-    public Set<GrantedAuthority> getAuthorities(final Collection<Grant> grants,
-                                                final Function<String, ? extends GrantedAuthority> roleMapper,
-                                                final Function<String, ? extends GrantedAuthority> permissionMapper) {
+    private Set<GrantedAuthority> getAuthorities(final Collection<Grant> grants,
+                                                 final Function<String, ? extends GrantedAuthority> roleMapper,
+                                                 final Function<String, ? extends GrantedAuthority> permissionMapper) {
         final ImmutableSet.Builder<GrantedAuthority> authorities = ImmutableSet.builder();
 
         final Map<String, Collection<String>> permissionsByRole = getPermissionsByRole();
@@ -93,15 +95,14 @@ class DefaultAuthorityService implements AuthorityService {
     /**
      * A role mapper that prepends "ROLE_" and creates a {@link SimpleGrantedAuthority}
      */
-    public static Function<String, SimpleGrantedAuthority> simpleRoleAuthorityMapper =
+    private static final Function<String, SimpleGrantedAuthority> simpleRoleAuthorityMapper =
             role -> new SimpleGrantedAuthority(roleToAuthorityName(role));
 
     /**
      * A permission mapper that prepends "PERM_" and creates a {@link SimpleGrantedAuthority}
      */
-    public static Function<String, SimpleGrantedAuthority> simplePermissionAuthorityMapper =
+    private static final Function<String, SimpleGrantedAuthority> simplePermissionAuthorityMapper =
             permission -> new SimpleGrantedAuthority(permissionToAuthorityName(permission));
-
 
     private Map<String, Collection<String>> getPermissionsByRole() {
         try {

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverter.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverter.java
@@ -1,10 +1,9 @@
 package org.opentestsystem.rdw.ingest.auth;
 
+import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.utils.TenancyChain;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
@@ -18,39 +17,24 @@ import java.util.Set;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.opentestsystem.rdw.ingest.auth.SecurityConfigurer.DataLoadAuthority;
-import static org.springframework.util.StringUtils.hasText;
 
 /**
  * A {@link AccessTokenConverter} that is aware of SBAC fields. Used by {@link ForgeRockTokenServices}.
+ * Uses the {@link AuthorityService} to convert tenancy chain grants to spring security authorities.
  * Note that the auth request will have the "expires_in" value offset from now as a request param;
  * this is used by {@link ForgeRockTokenServices.ExpiringAuthenticationCache}.
+ *
+ * This is not annotated as a component so that a stub version can be created for dev/tests.
+ * @see SecurityConfigurer
  */
 class SbacTokenConverter implements AccessTokenConverter {
-    private static final Logger logger = LoggerFactory.getLogger(SbacTokenConverter.class);
-
     private static final String EXPIRES_IN = "expires_in";
     private static final int DEFAULT_EXPIRES_IN = 3600;
 
-    private String client;
-    private String state;
+    private final AuthorityService authorityService;
 
-    /**
-     * If the client is set and the user has ASTMDATALOAD role grant for that client then the user is authorized.
-     *
-     * @param client client, e.g. SBAC
-     */
-    public void setClient(final String client) {
-        this.client = client;
-    }
-
-    /**
-     * If the state is set and the user has ASTMDATALOAD role grant for that state then the user is authorized.
-     *
-     * @param state client, e.g. CA
-     */
-    public void setState(final String state) {
-        this.state = state;
+    SbacTokenConverter(final AuthorityService authorityService) {
+        this.authorityService = authorityService;
     }
 
     @Override
@@ -69,24 +53,24 @@ class SbacTokenConverter implements AccessTokenConverter {
     @Override
     public OAuth2Authentication extractAuthentication(final Map<String, ?> map) {
         final String username = (String) map.get("mail");
-        final List<SimpleGrantedAuthority> authorities = newArrayList();
+        final List<GrantedAuthority> authorities = newArrayList();
         final Authentication authentication;
         if (username == null || username.equals("")) {
             authentication = null;
         } else {
             final TenancyChain tenancyChain = TenancyChain.fromString((String) map.get("sbacTenancyChain"));
-            if ((hasText(client) && tenancyChain.hasRoleForClient(DataLoadAuthority, client))
-             || (hasText(state) && tenancyChain.hasRoleForState(DataLoadAuthority, state))) {
-                authorities.add(new SimpleGrantedAuthority(DataLoadAuthority));
-            } else {
-                logger.info("User {} doesn't have data load authority: {}", username, tenancyChain.toString());
-            }
+            authorities.addAll(authorityService.getAuthorities(tenancyChain));
+
+            // TODO - convert grants to Permissions (resolve organization ids, etc.)
+            final List<Permission> permissions = newArrayList();
+
             final SbacUser user = SbacUser.builder()
                     .username(username)
                     .authorities(newArrayList(authorities))
                     .uid((String) map.get("uid"))
                     .sbacUuid((String) map.get("sbacUUID"))
                     .tenancyChain(tenancyChain)
+                    .permissions(permissions)
                     .build();
             authentication = new PreAuthenticatedAuthenticationToken(user, null, authorities);
         }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverter.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverter.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.ingest.auth;
 
 import org.opentestsystem.rdw.security.Permission;
 import org.opentestsystem.rdw.utils.TenancyChain;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
@@ -9,6 +10,7 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
@@ -27,12 +29,14 @@ import static com.google.common.collect.Sets.newHashSet;
  * This is not annotated as a component so that a stub version can be created for dev/tests.
  * @see SecurityConfigurer
  */
+@Component
 class SbacTokenConverter implements AccessTokenConverter {
     private static final String EXPIRES_IN = "expires_in";
     private static final int DEFAULT_EXPIRES_IN = 3600;
 
     private final AuthorityService authorityService;
 
+    @Autowired
     SbacTokenConverter(final AuthorityService authorityService) {
         this.authorityService = authorityService;
     }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacUser.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacUser.java
@@ -1,5 +1,8 @@
 package org.opentestsystem.rdw.ingest.auth;
 
+import com.google.common.collect.ImmutableList;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.utils.TenancyChain;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -16,17 +19,20 @@ public class SbacUser extends User implements SbacUserDetails {
     private final String uid;
     private final String sbacUuid;
     private final TenancyChain tenancyChain;
+    private final List<Permission> permissions;
 
-    public SbacUser(final String username,
-                    final String password,
-                    final Collection<? extends GrantedAuthority> authorities,
-                    final String uid,
-                    final String sbacUuid,
-                    final TenancyChain tenancyChain) {
+    SbacUser(final String username,
+             final String password,
+             final Collection<? extends GrantedAuthority> authorities,
+             final String uid,
+             final String sbacUuid,
+             final TenancyChain tenancyChain,
+             final Collection<Permission> permissions) {
         super(username, password, authorities);
         this.uid = uid;
         this.sbacUuid = sbacUuid;
         this.tenancyChain = tenancyChain;
+        this.permissions = ImmutableList.copyOf(permissions);
     }
 
     @Override
@@ -44,6 +50,18 @@ public class SbacUser extends User implements SbacUserDetails {
         return tenancyChain;
     }
 
+    @Override
+    public PermissionScope getPermissionScope(final String id) {
+        for (final Permission permission : permissions) {
+            if (permission.getId().equals(id)) return permission.getScope();
+        }
+        return PermissionScope.EMPTY;
+    }
+
+    public Builder copy() {
+        return new Builder().copy(this);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -55,9 +73,21 @@ public class SbacUser extends User implements SbacUserDetails {
         private String uid;
         private String sbacUuid;
         private TenancyChain tenancyChain;
+        private List<Permission> permissions = newArrayList();
 
         public SbacUser build() {
-            return new SbacUser(username, password, authorities, uid, sbacUuid, tenancyChain);
+            return new SbacUser(username, password, authorities, uid, sbacUuid, tenancyChain, permissions);
+        }
+
+        public Builder copy(final SbacUser user) {
+            username = user.getUsername();
+            password = user.getPassword();
+            authorities.addAll(user.getAuthorities());
+            uid = user.getUid();
+            sbacUuid = user.getSbacUuid();
+            tenancyChain = user.getTenancyChain();
+            permissions.addAll(user.permissions);
+            return this;
         }
 
         public Builder username(final String username) {
@@ -97,6 +127,16 @@ public class SbacUser extends User implements SbacUserDetails {
 
         public Builder tenancyChain(final String value) {
             return this.tenancyChain(TenancyChain.fromString(value));
+        }
+
+        public Builder permissions(final Collection<Permission> permissions) {
+            this.permissions = newArrayList(permissions);
+            return this;
+        }
+
+        public Builder permission(final Permission permission) {
+            this.permissions.add(permission);
+            return this;
         }
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacUserDetails.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SbacUserDetails.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.auth;
 
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.opentestsystem.rdw.utils.TenancyChain;
 
 /**
@@ -29,4 +30,10 @@ public interface SbacUserDetails {
      * @return tenancy chain of the user
      */
     TenancyChain getTenancyChain();
+
+    /**
+     * @param permission permission id to lookup, e.g. "GROUP_WRITE"
+     * @return permission scope for given permission, may be EMPTY, won't be null
+     */
+    PermissionScope getPermissionScope(String permission);
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfiguration.java
@@ -1,0 +1,43 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.opentestsystem.rdw.security.client.permissionservice.PermissionWebServiceClient;
+import org.opentestsystem.rdw.security.service.ComponentPermissionService;
+import org.opentestsystem.rdw.security.service.PermissionService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Default security configuration uses the real ForgeRockTokenServices and Authority/Permission services.
+ * Note that the (basic) PermissionService will be wrapped by the CachingPermissionService.
+ */
+@Configuration
+@ConditionalOnMissingBean(StubSecurityConfiguration.class)
+class SecurityConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "security.oauth2")
+    public ForgeRockTokenServices forgeRockTokenServices(final SbacTokenConverter tokenConverter) {
+        return new ForgeRockTokenServices(tokenConverter);
+    }
+
+    @Bean
+    public SbacTokenConverter sbacTokenConverter(final AuthorityService authorityService) {
+        return new SbacTokenConverter(authorityService);
+    }
+
+    @Bean
+    public PermissionService basicPermissionService(final PermissionWebServiceClient client,
+                                                    @Value("${security.permission-service.component}") final String component) {
+        return new ComponentPermissionService(client, component);
+    }
+
+    @Bean
+    public PermissionWebServiceClient permissionWebServiceClient(
+            @Value("${security.permission-service.endpoint}") final String endpoint) {
+        return new PermissionWebServiceClient(new RestTemplate(), endpoint);
+    }
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfiguration.java
@@ -25,11 +25,6 @@ class SecurityConfiguration {
     }
 
     @Bean
-    public SbacTokenConverter sbacTokenConverter(final AuthorityService authorityService) {
-        return new SbacTokenConverter(authorityService);
-    }
-
-    @Bean
     public PermissionService basicPermissionService(final PermissionWebServiceClient client,
                                                     @Value("${security.permission-service.component}") final String component) {
         return new ComponentPermissionService(client, component);

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
@@ -1,10 +1,6 @@
 package org.opentestsystem.rdw.ingest.auth;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -16,6 +12,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.R
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 
 /**
  * Security configuration uses oauth2.
@@ -26,46 +23,41 @@ import org.springframework.security.oauth2.provider.authentication.OAuth2Authent
  * submitting it with the request. However the resource server (this app) isn't relying
  * on OAuth2 for resource permissions.
  * </p>
+ *
  * @see ForgeRockTokenServices
  */
 @EnableWebSecurity
 @EnableResourceServer
-public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
-    private static final Logger logger = LoggerFactory.getLogger(SecurityConfigurer.class);
+class SecurityConfigurer extends WebSecurityConfigurerAdapter {
 
-    final static String DataLoadAuthority = "ASMTDATALOAD";
+    final static String DataLoadRole = "ASMTDATALOAD";
+    final static String DataLoadAuthority = roleToAuthorityName(DataLoadRole);
+
+    final static String GroupWritePermission = "GROUP_WRITE";
+    final static String GroupWriteAuthority = permissionToAuthorityName(GroupWritePermission);
+
+    static String roleToAuthorityName(final String role) {
+        return "ROLE_" + role;
+    }
+
+    static String permissionToAuthorityName(final String permission) {
+        return "PERM_" + permission;
+    }
+
+    @Autowired
+    private ResourceServerTokenServices tokenServices;
 
     @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
+    public AuthenticationManager authenticationManagerBean() {
         final OAuth2AuthenticationManager manager = new OAuth2AuthenticationManager();
-        manager.setTokenServices(forgeRockTokenServices());
+        manager.setTokenServices(tokenServices);
         return manager;
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(final AuthenticationManagerBuilder auth) throws Exception {
+    public AuthenticationManager authenticationManager(final AuthenticationManagerBuilder auth) {
         // this disables spring boot's auto-configuration of the default authentication manager
         return auth.getOrBuild();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "security.oauth2.token-info-url", havingValue="local")
-    public StubTokenServices stubTokenServices() {
-        logger.warn("Configuring stub token services intended for testing and local development only!");
-        return new StubTokenServices(sbacTokenConverter());
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(StubTokenServices.class)
-    @ConfigurationProperties(prefix = "security.oauth2")
-    public ForgeRockTokenServices forgeRockTokenServices() {
-        return new ForgeRockTokenServices(sbacTokenConverter());
-    }
-
-    @Bean
-    @ConfigurationProperties(prefix = "security")
-    public SbacTokenConverter sbacTokenConverter() {
-        return new SbacTokenConverter();
     }
 
     /**
@@ -82,7 +74,7 @@ public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
     public ResourceServerConfigurer configurer() {
         return new ResourceServerConfigurer() {
             @Override
-            public void configure(final ResourceServerSecurityConfigurer resources) throws Exception {
+            public void configure(final ResourceServerSecurityConfigurer resources) {
                 // no-op
             }
 
@@ -90,10 +82,16 @@ public class SecurityConfigurer extends WebSecurityConfigurerAdapter {
             public void configure(final HttpSecurity http) throws Exception {
                 final String contentRoot = "/{content:(exams|packages|accommodations|organizations|norms)}";
                 http.authorizeRequests()
-                    .antMatchers(contentRoot + "/imports/resubmit").authenticated()
-                    .antMatchers(contentRoot + "/**").hasAuthority(DataLoadAuthority)
-                    .antMatchers("/imports/**").hasAuthority(DataLoadAuthority)
-                    .antMatchers("/**").permitAll();
+                        // we allow any authenticated user to trigger a resubmit
+                        .antMatchers(contentRoot + "/imports/resubmit").authenticated()
+                        // most content needs ASMTDATALOAD
+                        .antMatchers(contentRoot + "/**").hasAuthority(DataLoadAuthority)
+                        .antMatchers("/imports/**").hasAuthority(DataLoadAuthority)
+                        // student groups end-points are treated differently; require GROUP_WRITE
+                        .antMatchers("/groups/**").hasAuthority(GroupWriteAuthority)
+                        // all other end-points are open because they are diagnostic end-points
+                        // exposed on a different port (and that port is not open to the world)
+                        .antMatchers("/**").permitAll();
             }
         };
     }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/StubPermissionService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/StubPermissionService.java
@@ -1,0 +1,24 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.security.service.PermissionService;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A stub implementation of {@link PermissionService} that just returns roles/permissions needed
+ * to make testing easier. Currently returns ASMTDATALOAD -> {}.
+ */
+class StubPermissionService implements PermissionService {
+
+    private final Map<String, Collection<String>> permissionsByRole =
+            ImmutableMap.of(SecurityConfigurer.DataLoadRole, ImmutableList.of(),
+                    "GROUP_ADMIN", ImmutableList.of(SecurityConfigurer.GroupWritePermission, "GROUP_READ"));
+
+    @Override
+    public Map<String, Collection<String>> getPermissionsByRole() {
+        return permissionsByRole;
+    }
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/StubSecurityConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/StubSecurityConfiguration.java
@@ -1,0 +1,34 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.opentestsystem.rdw.security.service.PermissionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Stub security configuration uses the StubTokenServices and StubPermissionService.
+ * Note that the (basic) PermissionService will be wrapped by the CachingPermissionService.
+ */
+@Configuration
+@ConditionalOnProperty(name = "security.oauth2.token-info-url", havingValue = "local")
+class StubSecurityConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(StubSecurityConfiguration.class);
+
+    @Bean
+    public StubTokenServices stubTokenServices(final AuthorityService authorityService) {
+        logger.warn("Configuring stub token services intended for testing and local development only!");
+        return new StubTokenServices(sbacTokenConverter(authorityService));
+    }
+
+    @Bean
+    public SbacTokenConverter sbacTokenConverter(final AuthorityService authorityService) {
+        return new SbacTokenConverter(authorityService);
+    }
+
+    @Bean
+    public PermissionService basicPermissionService() {
+        return new StubPermissionService();
+    }
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/StubSecurityConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/StubSecurityConfiguration.java
@@ -17,14 +17,9 @@ class StubSecurityConfiguration {
     private static final Logger logger = LoggerFactory.getLogger(StubSecurityConfiguration.class);
 
     @Bean
-    public StubTokenServices stubTokenServices(final AuthorityService authorityService) {
+    public StubTokenServices stubTokenServices(final SbacTokenConverter tokenConverter) {
         logger.warn("Configuring stub token services intended for testing and local development only!");
-        return new StubTokenServices(sbacTokenConverter(authorityService));
-    }
-
-    @Bean
-    public SbacTokenConverter sbacTokenConverter(final AuthorityService authorityService) {
-        return new SbacTokenConverter(authorityService);
+        return new StubTokenServices(tokenConverter);
     }
 
     @Bean

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -6,6 +6,11 @@ management:
   security:
     enabled: false
 
+app:
+  client: SBAC
+  state:
+    code: CA
+
 # spring auto-configured aws defense
 cloud:
   aws:
@@ -24,11 +29,12 @@ archive:
   root: file:///tmp/
 
 security:
-  client: SBAC
-  state: CA
-  # cause StubTokenServices to be used
+  # "local" causes stub services to be used
   oauth2:
     token-info-url: local
+  permission-service:
+    component: Reporting
+    endpoint: local
 
 # default values to give reasonable performance; adjust for tiny/huge configurations
 server:
@@ -38,6 +44,10 @@ server:
     accept-count: 20
 
 spring:
+  cache:
+    type: SIMPLE
+    cache-names: permissionsByRole
+
   # Force the (rabbit) queues to be created when posting messages so, even if
   # there are no consumers running, the messages will not get lost. Routing is
   # dynamic based on content but there is no way to do that here so we must

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/CachingPermissionServiceIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/CachingPermissionServiceIT.java
@@ -1,0 +1,39 @@
+package org.opentestsystem.rdw.ingest.auth;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.ingest.common.test.CachingTest;
+import org.opentestsystem.rdw.security.service.PermissionService;
+import org.opentestsystem.rdw.security.service.PermissionServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.SimpleKey;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@CachingTest
+public class CachingPermissionServiceIT {
+
+    @Autowired
+    private PermissionService permissionService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Test
+    public void itShouldCacheResults() throws PermissionServiceException {
+        final Cache cache = this.cacheManager.getCache("permissionsByRole");
+        assertThat(cache.get(SimpleKey.EMPTY)).isNull();
+
+        assertThat(permissionService.getPermissionsByRole()).isNotEmpty();
+
+        assertThat(cache.get(SimpleKey.EMPTY).get()).isInstanceOf(Map.class);
+    }
+}

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverterTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverterTest.java
@@ -56,9 +56,8 @@ public class SbacTokenConverterTest {
 
     // token converter that works with test token map
     static SbacTokenConverter testConverter() {
-        final SbacTokenConverter converter = new SbacTokenConverter();
-        converter.setState("CA");
-        return converter;
+        final AuthorityService authorityService = new DefaultAuthorityService(new StubPermissionService(), null, "CA");
+        return new SbacTokenConverter(authorityService);
     }
 
     // typical return from getting token info for a password grant token

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/SbacUserTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/SbacUserTest.java
@@ -1,6 +1,8 @@
 package org.opentestsystem.rdw.ingest.auth;
 
 import org.junit.Test;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -16,6 +18,7 @@ public class SbacUserTest {
                 .authorities(newArrayList(new SimpleGrantedAuthority("ASMTDATALOAD")))
                 .tenancyChain("|SBAC|ASMTDATALOAD|CLIENT|SBAC||||||||||||||")
                 .sbacUuid("57e3ed3de4b0e3b75702f3a0")
+                .permission(new Permission("ASMTDATALOAD", PermissionScope.STATEWIDE))
                 .build();
     }
 
@@ -31,5 +34,13 @@ public class SbacUserTest {
         final SbacUser user = SbacUser.builder().username("alice").build();
         assertThat(user.getPassword()).isNotBlank();
         assertThat(user.getAuthorities()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void itShouldFindPermissionsOrNot() {
+        final SbacUser user = testUser();
+        assertThat(user.getPermissionScope("ASMTDATALOAD").isStatewide()).isTrue();
+        // there is no isEmpty() method on PermissionScope, so go through the builder and use isValid() instead
+        assertThat(user.getPermissionScope("GROUP_WRITE").copy().isValid()).isFalse();
     }
 }


### PR DESCRIPTION
I'm trying to keep the PR's small so this just adds authorities to the security model. Still not really populating the permissions that will be needed for group file validation.

There is some functionality that is now common between ingest and reporting. For now, i'm not moving everything into RDW_Common, but i am thinking about parts of it.