### PR TITLE
add Reprocess/Ignore capability

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/RdwImport.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/model/RdwImport.java
@@ -30,15 +30,6 @@ public class RdwImport {
     }
 
     /**
-     * Normal code should not call this, as the data framework will be setting it appropriately.
-     *
-     * @param id system id of import
-     */
-    public void setId(final Long id) {
-        this.id = id;
-    }
-
-    /**
      * @return content, e.g. EXAM
      */
     public ImportContent getContent() {

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/common/model/RdwImportTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/common/model/RdwImportTest.java
@@ -63,12 +63,4 @@ public class RdwImportTest {
         assertThat(rdwImport.getUpdated()).isEqualTo(src.getUpdated());
         assertThat(rdwImport.getMessage()).isEqualTo("message");
     }
-
-    @Test
-    public void itAllowsIdToBeSet() {
-        final RdwImport rdwImport = RdwImport.builder().build();
-        assertThat(rdwImport.getId()).isNull();
-        rdwImport.setId(123L);
-        assertThat(rdwImport.getId()).isEqualTo(123);
-    }
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/GroupProcessor.java
@@ -32,10 +32,14 @@ public class GroupProcessor {
         this.batchRepository = batchRepository;
     }
 
+    // TODO - verify that processing results in timestamps that vary and not all with the same values
+
     @ServiceActivator(inputChannel = Processor.INPUT)
     public void process(final Message<?> message) {
         final RdwMessageHeaderAccessor accessor = RdwMessageHeaderAccessor.wrap(message);
         try {
+            // TODO - change expectation of payload
+            // TODO   expect just the digest in the body, not a structured GroupMessage
             //payload should be a json object
             final String payload = new String((byte[]) message.getPayload(), StandardCharsets.UTF_8);
 
@@ -46,6 +50,7 @@ public class GroupProcessor {
             batchRepository.updateBatch(gm.getUploadId(), ImportStatus.PROCESSED);
         } catch (final ImportException e) {
             logger.warn("failed with an unexpected import error: " + e.getMessage());
+            // TODO change this to update import record
             try {
                 batchRepository.updateBatch(accessor.getImportId(), e.getStatus(), e.getMessage());
             } catch (final Exception e2) {
@@ -53,6 +58,7 @@ public class GroupProcessor {
             }
         } catch (final Exception e) {
             logger.warn("failed with an unexpected error: " + e.getMessage());
+            // TODO change this to update import record
             try {
                 batchRepository.updateBatch(accessor.getImportId(), ImportStatus.BAD_DATA, e.getMessage());
             } catch (final Exception e2) {

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessor.java
@@ -41,10 +41,13 @@ public class DefaultGroupMessageProcessor implements GroupMessageProcessor {
 
     @Override
     public void process(final GroupMessage message) {
+        // TODO - don't expect GroupMessage, just digest
+        // TODO   get importId from message header, get digest from body or header?
         logger.debug("Received upload message: {}", abbreviate(message.toJson(), 80));
 
         final long batchId = message.getUploadId();
         try {
+            // TODO - validate the file first
             loadService.loadBatch(message.getDigest(), batchId);
             standardizationService.standardizeBatch(batchId);
             referenceService.lookupBatchReferences(batchId);

--- a/import-service/build.gradle
+++ b/import-service/build.gradle
@@ -39,5 +39,3 @@ dependencies {
     // for CachingTest amongst other things
     testCompile project(path: ':rdw-ingest-common', configuration: 'tests')
 }
-
-test.exclude '**/ScopedControllerTestSuite.*'

--- a/import-service/build.gradle
+++ b/import-service/build.gradle
@@ -39,3 +39,5 @@ dependencies {
     // for CachingTest amongst other things
     testCompile project(path: ':rdw-ingest-common', configuration: 'tests')
 }
+
+test.exclude '**/ScopedControllerTestSuite.*'

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/SecurityConfigurer.java
@@ -82,8 +82,9 @@ class SecurityConfigurer extends WebSecurityConfigurerAdapter {
             public void configure(final HttpSecurity http) throws Exception {
                 final String contentRoot = "/{content:(exams|packages|accommodations|organizations|norms)}";
                 http.authorizeRequests()
-                        // we allow any authenticated user to trigger a resubmit
+                        // we allow any authenticated user to trigger a resubmit and get their user info
                         .antMatchers(contentRoot + "/imports/resubmit").authenticated()
+                        .antMatchers("/imports/user").authenticated()
                         // most content needs ASMTDATALOAD
                         .antMatchers(contentRoot + "/**").hasAuthority(DataLoadAuthority)
                         .antMatchers("/imports/**").hasAuthority(DataLoadAuthority)

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
@@ -13,6 +13,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -60,6 +61,7 @@ class JdbcRdwImportRepository implements RdwImportRepository {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    @Transactional
     @Override
     public RdwImport create(final RdwImport rdwImport) {
         final KeyHolder keyHolder = new GeneratedKeyHolder();
@@ -69,6 +71,7 @@ class JdbcRdwImportRepository implements RdwImportRepository {
         return findOne(keyHolder.getKey().longValue());
     }
 
+    @Transactional
     @Override
     public RdwImport update(final RdwImport rdwImport) {
         checkArgument(rdwImport.getId() != null, "id required for update");

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/JdbcRdwImportRepository.java
@@ -10,16 +10,14 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newArrayList;
 
 /**
@@ -35,6 +33,9 @@ class JdbcRdwImportRepository implements RdwImportRepository {
 
     @Value("${sql.import.create}")
     private String sqlCreate;
+
+    @Value("${sql.import.update}")
+    private String sqlUpdate;
 
     @Value("${sql.import.delete}")
     private String sqlDelete;
@@ -62,26 +63,27 @@ class JdbcRdwImportRepository implements RdwImportRepository {
     @Override
     public RdwImport create(final RdwImport rdwImport) {
         final KeyHolder keyHolder = new GeneratedKeyHolder();
-        final SqlParameterSource parameterSource = new MapSqlParameterSource()
-                .addValue("status", rdwImport.getStatus().getValue())
-                .addValue("content", rdwImport.getContent().getValue())
-                .addValue("contentType", rdwImport.getContentType())
-                .addValue("digest", rdwImport.getDigest())
-                .addValue("batch", rdwImport.getBatch())
-                .addValue("creator", rdwImport.getCreator())
-                .addValue("message", rdwImport.getMessage());
+        jdbcTemplate.update(sqlCreate, mapToSqlParameterSource(rdwImport), keyHolder);
 
-        jdbcTemplate.update(sqlCreate, parameterSource, keyHolder);
+        // get saved copy so id, created, updated are set properly
+        return findOne(keyHolder.getKey().longValue());
+    }
 
-        rdwImport.setId(keyHolder.getKey().longValue());
-        return rdwImport;
+    @Override
+    public RdwImport update(final RdwImport rdwImport) {
+        checkArgument(rdwImport.getId() != null, "id required for update");
+
+        jdbcTemplate.update(sqlUpdate, mapToSqlParameterSource(rdwImport).addValue("id", rdwImport.getId()));
+
+        // get saved copy so updated is set properly
+        return findOne(rdwImport.getId());
     }
 
     @Override
     public RdwImport findOne(final long id) {
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource().addValue("id", id);
         try {
-            return jdbcTemplate.queryForObject(sqlFindOne, parameterSource, new RdwImportRowMapper());
+            return jdbcTemplate.queryForObject(sqlFindOne, parameterSource, RdwImportRowMapper);
         } catch (final EmptyResultDataAccessException ignored) {
             return null;
         }
@@ -93,7 +95,7 @@ class JdbcRdwImportRepository implements RdwImportRepository {
                 .addValue("content", content.getValue())
                 .addValue("digest", digest);
         try {
-            return jdbcTemplate.queryForObject(sqlFindOneByContentAndDigest, parameterSource, new RdwImportRowMapper());
+            return jdbcTemplate.queryForObject(sqlFindOneByContentAndDigest, parameterSource, RdwImportRowMapper);
         } catch (final EmptyResultDataAccessException ignored) {
             return null;
         }
@@ -120,7 +122,7 @@ class JdbcRdwImportRepository implements RdwImportRepository {
     public List<RdwImport> findBy(final RdwImportQuery query) {
         final MapSqlParameterSource parameterSource = mapQueryToSqlParameterSource(query);
         try {
-            return jdbcTemplate.query(sqlFindBy, parameterSource, new RdwImportRowMapper());
+            return jdbcTemplate.query(sqlFindBy, parameterSource, RdwImportRowMapper);
         } catch (final EmptyResultDataAccessException ignored) {
             return newArrayList();
         }
@@ -146,21 +148,28 @@ class JdbcRdwImportRepository implements RdwImportRepository {
         }
     }
 
-    private static class RdwImportRowMapper implements RowMapper<RdwImport> {
-        @Override
-        public RdwImport mapRow(final ResultSet rs, final int rowNum) throws SQLException {
-            return RdwImport.builder()
-                    .id(rs.getLong("id"))
-                    .content(ImportContent.fromValue(rs.getInt("content")))
-                    .contentType(rs.getString("contentType"))
-                    .digest(rs.getString("digest"))
-                    .status(ImportStatus.fromValue(rs.getInt("status")))
-                    .batch(rs.getString("batch"))
-                    .creator(rs.getString("creator"))
-                    .created(rs.getTimestamp("created").toInstant())
-                    .message(rs.getString("message"))
-                    .build();
-        }
+    private static final RowMapper<RdwImport> RdwImportRowMapper = (rs, rowNum) -> RdwImport.builder()
+            .id(rs.getLong("id"))
+            .content(ImportContent.fromValue(rs.getInt("content")))
+            .contentType(rs.getString("contentType"))
+            .digest(rs.getString("digest"))
+            .status(ImportStatus.fromValue(rs.getInt("status")))
+            .batch(rs.getString("batch"))
+            .creator(rs.getString("creator"))
+            .created(rs.getTimestamp("created").toInstant())
+            .updated(rs.getTimestamp("updated").toInstant())
+            .message(rs.getString("message"))
+            .build();
+
+    private MapSqlParameterSource mapToSqlParameterSource(final RdwImport rdwImport) {
+        return new MapSqlParameterSource()
+                .addValue("status", rdwImport.getStatus().getValue())
+                .addValue("content", rdwImport.getContent().getValue())
+                .addValue("contentType", rdwImport.getContentType())
+                .addValue("digest", rdwImport.getDigest())
+                .addValue("batch", rdwImport.getBatch())
+                .addValue("creator", rdwImport.getCreator())
+                .addValue("message", rdwImport.getMessage());
     }
 
     private MapSqlParameterSource mapQueryToSqlParameterSource(final RdwImportQuery query) {

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepository.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepository.java
@@ -14,13 +14,26 @@ public interface RdwImportRepository {
 
     /**
      * Create a new import record. This ignores any id on the import object; the returned
-     * object will have a newly assigned id.
+     * object will have a newly assigned id and new created/updated values.
      *
      * @param rdwImport import object to save
      * @return newly saved import object
      */
     RdwImport create(RdwImport rdwImport);
 
+    /**
+     * Update an existing import record. The id on the import object must be set. The
+     * returned object will have a new updated value.
+     *
+     * @param rdwImport import object to save
+     * @return updated import object
+     */
+    RdwImport update(RdwImport rdwImport);
+
+    /**
+     * @param id id of import record
+     * @return import record, null if id not found
+     */
     RdwImport findOne(long id);
 
     /**

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -2,9 +2,9 @@ package org.opentestsystem.rdw.ingest.service;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.opentestsystem.rdw.archive.ArchiveService;
-import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.common.util.LocationStrategy;
@@ -21,8 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Reprocess;
 
 /**
  * Default implementation of ImportService
@@ -54,46 +57,22 @@ class DefaultImportService implements ImportService {
                                    final byte[] payload,
                                    final ImportContent content,
                                    final String contentType,
-                                   final Map<String, String> metadata) {
+                                   final Map<String, String> metadata,
+                                   final DuplicateContentAction action) {
 
         final String digest = DigestUtils.md5Hex(payload).toUpperCase();
 
-        RdwImport rdwImport = repository.findOneByContentAndDigest(content, digest);
-        if (rdwImport != null) {
-            logger.info("Ignoring {} payload with existing digest {}", content, digest);
-            return rdwImport;
-        }
-
-        final String location = new LocationStrategy.ImportContentLocationStrategy(content).location(digest);
-        final Properties properties = new Properties();
-        properties.setProperty(ContentTypeProperty, contentType);
-        properties.setProperty(UsernameProperty, user.getUsername());
-        properties.setProperty(TenancyChainProperty, user.getTenancyChain().toString());
-        properties.put(ContentLengthProperty, (long) payload.length);
-        if (metadata != null) {
-            metadata.forEach((key, value) -> {
-                if (value != null) properties.setProperty(key, value);
-            });
-        }
-
-        archiveService.writeResource(location, payload, properties);
-
-        rdwImport = repository.create(RdwImport.builder()
-                .content(content)
-                .contentType(contentType)
-                .digest(digest)
-                .status(ImportStatus.ACCEPTED)
-                .creator(user.getUsername())
-                .batch(metadata == null ? null : metadata.get("batch"))
-                .build());
-
-        source.submitContent(payload, content, contentType, rdwImport.getId());
-
-        return rdwImport;
+        return importHelper(user, payload, content, contentType, metadata, action, digest, payload.length, (location, properties) ->
+                archiveService.writeResource(location, payload, properties));
     }
 
     @Override
-    public RdwImport importContent(final SbacUserDetails user, final MultipartFile file, final ImportContent content, final String contentType, final Map<String, String> metadata) {
+    public RdwImport importContent(final SbacUserDetails user,
+                                   final MultipartFile file,
+                                   final ImportContent content,
+                                   final String contentType,
+                                   final Map<String, String> metadata,
+                                   final DuplicateContentAction action) {
 
         final String digest;
         try (final InputStream is = file.getInputStream()) {
@@ -103,41 +82,61 @@ class DefaultImportService implements ImportService {
             throw new IllegalArgumentException(e);
         }
 
+        return importHelper(user, digest.getBytes(), content, contentType, metadata, action, digest, file.getSize(), (location, properties) -> {
+            try (final InputStream is = file.getInputStream()) {
+                archiveService.writeResource(location, is, properties);
+            } catch (final IOException e) {
+                logger.warn("Error archiving {} file {} to {}: {}", content, file.getName(), digest, e.getMessage());
+                throw new IllegalArgumentException(e);
+            }
+        });
+    }
+
+    // helper to avoid code duplication
+    private RdwImport importHelper(final SbacUserDetails user,
+                                   final byte[] payload,
+                                   final ImportContent content,
+                                   final String contentType,
+                                   final Map<String, String> metadata,
+                                   final DuplicateContentAction action,
+                                   final String digest,
+                                   final long contentLength,
+                                   final BiConsumer<String, Properties> archiver
+                                   ) {
+
+        // check for duplicate payload and act accordingly
         RdwImport rdwImport = repository.findOneByContentAndDigest(content, digest);
-        if (rdwImport != null) {
+        if (rdwImport == null) {
+            final String location = new LocationStrategy.ImportContentLocationStrategy(content).location(digest);
+            final Properties properties = new Properties();
+            properties.setProperty(ContentTypeProperty, contentType);
+            properties.setProperty(UsernameProperty, user.getUsername());
+            properties.setProperty(TenancyChainProperty, user.getTenancyChain().toString());
+            properties.put(ContentLengthProperty, contentLength);
+            if (metadata != null) {
+                metadata.forEach((key, value) -> {
+                    if (value != null) properties.setProperty(key, value);
+                });
+            }
+            archiver.accept(location, properties);
+
+            rdwImport = repository.create(RdwImport.builder()
+                    .content(content)
+                    .contentType(contentType)
+                    .digest(digest)
+                    .status(ImportStatus.ACCEPTED)
+                    .creator(user.getUsername())
+                    .batch(metadata == null ? null : metadata.get("batch"))
+                    .build());
+        } else if (action == Reprocess) {
+            rdwImport = repository.update(rdwImport.copy().status(ImportStatus.ACCEPTED).build());
+            logger.info("Reprocessing {} payload with digest {}", content, digest);
+        } else if (action == Ignore) {
             logger.info("Ignoring {} payload with existing digest {}", content, digest);
             return rdwImport;
         }
 
-        final String location = new LocationStrategy.ImportContentLocationStrategy(content).location(digest);
-        final Properties properties = new Properties();
-        properties.setProperty(ContentTypeProperty, contentType);
-        properties.setProperty(UsernameProperty, user.getUsername());
-        properties.setProperty(TenancyChainProperty, user.getTenancyChain().toString());
-        properties.put(ContentLengthProperty, file.getSize());
-        if (metadata != null) {
-            metadata.forEach((key, value) -> {
-                if (value != null) properties.setProperty(key, value);
-            });
-        }
-
-        try (final InputStream is = file.getInputStream()) {
-            archiveService.writeResource(location, is, properties);
-        } catch (final IOException e) {
-            logger.warn("Error archiving {} file {} to {}: {}", content, file.getName(), digest, e.getMessage());
-            throw new IllegalArgumentException(e);
-        }
-
-        rdwImport = repository.create(RdwImport.builder()
-                .content(content)
-                .contentType(contentType)
-                .digest(digest)
-                .status(ImportStatus.ACCEPTED)
-                .creator(user.getUsername())
-                .batch(metadata == null ? null : metadata.get("batch"))
-                .build());
-
-        source.submitContent(digest.getBytes(), content, contentType, rdwImport.getId());
+        source.submitContent(payload, content, contentType, rdwImport.getId());
 
         return rdwImport;
     }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DuplicateContentAction.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DuplicateContentAction.java
@@ -1,0 +1,12 @@
+package org.opentestsystem.rdw.ingest.service;
+
+/**
+ * This is used to control behavior for duplication import content.<ul>
+ *      *     <li>Ignore - ignore the import, returning the result from the previous attempt</li>
+ *      *     <li>Reprocess - reprocess payload (as if resubmit was called)</li>
+ *      * </ul>
+ */
+public enum DuplicateContentAction {
+    Ignore,
+    Reprocess
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/ImportService.java
@@ -33,15 +33,16 @@ public interface ImportService {
      * @param content import content
      * @param contentType content type, e.g. application/xml
      * @param metadata optional metadata key/values, may be null or empty
+     * @param action duplicate content action
      * @return newly created import resource
      */
-    RdwImport importContent(SbacUserDetails user, byte[] payload, final ImportContent content, String contentType, Map<String, String> metadata);
+    RdwImport importContent(SbacUserDetails user, byte[] payload, final ImportContent content, String contentType, Map<String, String> metadata, DuplicateContentAction action);
 
     /**
      * Accept the file for import processing. This will check for submission duplicates, archive
      * the content, create an import record, and post a message on the appropriate processing queue.
      * The message will have the digest as the message body. To get the file content as the message
-     * body, the caller should read the file contents and call the other method, e.g. (ignoring errors)<pre>
+     * body, the caller should read the file contents and call the other method, e.g.<pre>
      *   service.importContent(user, file.getBytes(), content, file.getContentType(), metadata)
      * </pre>
      *
@@ -58,9 +59,10 @@ public interface ImportService {
      * @param content import content
      * @param contentType content type, e.g. application/xml
      * @param metadata optional metadata key/values, may be null or empty
+     * @param action duplicate content action
      * @return newly created import resource
      */
-    RdwImport importContent(SbacUserDetails user, MultipartFile file, final ImportContent content, String contentType, Map<String, String> metadata);
+    RdwImport importContent(SbacUserDetails user, MultipartFile file, final ImportContent content, String contentType, Map<String, String> metadata, DuplicateContentAction action);
 
     /**
      * @param id import resource id

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/GroupController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/GroupController.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.ingest.web;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
+import org.opentestsystem.rdw.ingest.service.DuplicateContentAction;
 import org.opentestsystem.rdw.ingest.service.ImportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -32,7 +33,7 @@ class GroupController extends ScopedImportController {
 
     @Autowired
     public GroupController(final ImportService service) {
-        super(service, ImportContent.GROUPS);
+        super(service, ImportContent.GROUPS, DuplicateContentAction.Reprocess);
     }
 
     @PostMapping("/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ImportController.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.ingest.web;
 
+import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.service.ImportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -60,5 +62,10 @@ class ImportController {
     @GetMapping("/{id}/payload/properties")
     public Properties getImportPayloadProperties(@PathVariable final Long id) {
         return service.getPayloadProperties(id).get();
+    }
+
+    @GetMapping("/user")
+    public SbacUserDetails getUser(@AuthenticationPrincipal final SbacUserDetails sbacUser) {
+        return sbacUser;
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
@@ -4,6 +4,7 @@ import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
+import org.opentestsystem.rdw.ingest.service.DuplicateContentAction;
 import org.opentestsystem.rdw.ingest.service.ImportService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,10 +21,13 @@ import static com.google.common.collect.Maps.newHashMap;
  * Although we could use pattern matching and other cleverness, it is fighting the way the Spring
  * framework likes to do things. So the common functionality is pulled into this base class.
  *
+ * @see AccommodationController
  * @see ExamController
+ * @see GroupController
+ * @see NormsController
+ * @see OrganizationController
  * @see PackageController
  * @see ImportResourceAssembler
- * @see AccommodationController
  */
 @SuppressWarnings("ConstantConditions")
 abstract class ScopedImportController {
@@ -31,11 +35,30 @@ abstract class ScopedImportController {
     private final ImportService service;
     private final ImportContent content;
     private final ImportResourceAssembler assembler;
+    private final DuplicateContentAction duplicateContentAction;
 
+    /**
+     * Minimal constructor, defaults duplication content action to Ignore.
+     *
+     * @param service import service
+     * @param content import content type
+     */
     protected ScopedImportController(final ImportService service,
                                      final ImportContent content) {
+        this(service, content, DuplicateContentAction.Ignore);
+    }
+
+    /**
+     * @param service import service
+     * @param content import content type
+     * @param duplicateContentAction duplication content action
+     */
+    protected ScopedImportController(final ImportService service,
+                                     final ImportContent content,
+                                     final DuplicateContentAction duplicateContentAction) {
         this.service = service;
         this.content = content;
+        this.duplicateContentAction = duplicateContentAction;
         this.assembler = new ImportResourceAssembler();
     }
 
@@ -43,7 +66,7 @@ abstract class ScopedImportController {
                                            final String contentType,
                                            final byte[] body,
                                            final Map<String, String> params) {
-        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, params));
+        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, params, duplicateContentAction));
     }
 
     protected RdwImportResource uploadImport(final SbacUserDetails sbacUser,
@@ -73,7 +96,7 @@ abstract class ScopedImportController {
         metadata.put("filename", file.getOriginalFilename());
         request.getParameterMap().forEach((key, values) -> metadata.put(key, values[0]));
 
-        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, metadata));
+        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, metadata, duplicateContentAction));
     }
 
     protected List<RdwImportResource> getImports(final RdwImportQuery query) {

--- a/import-service/src/main/resources/application.sql.yml
+++ b/import-service/src/main/resources/application.sql.yml
@@ -7,6 +7,11 @@ sql:
       INSERT INTO import (status, content, contentType, digest, batch, creator, message)
         VALUES (:status, :content, :contentType, :digest, :batch, :creator, :message)
 
+    update: >-
+      UPDATE import
+      SET status=:status, content=:content, contentType=:contentType, digest=:digest, batch=:batch, creator=:creator, message=:message
+      WHERE id=:id
+
     delete: >-
       DELETE FROM import WHERE id=:id
 

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -29,6 +30,62 @@ public class RdwImportRepositoryIT {
 
     @Autowired
     private RdwImportRepository repository;
+
+    @Test
+    public void itShouldCreateAnImport() {
+        final RdwImport saved = repository.create(RdwImport.builder()
+                .status(ImportStatus.ACCEPTED)
+                .content(ImportContent.PROBE)
+                .contentType("text/plain")
+                .creator("dwtest@example.com")
+                .digest("DEADBEEF")
+                .message("simple create test")
+                .batch("abc")
+                .created(Instant.now().minus(1000, ChronoUnit.HOURS))
+                .updated(Instant.now().minus(800, ChronoUnit.HOURS))
+                .build());
+        assertThat(saved.getContent()).isEqualTo(ImportContent.PROBE);
+        assertThat(saved.getCreator()).isEqualTo("dwtest@example.com");
+        // check the values that are set by the repository
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreated()).isBetween(Instant.now().minus(1, ChronoUnit.MINUTES), Instant.now().plus(1, ChronoUnit.MINUTES));
+        assertThat(saved.getUpdated()).isBetween(Instant.now().minus(1, ChronoUnit.MINUTES), Instant.now().plus(1, ChronoUnit.MINUTES));
+    }
+
+    @Test
+    public void itShouldUpdateAnImport() throws InterruptedException {
+        final Map<String, Long> map = createTestData();
+
+        final RdwImport alice = repository.findOne(map.get("alice"));
+
+        sleep(100); // guarantee updated timestamp is different
+
+        final RdwImport updated = repository.update(alice.copy()
+                .status(ImportStatus.INVALID)
+                .digest("DEADBEEF")
+                .message("updated message")
+                .batch("updated")
+            .build());
+
+        assertThat(updated.getStatus()).isEqualTo(ImportStatus.INVALID);
+        assertThat(updated.getDigest()).isEqualTo("DEADBEEF");
+        assertThat(updated.getMessage()).isEqualTo("updated message");
+        assertThat(updated.getBatch()).isEqualTo("updated");
+        assertThat(updated.getCreated()).isEqualTo(alice.getCreated());
+        // updated should be different
+        assertThat(updated.getUpdated()).isGreaterThan(alice.getUpdated());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void updateRequiresId() {
+        repository.update(RdwImport.builder()
+                .status(ImportStatus.ACCEPTED)
+                .content(ImportContent.PROBE)
+                .contentType("text/plain")
+                .creator("dwtest@example.com")
+                .digest("DEADBEEF")
+                .build());
+    }
 
     @Test
     public void itShouldCreateAndFindImports() {

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/DefaultImportServiceTest.java
@@ -14,6 +14,7 @@ import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Properties;
 
@@ -26,6 +27,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Reprocess;
 
 public class DefaultImportServiceTest {
 
@@ -39,8 +42,11 @@ public class DefaultImportServiceTest {
         repository = mock(RdwImportRepository.class);
         when(repository.create(any(RdwImport.class))).thenAnswer(invocation -> {
             final RdwImport rdwImport = invocation.getArgument(0);
-            if (rdwImport.getId() == null) rdwImport.setId(123L);
-            return rdwImport;
+            return rdwImport.copy().id(123L).build();
+        });
+        when(repository.update(any(RdwImport.class))).thenAnswer(invocation -> {
+            final RdwImport rdwImport = invocation.getArgument(0);
+            return rdwImport.copy().status(ImportStatus.ACCEPTED).updated(Instant.now()).build();
         });
         archiveService = mock(ArchiveService.class);
 
@@ -55,7 +61,7 @@ public class DefaultImportServiceTest {
         final String contentType = "application/xml";
         final String batch = "batch123";
 
-        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, singletonMap("batch", batch)).getBatch())
+        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, singletonMap("batch", batch), Ignore).getBatch())
                 .isEqualTo(batch);
 
         verify(importSource).submitContent(body, ImportContent.EXAM, contentType, 123L);
@@ -68,7 +74,7 @@ public class DefaultImportServiceTest {
         final String contentType = "text/csv";
         final MultipartFile file = new MockMultipartFile("test-group.csv", "test-group.csv", "text/csv", body);
 
-        final RdwImport rdwImport = service.importContent(user, file, ImportContent.GROUPS, contentType, null);
+        final RdwImport rdwImport = service.importContent(user, file, ImportContent.GROUPS, contentType, null, Ignore);
         assertThat(rdwImport.getContent()).isEqualTo(ImportContent.GROUPS);
 
         final byte[] expectedPayload = DigestUtils.md5Hex(body).toUpperCase().getBytes();
@@ -76,7 +82,7 @@ public class DefaultImportServiceTest {
     }
 
     @Test
-    public void importShouldReturnExistingDigest() {
+    public void importShouldIgnoreAndReturnExistingDigest() {
         final SbacUserDetails user = SbacUserTest.testUser();
         final byte[] body = "<TDSReport/>".getBytes();
         final String contentType = "application/xml";
@@ -85,7 +91,7 @@ public class DefaultImportServiceTest {
         final RdwImport match = RdwImport.builder().build();
         when(repository.findOneByContentAndDigest(ImportContent.EXAM, digest)).thenReturn(match);
 
-        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null)).isSameAs(match);
+        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null, Ignore)).isSameAs(match);
     }
 
     @Test
@@ -98,8 +104,22 @@ public class DefaultImportServiceTest {
         final RdwImport match = RdwImport.builder().build();
         when(repository.findOneByContentAndDigest(ImportContent.PACKAGE, digest)).thenReturn(match);
 
-        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null).getId()).isEqualTo(123);
+        assertThat(service.importContent(user, body, ImportContent.EXAM, contentType, null, Ignore).getId()).isEqualTo(123);
         verify(importSource).submitContent(body, ImportContent.EXAM, contentType, 123L);
+    }
+
+    @Test
+    public void itShouldReprocessExistingDigest() {
+        final SbacUserDetails user = SbacUserTest.testUser();
+        final byte[] body = "group_name,school_natural_id,school_year,subject_code,student_ssid,group_user_login".getBytes();
+        final String contentType = "text/csv";
+
+        final String digest = DigestUtils.md5Hex(body).toUpperCase();
+        final RdwImport match = RdwImport.builder().id(42L).build();
+        when(repository.findOneByContentAndDigest(ImportContent.GROUPS, digest)).thenReturn(match);
+
+        assertThat(service.importContent(user, body, ImportContent.GROUPS, contentType, null, Reprocess).getId()).isEqualTo(42);
+        verify(importSource).submitContent(body, ImportContent.GROUPS, contentType, 42L);
     }
 
     @Test
@@ -153,5 +173,37 @@ public class DefaultImportServiceTest {
     @Test(expected = IllegalArgumentException.class)
     public void itShouldFailWithAnEmptyQuery() {
         service.resubmitImports(RdwImportQuery.builder().build());
+    }
+
+    @Test
+    public void itShouldReturnPayloadOrNot() {
+        final byte[] payload = "payload".getBytes();
+        final RdwImport rdwImport = RdwImport.builder()
+                .id(123L)
+                .content(ImportContent.EXAM)
+                .digest("12345678")
+                .build();
+
+        when(repository.findOne(123L)).thenReturn(rdwImport);
+        when(archiveService.readResource("EXAM/12/34/12345678")).thenReturn(payload);
+
+        assertThat(service.getPayload(123L).get()).isEqualTo(payload);
+        assertThat(service.getPayload(42L).isPresent()).isFalse();
+    }
+
+    @Test
+    public void itShouldReturnPayloadPropertiesOrNot() {
+        final Properties properties = new Properties();
+        final RdwImport rdwImport = RdwImport.builder()
+                .id(123L)
+                .content(ImportContent.EXAM)
+                .digest("12345678")
+                .build();
+
+        when(repository.findOne(123L)).thenReturn(rdwImport);
+        when(archiveService.readProperties("EXAM/12/34/12345678")).thenReturn(properties);
+
+        assertThat(service.getPayloadProperties(123L).get()).isSameAs(properties);
+        assertThat(service.getPayloadProperties(42L).isPresent()).isFalse();
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/status/DatabaseStatusIndicatorTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/status/DatabaseStatusIndicatorTest.java
@@ -31,8 +31,7 @@ public class DatabaseStatusIndicatorTest {
         when(repository.findAllStatuses()).thenReturn(Arrays.asList(ImportStatus.values()));
         when(repository.create(any(RdwImport.class))).thenAnswer(invocation -> {
             final RdwImport rdwImport = (RdwImport) invocation.getArguments()[0];
-            rdwImport.setId(123L);
-            return rdwImport;
+            return rdwImport.copy().id(123L).build();
         });
 
         archiveService = mock(ArchiveService.class);

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/AccommodationControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/AccommodationControllerIT.java
@@ -1,57 +1,35 @@
 package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.ImportContent;
-import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
-import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(AccommodationController.class)
-@ContextConfiguration(classes = TestAppConfig.class)
-@WebAppConfiguration
-public class AccommodationControllerIT {
+public class AccommodationControllerIT extends ScopedControllerTestSuite {
 
-    private final String ACCOMMODATIONS_URI = "/accommodations/imports";
+    private static final String ApplicationXml = MediaType.APPLICATION_XML_VALUE;
 
-    @Autowired
-    private MockMvc mvc;
-
-    @MockBean
-    private ImportService importService;
+    public AccommodationControllerIT() {
+        super("/accommodations/imports", ImportContent.CODES, AuthHeaderWithAuthority);
+    }
 
     @Test
     public void itShouldUseServiceToImportAccommodationsUpload() throws Exception {
@@ -59,121 +37,27 @@ public class AccommodationControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(fileUpload(ACCOMMODATIONS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(content), eq(ApplicationXml), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldUseServiceToImportAccommodationsRawBody() throws Exception {
         final byte[] body = "<Accessibility/>".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.CODES), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(post(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
+        when(importService.importContent(any(), eq(body), eq(content), eq(ApplicationXml), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(post(uri).header(AuthHeader, authHeader).contentType(ApplicationXml).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
-        final String batch = "abc";
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-        mvc.perform(get(ACCOMMODATIONS_URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(batch)))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
-        final ImportStatus status = ImportStatus.BAD_FORMAT;
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(status.toString())))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(ACCOMMODATIONS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImports() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
-    }
-
-    @Test
-    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-    }
-
-    @Test
-    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").param("status", "BAD_DATA"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ACCOMMODATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.CODES);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ExamControllerIT.java
@@ -1,57 +1,35 @@
 package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.ImportContent;
-import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
-import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(ExamController.class)
-@ContextConfiguration(classes = TestAppConfig.class)
-@WebAppConfiguration
-public class ExamControllerIT {
+public class ExamControllerIT extends ScopedControllerTestSuite {
 
-    private static final String EXAMS_URI = "/exams/imports";
+    private static final String ApplicationXml = MediaType.APPLICATION_XML_VALUE;
 
-    @Autowired
-    private MockMvc mvc;
-
-    @MockBean
-    private ImportService importService;
+    public ExamControllerIT() {
+        super("/exams/imports", ImportContent.EXAM, AuthHeaderWithAuthority);
+    }
 
     @Test
     public void itShouldUseServiceToImportExamUpload() throws Exception {
@@ -59,121 +37,27 @@ public class ExamControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.xml", "application/xml", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(fileUpload(EXAMS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(content), eq(ApplicationXml), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldUseServiceToImportExamRawBody() throws Exception {
         final byte[] body = "<TDSReport/>".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.EXAM), eq(MediaType.APPLICATION_XML_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(post(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_XML).content(body))
+        when(importService.importContent(any(), eq(body), eq(content), eq(ApplicationXml), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(post(uri).header(AuthHeader, authHeader).contentType(ApplicationXml).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
-        final String batch = "abc";
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-        mvc.perform(get(EXAMS_URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(batch)))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
-        final ImportStatus status = ImportStatus.BAD_FORMAT;
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-        mvc.perform(get(EXAMS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(status.toString())))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
-        mvc.perform(get(EXAMS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(EXAMS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(EXAMS_URI + "?status=ACCEPTED"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(EXAMS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(EXAMS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImports() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(EXAMS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
-    }
-
-    @Test
-    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(EXAMS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-    }
-
-    @Test
-    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(EXAMS_URI + "/resubmit").param("status", "BAD_DATA"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(EXAMS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.EXAM);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/GroupControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/GroupControllerIT.java
@@ -1,67 +1,44 @@
 package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.ImportContent;
-import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Reprocess;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
-import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(GroupController.class)
-@ContextConfiguration(classes = TestAppConfig.class)
-@WebAppConfiguration
-public class GroupControllerIT {
+public class GroupControllerIT extends ScopedControllerTestSuite {
 
-    private static final String URI = "/groups/imports";
     private static final String UserTokenWithGroupAdmin = "sbac;dwtest@example.com;|CA|GROUP_ADMIN|STATE|||||CA|California|||||||||";
     private static final String AuthHeaderWithGroupAdmin = "Bearer " + UserTokenWithGroupAdmin;
     private static final String TextCsv = "text/csv";
 
-    @Autowired
-    private MockMvc mvc;
-
-    @MockBean
-    private ImportService importService;
+    public GroupControllerIT() {
+        super("/groups/imports", ImportContent.GROUPS, AuthHeaderWithGroupAdmin);
+    }
 
     @Test
     public void itShouldUseServiceToImportGroup() throws Exception {
         final byte[] body = "group_name,school_natural_id,school_year,subject_code,student_ssid,group_user_login".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.GROUPS), eq(TextCsv), any())).thenReturn(rdwImport);
+        when(importService.importContent(any(), eq(body), eq(content), eq(TextCsv), any(), eq(Reprocess))).thenReturn(rdwImport);
         
-        mvc.perform(post(URI).header(AuthHeader, AuthHeaderWithGroupAdmin).contentType(TextCsv).content(body))
+        mvc.perform(post(uri).header(AuthHeader, authHeader).contentType(TextCsv).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
 				.andExpect(content().string(not(containsString("null"))))
@@ -74,112 +51,12 @@ public class GroupControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.csv", TextCsv, body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.GROUPS), eq(TextCsv), any())).thenReturn(rdwImport);
+        when(importService.importContent(any(), eq(body), eq(content), eq(TextCsv), any(), eq(Reprocess))).thenReturn(rdwImport);
 
-        mvc.perform(fileUpload(URI).file(file).header(AuthHeader, AuthHeaderWithGroupAdmin))
+        mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(URI).header(AuthHeader, AuthHeaderWithGroupAdmin))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
-        final String batch = "abc";
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-
-        mvc.perform(get(URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithGroupAdmin))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(batch)))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
-        final ImportStatus status = ImportStatus.BAD_FORMAT;
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-
-        mvc.perform(get(URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithGroupAdmin))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(status.toString())))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldReturn4xxForInvalidStatus() throws Exception {
-        mvc.perform(get(URI + "?status=fubar").header(AuthHeader, AuthHeaderWithGroupAdmin))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(URI))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(URI).header(AuthHeader, AuthHeaderForClient))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(URI).header(AuthHeader, AuthHeaderWithGroupAdmin))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImports() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(URI + "/resubmit").header(AuthHeader, AuthHeaderWithGroupAdmin).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.GROUPS);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
-    }
-
-    @Test
-    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-    }
-
-    @Test
-    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(URI + "/resubmit").param("status", "BAD_DATA"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(URI + "/resubmit").header(AuthHeader, AuthHeaderWithGroupAdmin))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.GROUPS);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ImportControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ImportControllerIT.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
@@ -94,5 +95,19 @@ public class ImportControllerIT {
         mvc.perform(get("/imports/123/payload/properties").header(AuthHeader, AuthHeaderWithAuthority))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("test.xml")));
+    }
+
+    @Test
+    public void itShouldReflectCurrentUser() throws Exception {
+        mvc.perform(get("/imports/user").header(AuthHeader, AuthHeaderWithAuthority))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", equalTo("dwtest@example.com")))
+                .andExpect(jsonPath("$.authorities[0].authority", equalTo("ROLE_ASMTDATALOAD")));
+    }
+
+    @Test
+    public void itShouldNotReflectUnauthenticatedUser() throws Exception {
+        mvc.perform(get("/imports/user"))
+                .andExpect(status().is4xxClientError());
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/NormsControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/NormsControllerIT.java
@@ -1,65 +1,45 @@
 package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.ImportContent;
-import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
-import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(NormsController.class)
-@ContextConfiguration(classes = TestAppConfig.class)
-@WebAppConfiguration
-public class NormsControllerIT {
+public class NormsControllerIT extends ScopedControllerTestSuite {
 
-    private final String NORMS_URI = "/norms/imports";
+    private static final String TextPlain = MediaType.TEXT_PLAIN_VALUE;
 
-    @Autowired
-    private MockMvc mvc;
-
-    @MockBean
-    private ImportService importService;
+    public NormsControllerIT() {
+        super("/norms/imports", ImportContent.NORMS, AuthHeaderWithAuthority);
+    }
 
     @Test
     public void itShouldUseServiceToImportNorms() throws Exception {
         final byte[] body = "assessmentId,start_date".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.NORMS), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(post(NORMS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.TEXT_PLAIN).content(body))
+        when(importService.importContent(any(), eq(body), eq(content), eq(TextPlain), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(post(uri).header(AuthHeader, authHeader).contentType(TextPlain).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
@@ -72,109 +52,13 @@ public class NormsControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/plain", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.NORMS), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(fileUpload(NORMS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(content), eq(TextPlain), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(NORMS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
-        final String batch = "abc";
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-        mvc.perform(get(NORMS_URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(batch)))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
-        final ImportStatus status = ImportStatus.BAD_FORMAT;
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-        mvc.perform(get(NORMS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(status.toString())))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldReturn4xxForInvalidStatus() throws Exception {
-        mvc.perform(get(NORMS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(NORMS_URI))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(NORMS_URI).header(AuthHeader, AuthHeaderForClient))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(NORMS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(NORMS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImports() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(NORMS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.NORMS);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
-    }
-
-    @Test
-    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(NORMS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-    }
-
-    @Test
-    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(NORMS_URI + "/resubmit").param("status", "BAD_DATA"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(NORMS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.NORMS);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/OrganizationControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/OrganizationControllerIT.java
@@ -1,57 +1,35 @@
 package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.ImportContent;
-import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
-import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(OrganizationController.class)
-@ContextConfiguration(classes = TestAppConfig.class)
-@WebAppConfiguration
-public class OrganizationControllerIT {
+public class OrganizationControllerIT extends ScopedControllerTestSuite {
 
-    private final String ORGANIZATIONS_URI = "/organizations/imports";
+    private static final String ApplicationJson = MediaType.APPLICATION_JSON_VALUE;
 
-    @Autowired
-    private MockMvc mvc;
-
-    @MockBean
-    private ImportService importService;
+    public OrganizationControllerIT() {
+        super("/organizations/imports", ImportContent.ORGANIZATION, AuthHeaderWithAuthority);
+    }
 
     @Test
     public void itShouldUseServiceToImportAccommodationsUpload() throws Exception {
@@ -59,97 +37,27 @@ public class OrganizationControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.json", "application/json", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.ORGANIZATION), eq(MediaType.APPLICATION_JSON_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(fileUpload(ORGANIZATIONS_URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(content), eq(ApplicationJson), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(ORGANIZATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void itShouldUseServiceToImportAccommodationsRawBody() throws Exception {
         final byte[] body = "{ \"districts\": [], \"schools\": [] }".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
-        when(importService.importContent(any(), eq(body), eq(ImportContent.ORGANIZATION), eq(MediaType.APPLICATION_JSON_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(post(ORGANIZATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.APPLICATION_JSON).content(body))
+        when(importService.importContent(any(), eq(body), eq(content), eq(ApplicationJson), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(post(uri).header(AuthHeader, authHeader).contentType(ApplicationJson).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
-        final ImportStatus status = ImportStatus.BAD_FORMAT;
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-        mvc.perform(get(ORGANIZATIONS_URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(status.toString())))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
-        mvc.perform(get(ORGANIZATIONS_URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(ORGANIZATIONS_URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(ORGANIZATIONS_URI + "?status=ACCEPTED"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(ORGANIZATIONS_URI + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(ORGANIZATIONS_URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImports() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ORGANIZATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.ORGANIZATION);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
-    }
-
-    @Test
-    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(ORGANIZATIONS_URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-    }
-
-    @Test
-    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(ORGANIZATIONS_URI + "/resubmit").param("status", "BAD_DATA"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/PackageControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/PackageControllerIT.java
@@ -1,66 +1,45 @@
 package org.opentestsystem.rdw.ingest.web;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.ImportContent;
-import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
-import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
-import org.opentestsystem.rdw.ingest.service.ImportService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.service.DuplicateContentAction.Ignore;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
-import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
 import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderWithAuthority;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(PackageController.class)
-@ContextConfiguration(classes = TestAppConfig.class)
-@WebAppConfiguration
-public class PackageControllerIT {
+public class PackageControllerIT extends ScopedControllerTestSuite {
 
-    private final String URI = "/packages/imports";
+    private static final String TextPlain = MediaType.TEXT_PLAIN_VALUE;
 
-    @Autowired
-    private MockMvc mvc;
-
-    @MockBean
-    private ImportService importService;
+    public PackageControllerIT() {
+        super("/packages/imports", ImportContent.PACKAGE, AuthHeaderWithAuthority);
+    }
 
     @Test
     public void itShouldUseServiceToImportPackage() throws Exception {
         final byte[] body = "assessmentId,assessmentName".getBytes();
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(rdwImport);
+        when(importService.importContent(any(), eq(body), eq(content), eq(TextPlain), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
         
-        mvc.perform(post(URI).header(AuthHeader, AuthHeaderWithAuthority).contentType(MediaType.TEXT_PLAIN).content(body))
+        mvc.perform(post(uri).header(AuthHeader, authHeader).contentType(TextPlain).content(body))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
 				.andExpect(content().string(not(containsString("null"))))
@@ -73,112 +52,13 @@ public class PackageControllerIT {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/plain", body);
 
-        when(importService.importContent(any(), eq(body), eq(ImportContent.PACKAGE), eq(MediaType.TEXT_PLAIN_VALUE), any())).thenReturn(rdwImport);
-        mvc.perform(fileUpload(URI).file(file).header(AuthHeader, AuthHeaderWithAuthority))
+        when(importService.importContent(any(), eq(body), eq(content), eq(TextPlain), any(), eq(Ignore)))
+                .thenReturn(rdwImport);
+
+        mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("123")))
                 .andExpect(content().string(not(containsString("null"))))
                 .andExpect(jsonPath("$._links['self'].href", endsWith("imports/123")));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
-        mvc.perform(fileUpload(URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
-        final String batch = "abc";
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
-
-        mvc.perform(get(URI + "?batch=" + batch).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(batch)))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
-        final ImportStatus status = ImportStatus.BAD_FORMAT;
-        when(importService.getImports(any(RdwImportQuery.class)))
-                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
-
-
-        mvc.perform(get(URI + "?status=" + status.toString()).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(status.toString())))
-                .andExpect(content().string(containsString("123")));
-    }
-
-    @Test
-    public void itShouldReturn4xxForInvalidStatus() throws Exception {
-        mvc.perform(get(URI + "?status=fubar").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
-        mvc.perform(get(URI))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
-        mvc.perform(get(URI).header(AuthHeader, AuthHeaderForClient))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
-        mvc.perform(get(URI).header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
-
-    @Test
-    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
-        mvc.perform(get(URI + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
-                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImports() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.PACKAGE);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
-    }
-
-    @Test
-    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(URI + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-    }
-
-    @Test
-    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
-        mvc.perform(post(URI + "/resubmit").param("status", "BAD_DATA"))
-                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
-    }
-
-    @Test
-    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
-        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
-        mvc.perform(post(URI + "/resubmit").header(AuthHeader, AuthHeaderWithAuthority))
-                .andExpect(status().is2xxSuccessful())
-                .andExpect(content().string(equalTo("1")));
-        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
-        verify(importService).resubmitImports(argumentCaptor.capture());
-        final RdwImportQuery query = argumentCaptor.getValue();
-        assertThat(query.getContent()).isEqualTo(ImportContent.PACKAGE);
-        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ScopedControllerTestSuite.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ScopedControllerTestSuite.java
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestAppConfig.class)
 @WebAppConfiguration
-class ScopedControllerTestSuite {
+abstract class ScopedControllerTestSuite {
 
     protected final String uri;
     protected final ImportContent content;

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ScopedControllerTestSuite.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/ScopedControllerTestSuite.java
@@ -1,0 +1,157 @@
+package org.opentestsystem.rdw.ingest.web;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.opentestsystem.rdw.common.model.ImportContent;
+import org.opentestsystem.rdw.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.common.model.RdwImport;
+import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
+import org.opentestsystem.rdw.ingest.service.ImportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeader;
+import static org.opentestsystem.rdw.ingest.web.TestAppConfig.AuthHeaderForClient;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Base suite for integration tests of {@link ScopedImportController}s.
+ * This has tests for the common functionality.
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestAppConfig.class)
+@WebAppConfiguration
+class ScopedControllerTestSuite {
+
+    protected final String uri;
+    protected final ImportContent content;
+    protected final String authHeader;
+
+    @Autowired
+    protected MockMvc mvc;
+
+    @MockBean
+    protected ImportService importService;
+
+    protected ScopedControllerTestSuite(final String uri, final ImportContent content, final String authHeader) {
+        this.uri = uri;
+        this.content = content;
+        this.authHeader = authHeader;
+    }
+
+    @Test
+    public void itShouldReturnBadRequestForUploadWithNoFile() throws Exception {
+        mvc.perform(fileUpload(uri).header(AuthHeader, authHeader))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void itShouldUseServiceToGetImportsByBatch() throws Exception {
+        final String batch = "abc";
+        when(importService.getImports(any(RdwImportQuery.class)))
+                .thenReturn(newArrayList(RdwImport.builder().id(123L).batch(batch).build()));
+        mvc.perform(get(uri + "?batch=" + batch).header(AuthHeader, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(batch)))
+                .andExpect(content().string(containsString("123")));
+    }
+
+    @Test
+    public void itShouldUseServiceToGetImportsByStatus() throws Exception {
+        final ImportStatus status = ImportStatus.BAD_FORMAT;
+        when(importService.getImports(any(RdwImportQuery.class)))
+                .thenReturn(newArrayList(RdwImport.builder().id(123L).status(status).build()));
+        mvc.perform(get(uri + "?status=" + status.toString()).header(AuthHeader, authHeader))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(status.toString())))
+                .andExpect(content().string(containsString("123")));
+    }
+
+    @Test
+    public void itShouldReturnBadRequestForInvalidStatus() throws Exception {
+        mvc.perform(get(uri + "?status=fubar").header(AuthHeader, authHeader))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void itShouldReturnBadRequestWhenNoCriteria() throws Exception {
+        mvc.perform(get(uri).header(AuthHeader, authHeader))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    public void itShouldReturnUnauthorizedIfNoAuthToken() throws Exception {
+        mvc.perform(get(uri + "?status=ACCEPTED"))
+                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    public void itShouldReturnForbiddenIfNoAuthority() throws Exception {
+        mvc.perform(get(uri + "?status=ACCEPTED").header(AuthHeader, AuthHeaderForClient))
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    public void itShouldReturnForbiddenIfWrongAuthority() throws Exception {
+        mvc.perform(get(uri + "?status=ACCEPTED").header(AuthHeader, "Bearer sbac;alice;|CA|GENERAL|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"))
+                .andExpect(status().is(HttpStatus.FORBIDDEN.value()));
+    }
+
+    @Test
+    public void itShouldResubmitImports() throws Exception {
+        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
+        mvc.perform(post(uri + "/resubmit").header(AuthHeader, authHeader).param("status", "BAD_DATA"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(importService).resubmitImports(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getContent()).isEqualTo(content);
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.BAD_DATA);
+    }
+
+    @Test
+    public void itShouldAllowResubmitIfNoAuthority() throws Exception {
+        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
+        mvc.perform(post(uri + "/resubmit").header(AuthHeader, AuthHeaderForClient).param("status", "BAD_DATA"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+    }
+
+    @Test
+    public void itShouldDenyResubmitIfNoAuthToken() throws Exception {
+        mvc.perform(post(uri + "/resubmit").param("status", "BAD_DATA"))
+                .andExpect(status().is(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @Test
+    public void itShouldResubmitImportsWithDefaultQuery() throws Exception {
+        when(importService.resubmitImports(any(RdwImportQuery.class))).thenReturn(1L);
+        mvc.perform(post(uri + "/resubmit").header(AuthHeader, authHeader))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().string(equalTo("1")));
+        final ArgumentCaptor<RdwImportQuery> argumentCaptor = ArgumentCaptor.forClass(RdwImportQuery.class);
+        verify(importService).resubmitImports(argumentCaptor.capture());
+        final RdwImportQuery query = argumentCaptor.getValue();
+        assertThat(query.getContent()).isEqualTo(content);
+        assertThat(query.getStatus()).isEqualTo(ImportStatus.ACCEPTED);
+    }
+
+}


### PR DESCRIPTION
Group processing needs to reprocess duplicate payloads instead of ignoring them because there are other things that could affect processing other than just the content (e.g. permissions, organizations). While adding this capability, i kept finding little things that needed tweaking. So, before continuing on with the main SIS changes (sigh) i thought i'd check this in.