### PR TITLE
async job runner

### DIFF
--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunner.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunner.java
@@ -42,6 +42,7 @@ public class MigrateJobRunner implements MigrateLifecycle {
         this.batchSize = batchSize;
     }
 
+    @Override
     public void run() {
         try {
             Optional<MigrateJobParameters> jobParameters;

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateLifecycle.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateLifecycle.java
@@ -3,9 +3,14 @@ package org.opentestsystem.rdw.migrate.common;
 import org.springframework.context.Lifecycle;
 
 /**
- * An interface for a component that may be disabled and/or paused.
+ * An interface for a runnable migrate component that may be disabled and/or paused.
  */
 public interface MigrateLifecycle extends Lifecycle {
+
+    /**
+     * take action
+     */
+    void run();
 
     /**
      * @param flag true to enable component, false to disable

--- a/migrate-olap/build.gradle
+++ b/migrate-olap/build.gradle
@@ -66,6 +66,28 @@ cleanAllTest migrateAllTest
  gradle rst)
 */
 // If you are using different instances the full set of variables can be found in application-redshift.yml.
+//
+// If you want to run the application from within your IDE, to debug or whatever, you'll need to set all those
+// environment variables (and a couple more) OR you can pass them in as program arguments. I guess you could also
+// just modify the embedded application.yml. But here are the program arguments, without the more sensitive secrets:
+/*
+--archive.root=s3://rdw-ci-archive
+--archive.cloud.aws.credentials.accessKey=access-key
+--archive.cloud.aws.credentials.secretKey=secret-key
+--migrate.aws.redshift.role=arn:aws:iam::269146879732:role/rdw-redshift
+--spring.migrate_datasource.url-server=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
+--spring.migrate_datasource.url-schema=bob_migrate_olap_test
+--spring.migrate_datasource.username=sbac
+--spring.migrate_datasource.password=password
+--spring.olap_datasource.url-server=rdw-qa.cibkulpjrgtr.us-west-2.redshift.amazonaws.com:5439
+--spring.olap_datasource.url-db=ci
+--spring.olap_datasource.username=bob
+--spring.olap_datasource.password=password
+--spring.warehouse_datasource.url-server=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
+--spring.warehouse_datasource.url-schema=bob_warehouse_test
+--spring.warehouse_datasource.username=sbac
+--spring.warehouse_datasource.password=password
+ */
 
 task RST(type: Test) {
     include '**/*RST.*'

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
@@ -8,11 +8,11 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Scheduled execution of the {@link MigrateOlapReportingConfiguration#jobBuilderFactory}'s job.
@@ -23,6 +23,7 @@ import javax.annotation.PostConstruct;
  * to ABANDONED with a message.
  */
 @EnableScheduling
+@EnableAsync
 @Component
 @Import({MigrateOlapReportingConfiguration.class})
 class MigrateOlapReportingJobRunner extends MigrateJobRunner {
@@ -35,10 +36,10 @@ class MigrateOlapReportingJobRunner extends MigrateJobRunner {
         super(migrateRepository, importRepository, jobLauncher, job, batchSize);
     }
 
-    @PostConstruct
+    @Async
     @Scheduled(cron = "${migrate.olap-batch.run-cron}", zone = "GMT")
     @Override
-    public void run(){
+    public void run() {
         super.run();
     }
 }

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/RunOnStartup.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/RunOnStartup.java
@@ -1,0 +1,26 @@
+package org.opentestsystem.rdw.ingest.migrate.olap;
+
+import org.opentestsystem.rdw.migrate.common.MigrateLifecycle;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Because the run() method on MigrateOlapReportingJobRunner is annotated @Async it cannot have a
+ * {@literal @}PostConstruct annotation. Instead, this bean forces it to run on startup.
+ *
+ * @see MigrateOlapReportingJobRunner
+ */
+@Component
+public class RunOnStartup {
+    private final MigrateLifecycle jobRunner;
+
+    public RunOnStartup(final MigrateLifecycle jobRunner) {
+        this.jobRunner = jobRunner;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        jobRunner.run();
+    }
+}

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
@@ -8,7 +8,10 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -22,6 +25,7 @@ import org.springframework.stereotype.Component;
  * to ABANDONED with a message.
  */
 @EnableScheduling
+@EnableAsync
 @Component
 @Import({MigrateReportingConfiguration.class})
 class MigrateReportingJobRunner extends MigrateJobRunner {
@@ -35,9 +39,10 @@ class MigrateReportingJobRunner extends MigrateJobRunner {
         super(migrateRepository, importRepository, jobLauncher, job, batchSize);
     }
 
+    @Async
     @Scheduled(fixedDelayString = "${migrate.batch.delay}")
     @Override
-    public void run(){
+    public void run() {
         super.run();
     }
 }


### PR DESCRIPTION
I'm not 100% sure that this is the best practice approach to this problem. I did play with another approach where i made the TaskExecutor for the JobLauncher a SimpleAsyncTaskExecutor. My concern with that approach is that the JobLauncher will return right away and any scheduling will not take into account when the job actually completes. Since the sole purpose of the migrate apps is to run this one job, it seemed wrong somehow to use an async executor way down in the innards. 

Anyway, this seems to work and is simpler.