### PR TITLE
Refactor the caching permission service test to avoid standing up the…

### DIFF
--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/CachingPermissionServiceIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/CachingPermissionServiceIT.java
@@ -1,5 +1,8 @@
 package org.opentestsystem.rdw.ingest.auth;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.ingest.common.test.CachingTest;
@@ -7,25 +10,44 @@ import org.opentestsystem.rdw.security.service.PermissionService;
 import org.opentestsystem.rdw.security.service.PermissionServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.SimpleKey;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Collection;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = {
+        CachingPermissionService.class
+})
+@EnableCaching
 @CachingTest
 public class CachingPermissionServiceIT {
 
     @Autowired
     private PermissionService permissionService;
 
+    @MockBean(name = "basicPermissionService")
+    private PermissionService basicPermissionService;
+
     @Autowired
     private CacheManager cacheManager;
+
+    @Before
+    public void setup() throws Exception {
+        final Map<String, Collection<String>> permissionsByRole =
+                ImmutableMap.of(Authorities.DataLoadRole, ImmutableList.of(),
+                        "GROUP_ADMIN", ImmutableList.of(Authorities.GroupWritePermission, "GROUP_READ"));
+
+        when(basicPermissionService.getPermissionsByRole()).thenReturn(permissionsByRole);
+    }
 
     @Test
     public void itShouldCacheResults() throws PermissionServiceException {


### PR DESCRIPTION
… entire application context

The problem was that it was using `@SpringBootTest` without limiting the scope, so the entire application context was being stood up, including the repositories.
We were also missing the `@ActiveProfiles("test")` annotation, which means it was attempting to connect the repositories to the `warehouse` schema rather than `warehouse_test`

I just re-worked the test to limit the application context to the classes needed for testing.