### PR TITLE
tweak controllers to allow file upload to be processed as either a file or bytes

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/AccommodationController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/AccommodationController.java
@@ -48,7 +48,7 @@ class AccommodationController extends ScopedImportController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
-        return super.uploadImport(sbacUser, request);
+        return super.uploadImport(sbacUser, request, false);
     }
 
     @GetMapping(value = "/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ExamController.java
@@ -48,7 +48,7 @@ class ExamController extends ScopedImportController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
-        return super.uploadImport(sbacUser, request);
+        return super.uploadImport(sbacUser, request, false);
     }
 
     @GetMapping("/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/GroupController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/GroupController.java
@@ -49,7 +49,7 @@ class GroupController extends ScopedImportController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
-        return super.uploadImport(sbacUser, request);
+        return super.uploadImport(sbacUser, request, true);
     }
 
     @GetMapping("/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/GroupController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/GroupController.java
@@ -42,6 +42,8 @@ class GroupController extends ScopedImportController {
                                         @RequestHeader(value = CONTENT_TYPE, required = false) final String contentType,
                                         @RequestBody final byte[] body,
                                         @RequestParam final Map<String, String> requestParams) {
+        // TODO - should we remove this method? if we don't a client could post byte[] content
+        // TODO   which won't be processed properly unless we make further changes to the processor
         return super.postImport(sbacUser, contentType, body, requestParams);
     }
 

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/NormsController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/NormsController.java
@@ -48,7 +48,7 @@ class NormsController extends ScopedImportController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
-        return super.uploadImport(sbacUser, request);
+        return super.uploadImport(sbacUser, request, false);
     }
 
     @GetMapping("/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/OrganizationController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/OrganizationController.java
@@ -48,7 +48,7 @@ class OrganizationController extends ScopedImportController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
-        return super.uploadImport(sbacUser, request);
+        return super.uploadImport(sbacUser, request, false);
     }
 
     @GetMapping(value = "/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/PackageController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/PackageController.java
@@ -48,7 +48,7 @@ class PackageController extends ScopedImportController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public RdwImportResource uploadImport(@AuthenticationPrincipal final SbacUserDetails sbacUser,
                                           final MultipartHttpServletRequest request) {
-        return super.uploadImport(sbacUser, request);
+        return super.uploadImport(sbacUser, request, false);
     }
 
     @GetMapping("/imports")

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/web/ScopedImportController.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.ingest.web;
 import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
+import org.opentestsystem.rdw.ingest.common.model.RdwImport;
 import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.service.DuplicateContentAction;
 import org.opentestsystem.rdw.ingest.service.ImportService;
@@ -69,8 +70,17 @@ abstract class ScopedImportController {
         return assembler.toResource(service.importContent(sbacUser, body, content, contentType, params, duplicateContentAction));
     }
 
+    /**
+     * Accept a file for import.
+     *
+     * @param sbacUser user credentials
+     * @param request request with multipart file
+     * @param importAsFile true to import as file, false to read and import file bytes instead
+     * @return RdwImport
+     */
     protected RdwImportResource uploadImport(final SbacUserDetails sbacUser,
-                                             final MultipartHttpServletRequest request) {
+                                             final MultipartHttpServletRequest request,
+                                             final boolean importAsFile) {
         // get the best MultipartFile (either the only one or the one named "file")
         final MultipartFile file;
         final Map<String, MultipartFile> fileMap = request.getFileMap();
@@ -82,21 +92,26 @@ abstract class ScopedImportController {
             file = fileMap.get("file");
         }
 
-        final String contentType = file.getContentType();
-        final byte[] body;
-        try {
-            body = file.getBytes();
-        } catch (final IOException e) {
-            throw new IllegalArgumentException("error getting file content", e);
-        }
-
         // extract parameter values from form data and request params
         // note that getParameterMap returns lists of values, so take just first value for each key
         final Map<String, String> metadata = newHashMap();
         metadata.put("filename", file.getOriginalFilename());
         request.getParameterMap().forEach((key, values) -> metadata.put(key, values[0]));
 
-        return assembler.toResource(service.importContent(sbacUser, body, content, contentType, metadata, duplicateContentAction));
+        final RdwImport rdwImport;
+        if (importAsFile) {
+            rdwImport = service.importContent(sbacUser, file, content, file.getContentType(), metadata, duplicateContentAction);
+        } else {
+            final byte[] body;
+            try {
+                body = file.getBytes();
+            } catch (final IOException e) {
+                throw new IllegalArgumentException("error getting file content", e);
+            }
+            rdwImport = service.importContent(sbacUser, body, content, file.getContentType(), metadata, duplicateContentAction);
+        }
+
+        return assembler.toResource(rdwImport);
     }
 
     protected List<RdwImportResource> getImports(final RdwImportQuery query) {

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/GroupControllerIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/GroupControllerIT.java
@@ -51,7 +51,7 @@ public class GroupControllerIT extends ScopedControllerTestSuite {
         final RdwImport rdwImport = RdwImport.builder().id(123L).build();
         final MockMultipartFile file = new MockMultipartFile("file", "test.csv", TextCsv, body);
 
-        when(importService.importContent(any(), eq(body), eq(content), eq(TextCsv), any(), eq(Reprocess))).thenReturn(rdwImport);
+        when(importService.importContent(any(), eq(file), eq(content), eq(TextCsv), any(), eq(Reprocess))).thenReturn(rdwImport);
 
         mvc.perform(fileUpload(uri).file(file).header(AuthHeader, authHeader))
                 .andExpect(status().is2xxSuccessful())


### PR DESCRIPTION
This is WIP, just checking in because it doesn't hurt anything and i'm trying to avoid a big checkin.

@wtritch if you get a chance can you think about this one, or maybe we can just chat about it tomorrow? The idea is that most import content is handled by pushing the file contents onto the rabbit queue. But because we expect student groups to be large we want to archive it off and post a small message: it will be processed directly from the archive. This lets a controller choose which technique to use.