### PR TITLE
default the client id to blank

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/DefaultAuthorityService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/DefaultAuthorityService.java
@@ -35,7 +35,7 @@ class DefaultAuthorityService implements AuthorityService {
 
     @Autowired
     public DefaultAuthorityService(final PermissionService permissionService,
-                                   final @Value("${app.client}") String client,
+                                   final @Value("${app.client:}") String client,
                                    final @Value("${app.state.code}") String state) {
         this.permissionService = permissionService;
         this.client = client;

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -7,7 +7,6 @@ management:
     enabled: false
 
 app:
-  client: SBAC
   state:
     code: CA
 


### PR DESCRIPTION
The import service auth mechanism checks the client id *if it is set*. In all but the production environment the client id is not likely to be sensical so i think it is better to default it to blank.