### PR TITLE
set timeouts for connect, socket and query

### DIFF
--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -29,16 +29,20 @@ spring:
       &characterEncoding=${spring.datasource.character-encoding:utf8}\
       &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
       &noAccessToProcedureBodies=${spring.datasource.no-access-to-procedure-bodies:true}\
+      &connectTimeout=${spring.datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.datasource.socket-timeout:40000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 12
     initialSize: 6
     maxWait: 10000
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=30)"
 
   jackson:
     default-property-inclusion: non_null

--- a/group-processor/src/main/resources/application.yml
+++ b/group-processor/src/main/resources/application.yml
@@ -42,15 +42,19 @@ spring:
       &characterEncoding=${spring.datasource.character-encoding:utf8}\
       &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
       &sessionVariables=${spring.datasource.session-variables:group_concat_max_len=10000}\
+      &connectTimeout=${spring.datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.datasource.socket-timeout:130000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   jackson:
     default-property-inclusion: non_null

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -83,16 +83,20 @@ spring:
       ?useSSL=${spring.datasource.use-ssl:false}\
       &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.datasource.character-encoding:utf8}\
+      &connectTimeout=${spring.datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.datasource.socket-timeout:40000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 20
     initialSize: 4
     maxWait: 10000
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=30)"
 
   http:
     multipart:

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/DataSourceIT.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/repository/DataSourceIT.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -39,6 +40,15 @@ public class DataSourceIT {
             assertThat(rs.getString(1).toLowerCase()).contains("utf8");
             assertThat(rs.getString(2).toLowerCase()).contains("utf8");
             assertThat(rs.getString(3).toLowerCase()).contains("utf8");
+        });
+    }
+
+    @Test(expected = QueryTimeoutException.class)
+    public void itShouldTimeout() {
+        template.query("SELECT SLEEP(3)", rs -> {
+            // if it does get here then the result should not be 0 (success), it should be 1 (failure)
+            // but i don't think it will ever get here
+            assertThat(rs.getInt(1)).isEqualTo(1);
         });
     }
 }

--- a/import-service/src/test/resources/application-test.yml
+++ b/import-service/src/test/resources/application-test.yml
@@ -2,3 +2,5 @@ spring:
   datasource:
     url-schema: warehouse_test
     maxActive: 10
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=2)"
+

--- a/migrate-olap/src/main/resources/application.yml
+++ b/migrate-olap/src/main/resources/application.yml
@@ -91,7 +91,7 @@ spring:
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
-    validationQueryTimeout: 10000
+    validationQueryTimeout: 30000
     driverClassName: com.amazon.redshift.jdbc42.Driver
 
   warehouse_datasource:

--- a/migrate-olap/src/main/resources/application.yml
+++ b/migrate-olap/src/main/resources/application.yml
@@ -64,15 +64,19 @@ spring:
       ?useSSL=${spring.migrate_datasource.use-ssl:false}\
       &useLegacyDatetimeCode=${spring.migrate_datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.migrate_datasource.character-encoding:utf8}\
+      &connectTimeout=${spring.migrate_datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.migrate_datasource.socket-timeout:130000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   # http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-options.html
   # https://jdbc.postgresql.org/documentation/head/connect.html
@@ -81,12 +85,16 @@ spring:
     url: "\
       jdbc:redshift://${spring.olap_datasource.url-server:localhost:5432}/${spring.olap_datasource.url-db:dev}\
       ?ApplicationName=rdw-ingest-migrate-olap\
+      &loginTimeout=${spring.migrate_datasource.connect-timeout:10}\
+      &socketTimeout=${spring.migrate_datasource.socket-timeout:130}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.amazon.redshift.jdbc42.Driver
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   warehouse_datasource:
     url: "\
@@ -94,15 +102,19 @@ spring:
       ?useSSL=${spring.warehouse_datasource.use-ssl:false}\
       &useLegacyDatetimeCode=${spring.warehouse_datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.warehouse_datasource.character-encoding:utf8}\
+      &connectTimeout=${spring.warehouse_datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.warehouse_datasource.socket-timeout:130000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
 logging:
   level:

--- a/migrate-olap/src/main/resources/application.yml
+++ b/migrate-olap/src/main/resources/application.yml
@@ -65,7 +65,7 @@ spring:
       &useLegacyDatetimeCode=${spring.migrate_datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.migrate_datasource.character-encoding:utf8}\
       &connectTimeout=${spring.migrate_datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.migrate_datasource.socket-timeout:130000}\
+      &socketTimeout=${spring.migrate_datasource.socket-timeout:0}\
       "
     username: root
     password:
@@ -76,7 +76,6 @@ spring:
     initialize: false
     maxActive: 10
     initialSize: 4
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   # http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-options.html
   # https://jdbc.postgresql.org/documentation/head/connect.html
@@ -86,7 +85,7 @@ spring:
       jdbc:redshift://${spring.olap_datasource.url-server:localhost:5432}/${spring.olap_datasource.url-db:dev}\
       ?ApplicationName=rdw-ingest-migrate-olap\
       &loginTimeout=${spring.migrate_datasource.connect-timeout:10}\
-      &socketTimeout=${spring.migrate_datasource.socket-timeout:130}\
+      &socketTimeout=${spring.migrate_datasource.socket-timeout:0}\
       "
     username: root
     password:
@@ -94,7 +93,6 @@ spring:
     validationQuery: SELECT 1
     validationQueryTimeout: 10000
     driverClassName: com.amazon.redshift.jdbc42.Driver
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   warehouse_datasource:
     url: "\
@@ -103,7 +101,7 @@ spring:
       &useLegacyDatetimeCode=${spring.warehouse_datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.warehouse_datasource.character-encoding:utf8}\
       &connectTimeout=${spring.warehouse_datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.warehouse_datasource.socket-timeout:130000}\
+      &socketTimeout=${spring.warehouse_datasource.socket-timeout:0}\
       "
     username: root
     password:
@@ -114,7 +112,6 @@ spring:
     initialize: false
     maxActive: 10
     initialSize: 4
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
 logging:
   level:

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -27,15 +27,19 @@ spring:
       &useLegacyDatetimeCode=${spring.reporting_datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.reporting_datasource.character-encoding:utf8}\
       &rewriteBatchedStatements=${spring.reporting_datasource.rewrite-batched-statements:true}\
+      &connectTimeout=${spring.reporting_datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.reporting_datasource.socket-timeout:130000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   warehouse_datasource:
     url: "\
@@ -43,15 +47,19 @@ spring:
       ?useSSL=${spring.warehouse_datasource.use-ssl:false}\
       &useLegacyDatetimeCode=${spring.warehouse_datasource.use-legacy-datetime-code:false}\
       &characterEncoding=${spring.warehouse_datasource.character-encoding:utf8}\
+      &connectTimeout=${spring.warehouse_datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.warehouse_datasource.socket-timeout:130000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   batch:
     job:

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -57,15 +57,19 @@ spring:
       &characterEncoding=${spring.datasource.character-encoding:utf8}\
       &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
       &noAccessToProcedureBodies=${spring.datasource.no-access-to-procedure-bodies:true}\
+      &connectTimeout=${spring.datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.datasource.socket-timeout:40000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=30)"
 
   jackson:
     default-property-inclusion: non_null

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
       &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
       &noAccessToProcedureBodies=${spring.datasource.no-access-to-procedure-bodies:true}\
       &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:40000}\
+      &socketTimeout=${spring.datasource.socket-timeout:130000}\
       "
     username: root
     password:
@@ -69,7 +69,7 @@ spring:
     initialize: false
     maxActive: 10
     initialSize: 4
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=30)"
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=120)"
 
   jackson:
     default-property-inclusion: non_null

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -29,15 +29,19 @@ spring:
       ?useSSL=${spring.datasource.use-ssl:false}\
       &characterEncoding=${spring.datasource.character-encoding:utf8}\
       &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
+      &connectTimeout=${spring.datasource.connect-timeout:10000}\
+      &socketTimeout=${spring.datasource.socket-timeout:40000}\
       "
     username: root
     password:
     testWhileIdle: true
     validationQuery: SELECT 1
+    validationQueryTimeout: 10000
     driverClassName: com.mysql.jdbc.Driver
     initialize: false
     maxActive: 10
     initialSize: 4
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=30)"
 
   jackson:
     default-property-inclusion: non_null


### PR DESCRIPTION
Thoughts when doing this:
* connect and validation timeouts should be short, i chose 10s. Could be lower, what do you think?
* query timeout depends on app, either 30s or 120s
* socket timeout needs to be longer than query timeout (or else query won't be aborted), i added 10s to query timeout