### PR TITLE
improve message for bad date

### DIFF
--- a/common/src/main/java/org/opentestsystem/rdw/ingest/common/util/ParserHelper.java
+++ b/common/src/main/java/org/opentestsystem/rdw/ingest/common/util/ParserHelper.java
@@ -5,6 +5,7 @@ import org.springframework.util.StringUtils;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.format.DateTimeParseException;
 import java.util.function.Function;
 
 /**
@@ -125,7 +126,12 @@ public class ParserHelper {
 
     public static final Function<String, LocalDate> toLocalDate = value -> {
         Precondition.checkNotBlank(value);
-        return LocalDate.parse(value.trim());
+        try {
+            return LocalDate.parse(value.trim());
+        } catch (final DateTimeParseException e) {
+            // the message from parse is a bit cryptic and includes single quotes, so provide our own
+            throw new IllegalArgumentException("invalid date [" + value + "], use format YYYY-MM-DD");
+        }
     };
 
     public static final Function<String, Double> toDoubleOrNull = value ->
@@ -135,7 +141,7 @@ public class ParserHelper {
             StringUtils.hasText(value) ? Integer.parseInt(value.trim()) : null;
 
     public static final Function<String, LocalDate> toLocalDateOrNull = value ->
-            StringUtils.hasText(value) ? LocalDate.parse(value.trim()) : null;
+            StringUtils.hasText(value) ? toLocalDate.apply(value.trim()) : null;
 
     public static Function<String, String> toGrade = value -> {
         Precondition.checkNotBlank(value);

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/common/util/ParserHelperTest.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/common/util/ParserHelperTest.java
@@ -4,9 +4,7 @@ import com.google.common.base.Function;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.text.ParseException;
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 
 import static java.time.Year.MAX_VALUE;
 import static java.time.Year.MIN_VALUE;
@@ -18,6 +16,7 @@ import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toDouble;
 import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toGrade;
 import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toInteger;
 import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toIntegerOrNull;
+import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toLocalDate;
 import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toLocalDateOrNull;
 import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toLong;
 import static org.opentestsystem.rdw.ingest.common.util.ParserHelper.toYear;
@@ -51,7 +50,7 @@ public class ParserHelperTest {
     }
 
     @Test
-    public void ItShouldParseToBoolean() throws ParseException {
+    public void ItShouldParseToBoolean() {
         assertThat(toBoolean.apply("yes")).isEqualTo(true);
         assertThat(toBoolean.apply("YES")).isEqualTo(true);
         assertThat(toBoolean.apply("Yes")).isEqualTo(true);
@@ -79,12 +78,12 @@ public class ParserHelperTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void ItShouldThrowUnsupportedValueForBoolean() throws ParseException {
+    public void ItShouldThrowUnsupportedValueForBoolean() {
         toBoolean.apply("something");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void ItShouldThrowUnsupportedForNull() throws ParseException {
+    public void ItShouldThrowUnsupportedForNull() {
         toBoolean.apply(null);
     }
 
@@ -212,7 +211,7 @@ public class ParserHelperTest {
         assertThat(toLocalDateOrNull.apply("  2007-12-03  ")).isEqualTo(LocalDate.parse("2007-12-03"));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void itShouldFailToParseInvalidLocalDateOrNull() {
         toLocalDateOrNull.apply("notadate");
     }
@@ -228,5 +227,18 @@ public class ParserHelperTest {
     @Test(expected = IllegalArgumentException.class)
     public void isShouldFailToParseToGrade() {
         toGrade.apply(" ");
+    }
+
+    @Test
+    public void itShouldHaveAUsefulMessageForUnparseableDate() {
+        // samples from the wild; yes, they are expected to fail but this tests the message back
+
+        assertThat(parserHelper.validate("testLocalDate", "8/1/17", toLocalDate)).isNull();
+        assertThat(errorCollector.size()).isEqualTo(1);
+        assertThat(errorCollector.toJson()).isEqualTo("{\"messages\":[{\"elementName\":\"testLocalDate\",\"value\":\"8/1/17\",\"error\":\"invalid date [8/1/17], use format YYYY-MM-DD\"}]}");
+
+        errorCollector.reset();
+        assertThat(parserHelper.validate("testLocalDateOrNull", "6/30/18", toLocalDateOrNull)).isNull();
+        assertThat(errorCollector.toJson()).isEqualTo("{\"messages\":[{\"elementName\":\"testLocalDateOrNull\",\"value\":\"6/30/18\",\"error\":\"invalid date [6/30/18], use format YYYY-MM-DD\"}]}");
     }
 }

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
@@ -48,9 +48,9 @@ public class DefaultExamineeProcessorIT {
                     "{\"elementName\":\"StudentIdentifier\",\"value\":\"\",\"error\":\"value may not be blank\"}," +
                     "{\"elementName\":\"Birthdate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
                     "{\"elementName\":\"Sex\",\"value\":\"bad data\",\"error\":\"unknown gender code [bad data]\"}," +
-                    "{\"elementName\":\"FirstEntryDateIntoUSSchool\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
-                    "{\"elementName\":\"LimitedEnglishProficiencyEntryDate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
-                    "{\"elementName\":\"LEPExitDate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}," +
+                    "{\"elementName\":\"FirstEntryDateIntoUSSchool\",\"value\":\"bad data\",\"error\":\"invalid date [bad data], use format YYYY-MM-DD\"}," +
+                    "{\"elementName\":\"LimitedEnglishProficiencyEntryDate\",\"value\":\"bad data\",\"error\":\"invalid date [bad data], use format YYYY-MM-DD\"}," +
+                    "{\"elementName\":\"LEPExitDate\",\"value\":\"bad data\",\"error\":\"invalid date [bad data], use format YYYY-MM-DD\"}," +
                     "{\"elementName\":\"AmericanIndianOrAlaskaNative\",\"value\":\"bad data\",\"error\":\"invalid value [bad data]\"}," +
                     "{\"elementName\":\"Asian\",\"value\":\"bad data\",\"error\":\"invalid value [bad data]\"}," +
                     "{\"elementName\":\"BlackOrAfricanAmerican\",\"value\":\"bad data\",\"error\":\"invalid value [bad data]\"}," +
@@ -95,7 +95,7 @@ public class DefaultExamineeProcessorIT {
                 "{\"elementName\":\"LEPStatus\",\"value\":\"bad data\",\"error\":\"invalid value [bad data]\"}," +
                 "{\"elementName\":\"GradeLevelWhenAssessed\",\"value\":\"bad data\",\"error\":\"unknown grade code [bad data]\"}," +
                 "{\"elementName\":\"EnglishLanguageAcquisitionStatus\",\"value\":\"bad data\",\"error\":\"unknown elas code [bad data]\"}," +
-                "{\"elementName\":\"EnglishLanguageAcquisitionStatusStartDate\",\"value\":\"bad data\",\"error\":\"Text \\u0027bad data\\u0027 could not be parsed at index 0\"}" +
+                "{\"elementName\":\"EnglishLanguageAcquisitionStatusStartDate\",\"value\":\"bad data\",\"error\":\"invalid date [bad data], use format YYYY-MM-DD\"}" +
                 "]}");
     }
 


### PR DESCRIPTION
The parser helper has a helper function to parse dates. It requires the format to be ISO-8601 whatever. It uses the LocalDate parse exception message which is a bit cryptic, something like `"Text \u00278/1/17\u0027 could not be parsed at index 0"`. Since this is the third or fourth time i've stared at the message and wondered what `\u0027` is and confused `index 0` for the line offset (it's really the field text offset) i thought i'd clean it up. It now emits something like `"invalid date [8/1/17], use format YYYY-MM-DD"`.

Since this is a teeny change, i'll commit and address any concerns raised.
