### PR TITLE
use updated instead of created for reconciliation report

### DIFF
--- a/import-service/src/main/resources/application.sql.yml
+++ b/import-service/src/main/resources/application.sql.yml
@@ -31,8 +31,8 @@ sql:
         AND (:status IS NULL OR i.status = :status)
         AND (:batch IS NULL OR i.batch = :batch)
         AND (:creator IS NULL OR i.creator = :creator)
-        AND (:before IS NULL OR i.created < :before)
-        AND (:after IS NULL OR i.created > :after)
+        AND (:before IS NULL OR i.updated < :before)
+        AND (:after IS NULL OR i.updated > :after)
       ORDER BY i.id
       LIMIT :limit
 

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/RdwImportRepositoryIT.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static java.lang.Thread.sleep;
@@ -121,6 +122,20 @@ public class RdwImportRepositoryIT {
         final int initialCount = repository.findBy(query).size();
         createTestData();
         assertThat(repository.findBy(query)).hasSize(initialCount+3);
+    }
+
+    @Test
+    @Sql(statements = {
+            "INSERT INTO import (id,status,content,contentType,digest,created,updated) VALUES " +
+                    "(-1,0,1,'application/xml','1D849A91956B74350FF895F067F115E6',(CURRENT_TIMESTAMP - INTERVAL 12 HOUR),(CURRENT_TIMESTAMP - INTERVAL 1 HOUR))," +
+                    "(-2,0,1,'application/xml','1D849A91956B74350FF895F067F115E7',(CURRENT_TIMESTAMP - INTERVAL 12 HOUR),(CURRENT_TIMESTAMP - INTERVAL 3 HOUR))," +
+                    "(-3,0,1,'application/xml','1D849A91956B74350FF895F067F125E6',(CURRENT_TIMESTAMP - INTERVAL 12 HOUR),(CURRENT_TIMESTAMP - INTERVAL 10 HOUR));"
+    })
+    public void itShouldFindByUpdated() {
+        // there was a bug where AFTER/BEFORE values were compared against created instead of updated
+        // because of the way things work, we have to directly inject the data to test the query
+        final RdwImportQuery query = RdwImportQuery.builder().after(Instant.now().minus(6, ChronoUnit.HOURS)).build();
+        assertThat(repository.findBy(query).stream().map(RdwImport::getId).collect(Collectors.toSet())).contains(-1L, -2L);
     }
 
     @Test


### PR DESCRIPTION
This came up in production: basically updated imports were not being included in reconciliation report. Since updated=created initially we can just ignore created and check updated.