### PR TITLE
use a streaming copy for migrate

### DIFF
--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessor.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultGroupMessageProcessor.java
@@ -30,12 +30,15 @@ public class DefaultGroupMessageProcessor implements GroupMessageProcessor {
     public void process(final String digest, final long importId) {
         loadService.cleanup(importId);  // clean up in case this is a resubmit
         loadService.loadGroup(digest, importId);
+        logger.info("Loaded data for group import {}, digest {}", importId, digest);
+
         userImportService.processStudents(importId);
+        logger.info("Processed students for group import {}", importId);
+
         groupImportService.processGroups(importId);
         groupImportService.processGroupUsers(importId);
         groupImportService.processGroupMembership(importId);
         loadService.cleanup(importId);  // clean up because it succeeded
-
         logger.info("Processed group import {}", importId);
     }
 }

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingLoadService.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/service/impl/DefaultProcessingLoadService.java
@@ -37,9 +37,6 @@ public class DefaultProcessingLoadService implements ProcessingLoadService {
     @Value("${sql.cleanup}")
     private String cleanupSql;
 
-    @Value("${sql.wait}")
-    private String waitSql;
-
     private final ArchiveService archiveService;
     private final SqlListExecutionRepository repository;
     private final GroupProcessingSqlConfiguration sqlConfiguration;
@@ -102,7 +99,5 @@ public class DefaultProcessingLoadService implements ProcessingLoadService {
     public void cleanup(final long importId) {
         repository.execute(new SqlListBuilder(sqlConfiguration.getEntities()).addNext(cleanupSql).build(),
                 ImmutableMap.of("import_id", importId));
-
-        repository.execute(new SqlListBuilder(sqlConfiguration.getEntities()).addNext(waitSql).build());
     }
 }

--- a/group-processor/src/main/resources/application.sql.yml
+++ b/group-processor/src/main/resources/application.sql.yml
@@ -3,7 +3,6 @@ sql:
     entities:
       # ------------ Import Student SSIDs
       # Assign existing students with matching SSIDs and import deleted/non-existent student SSIDs
-      # NOTE: the updated timestamps are randomized a bit to spread out the migrate work
       import-students:
         sql:
           assign-existing: >-
@@ -14,12 +13,11 @@ sql:
               AND sgl.import_id = :import_id
 
           insert-new: >-
-            INSERT IGNORE INTO student (ssid, import_id, update_import_id, updated)
+            INSERT IGNORE INTO student (ssid, import_id, update_import_id)
               SELECT
                 DISTINCT student_ssid,
                 sgl.import_id,
-                sgl.import_id,
-                TIMESTAMPADD(MICROSECOND, FLOOR(rand()*1000), CURRENT_TIMESTAMP(6))
+                sgl.import_id
               FROM upload_student_group sgl
                 LEFT JOIN student s ON sgl.student_ssid = s.ssid
               WHERE s.id IS NULL
@@ -31,8 +29,7 @@ sql:
             UPDATE student s
               JOIN upload_student_group sgl ON sgl.student_ssid = s.ssid
             SET s.deleted = 0,
-              s.update_import_id = sgl.import_id,
-              s.updated = TIMESTAMPADD(MICROSECOND, FLOOR(rand()*1000), CURRENT_TIMESTAMP(6))
+              s.update_import_id = sgl.import_id
             WHERE s.deleted = 1
               AND sgl.student_ssid IS NOT NULL
               AND sgl.import_id = :import_id
@@ -48,7 +45,6 @@ sql:
       # Assign schools and subjects.
       # Assign existing groups, import deleted/non-existent groups.
       # Import modified groups including metadata, student and user membership.
-      # NOTE: the updated timestamps are randomized a bit to spread out the migrate work
       import-groups:
         sql:
           assign-school-and-subject: >-
@@ -67,7 +63,7 @@ sql:
               AND sgl.import_id = :import_id
 
           insert-new: >-
-            INSERT IGNORE INTO student_group (name, school_id, active, school_year, subject_id, creator, import_id, update_import_id, updated)
+            INSERT IGNORE INTO student_group (name, school_id, active, school_year, subject_id, creator, import_id, update_import_id)
               SELECT
                 sgl.group_name,
                 sgl.school_id,
@@ -76,8 +72,7 @@ sql:
                 sgl.subject_id,
                 sgl.creator,
                 sgl.import_id,
-                sgl.import_id,
-                TIMESTAMPADD(MICROSECOND, 1000 + FLOOR(rand()*100), CURRENT_TIMESTAMP(6))
+                sgl.import_id
               FROM upload_student_group sgl
                 LEFT JOIN student_group sg ON sgl.group_name = sg.name AND sgl.school_id = sg.school_id AND sgl.school_year = sg.school_year
               WHERE sg.id IS NULL
@@ -90,8 +85,7 @@ sql:
               JOIN upload_student_group sgl ON sgl.school_id = sg.school_id AND sgl.group_name = sg.name AND sgl.school_year = sg.school_year
             SET sg.deleted = 0,
               sg.subject_id = sgl.subject_id,
-              sg.update_import_id = sgl.import_id,
-              sg.updated = TIMESTAMPADD(MICROSECOND, 1000 + FLOOR(rand()*100), CURRENT_TIMESTAMP(6))
+              sg.update_import_id = sgl.import_id
             WHERE sg.deleted = 1
               AND sgl.import_id = :import_id
 
@@ -102,8 +96,8 @@ sql:
               JOIN (SELECT loading.group_id, loading.subject_id FROM
                 (SELECT esg.id AS group_id,
                         MAX(esg.subject_id) AS subject_id,
-                        GROUP_CONCAT(usg.user_login ORDER BY usg.user_login) AS users,
-                        GROUP_CONCAT(sgm.student_id ORDER BY sgm.student_id) AS students
+                        GROUP_CONCAT(DISTINCT usg.user_login ORDER BY usg.user_login) AS users,
+                        GROUP_CONCAT(DISTINCT sgm.student_id ORDER BY sgm.student_id) AS students
                  FROM student_group esg
                    JOIN upload_student_group upload ON upload.group_id = esg.id
                    LEFT JOIN user_student_group usg ON usg.student_group_id = esg.id
@@ -113,17 +107,16 @@ sql:
                 JOIN
                 (SELECT group_id,
                    MAX(subject_id) AS subject_id,
-                   GROUP_CONCAT(group_user_login ORDER BY group_user_login) AS users,
-                   GROUP_CONCAT(student_id ORDER BY student_id) AS students
+                   GROUP_CONCAT(DISTINCT group_user_login ORDER BY group_user_login) AS users,
+                   GROUP_CONCAT(DISTINCT student_id ORDER BY student_id) AS students
                  FROM upload_student_group
-                 WHERE import_id = :import_id
+                 WHERE group_id IS NOT NULL AND import_id = :import_id
                  GROUP BY group_id) loading
                   ON loading.group_id = existing.group_id
                      AND (NOT loading.subject_id <=> existing.subject_id OR NOT loading.users <=> existing.users OR NOT loading.students <=> existing.students)
                 ) sub ON sub.group_id = sg.id
             SET sg.subject_id = sub.subject_id,
-            sg.update_import_id = :import_id,
-            sg.updated = TIMESTAMPADD(MICROSECOND, 1000 + FLOOR(rand()*100), CURRENT_TIMESTAMP(6))
+            sg.update_import_id = :import_id
 
           assign-new: >-
             UPDATE upload_student_group sgl
@@ -201,9 +194,3 @@ sql:
   cleanup: >-
     DELETE FROM upload_student_group
     WHERE import_id = :import_id
-
-  # As noted above, the updated values are randomly shifted to avoid overloading migrate.
-  # So we need to pause a bit before moving on and updating the import record. Since the
-  # maximum random shift is 1100us, sleeping for 10ms will be more than enough.
-  wait: >-
-    SELECT SLEEP(0.010);

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/GroupImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/GroupImportService.java
@@ -136,7 +136,10 @@ class GroupImportService extends DefaultImportService {
                     .status(ImportStatus.BAD_DATA)
                     .message(validationService.toFailureMessage(validationResults))
                     .build());
+            logger.info("{} validation failed\n{}", content, rdwImport.getMessage());
             return rdwImport;
+        } else {
+            logger.info("{} validation succeeded", content);
         }
 
         // Group imports are always reprocessed even if duplicate (because changes to permissions

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
@@ -97,8 +97,6 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
         private final ParsedSql parsedSql;
         private final Long migrateId;
 
-        private String[] columnNames;
-
         StreamingBatchCopier(final JdbcOperations jdbcOperations, final String rawSql, final Long migrateId) {
             this.jdbcOperations = jdbcOperations;
             this.parsedSql = NamedParameterUtils.parseSqlStatement(rawSql);
@@ -107,7 +105,7 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
 
         @Override
         public Object extractData(final ResultSet rs) throws SQLException, DataAccessException {
-            readColumnNames(rs);
+            final String[] columnNames = readColumnNames(rs);
 
             final List<SqlParameterSource> batchParams = newArrayList();
             while (true) {
@@ -129,14 +127,14 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
             return null;
         }
 
-        private void readColumnNames(final ResultSet rs) throws SQLException {
+        private static String[] readColumnNames(final ResultSet rs) throws SQLException {
             final ResultSetMetaData rsmd = rs.getMetaData();
             final int columnCount = rsmd.getColumnCount();
             final String[] names = new String[columnCount+1];
             for (int i = 1; i <= columnCount; i++) {
                 names[i] = JdbcUtils.lookupColumnName(rsmd, i);
             }
-            columnNames = names;
+            return names;
         }
     }
 

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
@@ -3,6 +3,7 @@ package org.opentestsystem.rdw.ingest.migrate.reporting.repository.impl;
 import org.opentestsystem.rdw.ingest.migrate.reporting.repository.SqlCopyWarehouseToStagingRepository;
 import org.opentestsystem.rdw.ingest.migrate.reporting.step.SqlCopyStatements;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -39,16 +40,17 @@ import static org.springframework.jdbc.core.namedparam.NamedParameterBatchUpdate
  */
 @Repository
 class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagingRepository {
-    private static final int StreamingBatchSize = 500;
-
     private final NamedParameterJdbcTemplate reportingJdbcTemplate;
     private final NamedParameterJdbcTemplate warehouseJdbcTemplate;
+    private final int streamingBatchSize;
 
     @Autowired
     public JdbcSqlCopyWarehouseToStagingRepository(final NamedParameterJdbcTemplate reportingJdbcTemplate,
-                                                   final NamedParameterJdbcTemplate warehouseJdbcTemplate) {
+                                                   final NamedParameterJdbcTemplate warehouseJdbcTemplate,
+                                                   @Value("${migrate.batch.size:1000}") final int streamingBatchSize) {
         this.reportingJdbcTemplate = reportingJdbcTemplate;
         this.warehouseJdbcTemplate = warehouseJdbcTemplate;
+        this.streamingBatchSize = streamingBatchSize;
     }
 
     @Override
@@ -79,10 +81,8 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
         final JdbcTemplate jdbcTemplate = (JdbcTemplate)warehouseJdbcTemplate.getJdbcOperations();
 
         for (final SqlCopyStatements statements : copyStatementsList) {
-            final StreamingStatementCreator reader =
-                    new StreamingStatementCreator(statements.getWarehouseRead(), queryParams);
-            final StreamingBatchCopier copier =
-                    new StreamingBatchCopier(reportingJdbcTemplate.getJdbcOperations(), statements.getStagingInsert(), migrateId);
+            final StreamingStatementCreator reader = new StreamingStatementCreator(statements.getWarehouseRead(), queryParams);
+            final StreamingBatchCopier copier = new StreamingBatchCopier(statements.getStagingInsert(), migrateId);
 
             jdbcTemplate.query(reader, reader, copier);
         }
@@ -92,25 +92,25 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
      * This class is responsible for reading a result set in chunks. For each chunk, it collects
      * the result set columns as parameters and does a batch update with them.
      */
-    static class StreamingBatchCopier implements ResultSetExtractor<Object> {
-        private final JdbcOperations jdbcOperations;
+    class StreamingBatchCopier implements ResultSetExtractor<Object> {
         private final ParsedSql parsedSql;
         private final Long migrateId;
 
-        StreamingBatchCopier(final JdbcOperations jdbcOperations, final String rawSql, final Long migrateId) {
-            this.jdbcOperations = jdbcOperations;
+        StreamingBatchCopier(final String rawSql, final Long migrateId) {
             this.parsedSql = NamedParameterUtils.parseSqlStatement(rawSql);
             this.migrateId = migrateId;
         }
 
         @Override
         public Object extractData(final ResultSet rs) throws SQLException, DataAccessException {
+            final JdbcOperations jdbcOperations = reportingJdbcTemplate.getJdbcOperations();
+
             final String[] columnNames = readColumnNames(rs);
 
             final List<SqlParameterSource> batchParams = newArrayList();
             while (true) {
                 batchParams.clear();
-                for (int batch = 0; batch < StreamingBatchSize && rs.next(); ++batch) {
+                for (int batch = 0; batch < streamingBatchSize && rs.next(); ++batch) {
                     final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
                     if (migrateId != null) {
                         parameterSource.addValue("migrate_id", migrateId);
@@ -127,11 +127,11 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
             return null;
         }
 
-        private static String[] readColumnNames(final ResultSet rs) throws SQLException {
+        private String[] readColumnNames(final ResultSet rs) throws SQLException {
             final ResultSetMetaData rsmd = rs.getMetaData();
             final int columnCount = rsmd.getColumnCount();
             final String[] names = new String[columnCount+1];
-            for (int i = 1; i <= columnCount; i++) {
+            for (int i = 1; i <= columnCount; ++i) {
                 names[i] = JdbcUtils.lookupColumnName(rsmd, i);
             }
             return names;
@@ -155,8 +155,9 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
 
         @Override
         public PreparedStatement createPreparedStatement(final Connection connection) throws SQLException {
+            // this enables streaming results
             final PreparedStatement statement = connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-            statement.setFetchSize(StreamingBatchSize);
+            statement.setFetchSize(Integer.MIN_VALUE);
             return statement;
         }
 
@@ -168,7 +169,7 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
         @Override
         public void setValues(final PreparedStatement ps) throws SQLException {
             // This was derived from PreparedStatementCreatorFactory#PreparedStatementCreatorImpl
-            // but this can be much simpler because we have the SqlParameters and we know we don't
+            // but this can be much simpler because we have the SqlParameterValues and we don't
             // have to deal with different parameter types, collections, etc.
             int idx = 0;
             for (final Object o : params) {

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepository.java
@@ -3,15 +3,27 @@ package org.opentestsystem.rdw.ingest.migrate.reporting.repository.impl;
 import org.opentestsystem.rdw.ingest.migrate.reporting.repository.SqlCopyWarehouseToStagingRepository;
 import org.opentestsystem.rdw.ingest.migrate.reporting.step.SqlCopyStatements;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.ColumnMapRowMapper;
-import org.springframework.jdbc.core.RowMapper;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.SqlParameter;
+import org.springframework.jdbc.core.SqlParameterValue;
+import org.springframework.jdbc.core.SqlProvider;
+import org.springframework.jdbc.core.StatementCreatorUtils;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterUtils;
+import org.springframework.jdbc.core.namedparam.ParsedSql;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -19,11 +31,15 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static org.springframework.jdbc.core.namedparam.NamedParameterBatchUpdateUtils.executeBatchUpdateWithNamedParameters;
+
 /**
  * Jdbc implementation of {@link SqlCopyWarehouseToStagingRepository}.
  */
 @Repository
 class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagingRepository {
+    private static final int StreamingBatchSize = 500;
 
     private final NamedParameterJdbcTemplate reportingJdbcTemplate;
     private final NamedParameterJdbcTemplate warehouseJdbcTemplate;
@@ -59,39 +75,108 @@ class JdbcSqlCopyWarehouseToStagingRepository implements SqlCopyWarehouseToStagi
     private void execute(final List<SqlCopyStatements> copyStatementsList,
                          final Long migrateId,
                          final MapSqlParameterSource queryParams) {
-        for (final SqlCopyStatements sqlCopyStatements : copyStatementsList) {
-            final List<SqlParameterSource> params = warehouseJdbcTemplate.query(
-                    sqlCopyStatements.getWarehouseRead(), queryParams, new SqlParamsRowMapper(migrateId));
-            final SqlParameterSource[] stagingParams = params.toArray(new SqlParameterSource[params.size()]);
-            reportingJdbcTemplate.batchUpdate(sqlCopyStatements.getStagingInsert(), stagingParams);
+        // for whatever reason, the method we need is on JdbcTemplate so coerce what we have ...
+        final JdbcTemplate jdbcTemplate = (JdbcTemplate)warehouseJdbcTemplate.getJdbcOperations();
+
+        for (final SqlCopyStatements statements : copyStatementsList) {
+            final StreamingStatementCreator reader =
+                    new StreamingStatementCreator(statements.getWarehouseRead(), queryParams);
+            final StreamingBatchCopier copier =
+                    new StreamingBatchCopier(reportingJdbcTemplate.getJdbcOperations(), statements.getStagingInsert(), migrateId);
+
+            jdbcTemplate.query(reader, reader, copier);
         }
     }
 
     /**
-     * A RowMapper that converts a row directly into a SqlParameterSource.
-     * Implementation inspired by {@link ColumnMapRowMapper}.
+     * This class is responsible for reading a result set in chunks. For each chunk, it collects
+     * the result set columns as parameters and does a batch update with them.
      */
-    private static class SqlParamsRowMapper implements RowMapper<SqlParameterSource> {
+    static class StreamingBatchCopier implements ResultSetExtractor<Object> {
+        private final JdbcOperations jdbcOperations;
+        private final ParsedSql parsedSql;
         private final Long migrateId;
 
-        SqlParamsRowMapper(final Long migrateId) {
+        private String[] columnNames;
+
+        StreamingBatchCopier(final JdbcOperations jdbcOperations, final String rawSql, final Long migrateId) {
+            this.jdbcOperations = jdbcOperations;
+            this.parsedSql = NamedParameterUtils.parseSqlStatement(rawSql);
             this.migrateId = migrateId;
         }
 
         @Override
-        public SqlParameterSource mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+        public Object extractData(final ResultSet rs) throws SQLException, DataAccessException {
+            readColumnNames(rs);
+
+            final List<SqlParameterSource> batchParams = newArrayList();
+            while (true) {
+                batchParams.clear();
+                for (int batch = 0; batch < StreamingBatchSize && rs.next(); ++batch) {
+                    final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+                    if (migrateId != null) {
+                        parameterSource.addValue("migrate_id", migrateId);
+                    }
+                    for (int i = 1; i < columnNames.length; ++i) {
+                        parameterSource.addValue(columnNames[i], JdbcUtils.getResultSetValue(rs, i));
+                    }
+                    batchParams.add(parameterSource);
+                }
+                if (batchParams.isEmpty()) break;
+
+                executeBatchUpdateWithNamedParameters(parsedSql, batchParams.toArray(new SqlParameterSource[0]), jdbcOperations);
+            }
+            return null;
+        }
+
+        private void readColumnNames(final ResultSet rs) throws SQLException {
             final ResultSetMetaData rsmd = rs.getMetaData();
             final int columnCount = rsmd.getColumnCount();
-            final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+            final String[] names = new String[columnCount+1];
             for (int i = 1; i <= columnCount; i++) {
-                final String key = JdbcUtils.lookupColumnName(rsmd, i);
-                final Object value = JdbcUtils.getResultSetValue(rs, i);
-                parameterSource.addValue(key, value);
+                names[i] = JdbcUtils.lookupColumnName(rsmd, i);
             }
-            if (migrateId != null) {
-                parameterSource.addValue("migrate_id", migrateId);
+            columnNames = names;
+        }
+    }
+
+    /**
+     * This class creates a streaming statement so that large result sets can be read in chunks to
+     * avoid blowing heap. The logic is derived from code in NamedParamterJdbcTemplate.
+     */
+    static class StreamingStatementCreator implements PreparedStatementCreator, SqlProvider, PreparedStatementSetter {
+        private final String sql;
+        private final Object[] params;
+
+        StreamingStatementCreator(final String rawSql, final SqlParameterSource paramSource) {
+            final ParsedSql parsedSql = NamedParameterUtils.parseSqlStatement(rawSql);
+            sql = NamedParameterUtils.substituteNamedParameters(parsedSql, paramSource);
+            final List<SqlParameter> sqlParams = NamedParameterUtils.buildSqlParameterList(parsedSql, paramSource);
+            params = NamedParameterUtils.buildValueArray(parsedSql, paramSource, sqlParams);
+        }
+
+        @Override
+        public PreparedStatement createPreparedStatement(final Connection connection) throws SQLException {
+            final PreparedStatement statement = connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            statement.setFetchSize(StreamingBatchSize);
+            return statement;
+        }
+
+        @Override
+        public String getSql() {
+            return sql;
+        }
+
+        @Override
+        public void setValues(final PreparedStatement ps) throws SQLException {
+            // This was derived from PreparedStatementCreatorFactory#PreparedStatementCreatorImpl
+            // but this can be much simpler because we have the SqlParameters and we know we don't
+            // have to deal with different parameter types, collections, etc.
+            int idx = 0;
+            for (final Object o : params) {
+                final SqlParameterValue param = (SqlParameterValue) o;
+                StatementCreatorUtils.setParameterValue(ps, ++idx, param, param.getValue());
             }
-            return parameterSource;
         }
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepositoryIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepositoryIT.java
@@ -52,7 +52,7 @@ public class JdbcSqlCopyWarehouseToStagingRepositoryIT extends RepositoryIT {
 
         assertThat(countRowsInTable(reportingJdbcTemplate, "staging_district")).isEqualTo(0);
 
-        List<SqlCopyStatements> copyStatementsList = newArrayList();
+        final List<SqlCopyStatements> copyStatementsList = newArrayList();
         copyStatementsList.add(new SqlCopyStatements(sqlConfig.getEntities().get("district").getSql().get("warehouseRead"),
                 sqlConfig.getEntities().get("district").getSql().get("stagingInsert")));
 


### PR DESCRIPTION
Even with timestamp-smearing, uploading a large group file was resulting in blown memory when staging data. In my basic test, it was creating 280k students and trying to read all those rows into memory during warehouse-to-staging. 

This change switches to a "streaming" approach where it reads/writes data in chunks. Please review with a very critical eye since this is a non-trivial change.