### PR TITLE
resubmit-groups

### DIFF
--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthorityService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/auth/AuthorityService.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * This service knows all about roles, permissions and spring security authorities.
  * Some mixing of concerns here, and the name is a bit misleading - deal with it.
  */
-interface AuthorityService {
+public interface AuthorityService {
 
     /**
      * Extract authorities from roles granted by a tenancy chain.<br/>

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/DefaultImportService.java
@@ -31,15 +31,16 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * Default implementation of ImportService
  */
+@SuppressWarnings("WeakerAccess")
 @Primary
 @Service
 class DefaultImportService implements ImportService {
     protected static final Logger logger = LoggerFactory.getLogger(DefaultImportService.class);
 
-    private static final String ContentTypeProperty = "Content-Type";
-    private static final String ContentLengthProperty = "Content-Length";
-    private static final String UsernameProperty = "username";
-    private static final String TenancyChainProperty = "tenancy-chain";
+    protected static final String ContentTypeProperty = "Content-Type";
+    protected static final String ContentLengthProperty = "Content-Length";
+    protected static final String UsernameProperty = "username";
+    protected static final String TenancyChainProperty = "tenancy-chain";
 
     protected final RdwImportRepository repository;
     protected final ArchiveService archiveService;
@@ -208,7 +209,7 @@ class DefaultImportService implements ImportService {
         return Optional.of(archiveService.readResource(location(rdwImport)));
     }
 
-    private static String location(final RdwImport rdwImport) {
+    protected static String location(final RdwImport rdwImport) {
         return new LocationStrategy.ImportContentLocationStrategy(rdwImport.getContent()).location(rdwImport.getDigest());
     }
 }

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/GroupImportService.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/service/GroupImportService.java
@@ -7,9 +7,14 @@ import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.group.CsvValidationResult;
 import org.opentestsystem.rdw.group.CsvValidationService;
+import org.opentestsystem.rdw.ingest.auth.AuthorityService;
 import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
+import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.opentestsystem.rdw.utils.TenancyChain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,7 +27,9 @@ import java.security.MessageDigest;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Maps.newHashMap;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.opentestsystem.rdw.ingest.auth.Authorities.GroupWritePermission;
@@ -46,14 +53,17 @@ import static org.opentestsystem.rdw.ingest.auth.Authorities.GroupWritePermissio
 class GroupImportService extends DefaultImportService {
 
     private final CsvValidationService validationService;
+    private final AuthorityService authorityService;
 
     @Autowired
     GroupImportService(final RdwImportRepository repository,
                        final ArchiveService archiveService,
                        final ImportSource source,
-                       final CsvValidationService validationService) {
+                       final CsvValidationService validationService,
+                       final AuthorityService authorityService) {
         super(repository, archiveService, source);
         this.validationService = validationService;
+        this.authorityService = authorityService;
     }
 
     @Override
@@ -117,6 +127,46 @@ class GroupImportService extends DefaultImportService {
         return failOrSubmit(result.getKey(), result.getValue(), digest, contentType, validationResults);
     }
 
+    @Override
+    public long resubmitImports(final RdwImportQuery query) {
+        // Group payload is not submitted with the message so we have to override this behavior.
+        // This is further complicated because we need to re-validate the payload using the original
+        // user's credentials (not the credentials of the user triggering the resubmit). It doesn't
+        // handle the situation of that user having new credentials but they can re-upload for that.
+        checkArgument(query != null && !query.isEmpty(), "resubmit requires a non-empty query");
+
+        long count = 0;
+        final List<RdwImport> imports = repository.findBy(query);
+        for (final RdwImport rdwImport : imports) {
+            final String location = location(rdwImport);
+            if (!archiveService.exists(location)) {
+                logger.warn("Unable to resubmit GROUPS import, location not found {}", location);
+                continue;
+            }
+
+            // use tenancy chain archived with the file to recreate the permission scope
+            final Properties properties = archiveService.readProperties(location);
+            final String tenancyChainStr = properties.getProperty(TenancyChainProperty);
+            if (tenancyChainStr == null) {
+                logger.warn("Unable to resubmit GROUPS import, tenancy chain property not found at {}", location);
+                continue;
+            }
+
+            final PermissionScope permissionScope = getGroupWritePermissionScope(tenancyChainStr);
+            final List<CsvValidationResult> validationResults;
+            try (final InputStream is = archiveService.openResource(location)) {
+                validationResults = validationService.validate(is, permissionScope, newHashMap());
+            } catch (final IOException e) {
+                logger.warn("Unable to validate GROUPS location {}, error {}", location, e.getMessage());
+                continue;
+            }
+
+            failOrSubmit(rdwImport, true, rdwImport.getDigest(), rdwImport.getContentType(), validationResults);
+            ++count;
+        }
+        return count;
+    }
+
     // this helper is just here to eliminate duplication
     private RdwImport failOrSubmit(RdwImport rdwImport,
                                    final boolean found,
@@ -149,5 +199,13 @@ class GroupImportService extends DefaultImportService {
         source.submitContent(digest.getBytes(UTF_8), ImportContent.GROUPS, contentType, rdwImport.getId());
 
         return rdwImport;
+    }
+
+    private PermissionScope getGroupWritePermissionScope(final String tenancyChainStr) {
+        final TenancyChain tenancyChain = TenancyChain.fromString(tenancyChainStr);
+        for (final Permission permission : authorityService.getPermissions(tenancyChain)) {
+            if (GroupWritePermission.equals(permission.getId())) return permission.getScope();
+        }
+        return PermissionScope.EMPTY;
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/GroupImportServiceTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/service/GroupImportServiceTest.java
@@ -3,30 +3,43 @@ package org.opentestsystem.rdw.ingest.service;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.archive.ArchiveService;
 import org.opentestsystem.rdw.common.model.ImportContent;
 import org.opentestsystem.rdw.common.model.ImportStatus;
 import org.opentestsystem.rdw.group.CsvValidationResult;
 import org.opentestsystem.rdw.group.CsvValidationService;
+import org.opentestsystem.rdw.ingest.auth.AuthorityService;
 import org.opentestsystem.rdw.ingest.auth.SbacUserDetails;
 import org.opentestsystem.rdw.ingest.auth.SbacUserTest;
 import org.opentestsystem.rdw.ingest.common.model.RdwImport;
+import org.opentestsystem.rdw.ingest.common.model.RdwImportQuery;
 import org.opentestsystem.rdw.ingest.repository.RdwImportRepository;
+import org.opentestsystem.rdw.security.Permission;
+import org.opentestsystem.rdw.security.PermissionScope;
+import org.opentestsystem.rdw.utils.TenancyChain;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
+import java.util.Properties;
 import java.util.StringJoiner;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.auth.Authorities.GroupWritePermission;
+import static org.opentestsystem.rdw.ingest.service.DefaultImportService.TenancyChainProperty;
 
 public class GroupImportServiceTest {
 
@@ -35,6 +48,7 @@ public class GroupImportServiceTest {
     private ImportService service;
     private ImportSource importSource;
     private CsvValidationService validationService;
+    private AuthorityService authorityService;
 
     @Before
     public void createService() {
@@ -47,14 +61,18 @@ public class GroupImportServiceTest {
             final RdwImport rdwImport = invocation.getArgument(0);
             return rdwImport.copy().updated(Instant.now()).build();
         });
+
         archiveService = mock(ArchiveService.class);
+
         importSource = mock(ImportSource.class);
 
         validationService = mock(CsvValidationService.class);
         when(validationService.toFailureMessage(any())).thenAnswer(invocation -> joinMessages(invocation.getArgument(0)));
         when(validationService.toSuccessMessage(any())).thenAnswer(invocation -> joinMessages(invocation.getArgument(0)));
 
-        service = new GroupImportService(repository, archiveService, importSource, validationService);
+        authorityService = mock(AuthorityService.class);
+
+        service = new GroupImportService(repository, archiveService, importSource, validationService, authorityService);
     }
 
     private static String joinMessages(final List<CsvValidationResult> results) {
@@ -117,5 +135,69 @@ public class GroupImportServiceTest {
         // verify archive was called but the message queue was not
         verify(archiveService).writeResource(any(), any(byte[].class), any());
         verifyZeroInteractions(importSource);
+    }
+
+    @Test
+    public void itShouldNotResubmitIfArchiveLocationNotFound() {
+        final RdwImportQuery query = RdwImportQuery.builder().content(ImportContent.GROUPS).build();
+
+        final RdwImport rdwImport = RdwImport.builder()
+                .id(123L)
+                .content(ImportContent.GROUPS)
+                .digest("DEADBEEF")
+                .build();
+        when(repository.findBy(query)).thenReturn(newArrayList(rdwImport));
+        when(archiveService.exists("GROUPS/DE/AD/DEADBEEF")).thenReturn(false);
+        assertThat(service.resubmitImports(query)).isEqualTo(0);
+    }
+
+    @Test
+    public void itShouldNotResubmitIfTenancyChainNotFound() {
+        final RdwImportQuery query = RdwImportQuery.builder().content(ImportContent.GROUPS).build();
+
+        final RdwImport rdwImport = RdwImport.builder()
+                .id(123L)
+                .content(ImportContent.GROUPS)
+                .digest("DEADBEEF")
+                .build();
+        final String location = "GROUPS/DE/AD/DEADBEEF";
+        when(repository.findBy(query)).thenReturn(newArrayList(rdwImport));
+        when(archiveService.exists("GROUPS/DE/AD/DEADBEEF")).thenReturn(true);
+        when(archiveService.readProperties(location)).thenReturn(new Properties());
+        assertThat(service.resubmitImports(query)).isEqualTo(0);
+    }
+
+    @Test
+    public void itShouldUseArchivePropertiesToValidateAndResubmit() {
+        final RdwImportQuery query = RdwImportQuery.builder().content(ImportContent.GROUPS).build();
+
+        final String digest = "DEADBEEF";
+        final String location = "GROUPS/DE/AD/DEADBEEF";
+        final RdwImport rdwImport = RdwImport.builder()
+                .id(123L)
+                .content(ImportContent.GROUPS)
+                .contentType("application/csv")
+                .digest(digest)
+                .build();
+
+        final String tenancyChainStr = "|SBAC|GROUP_ADMIN|CLIENT|SBAC||||||||||||||";
+        final Properties properties = new Properties();
+        properties.put(TenancyChainProperty, tenancyChainStr);
+
+        when(repository.findBy(query)).thenReturn(newArrayList(rdwImport));
+        when(archiveService.exists(location)).thenReturn(true);
+        when(archiveService.readProperties(location)).thenReturn(properties);
+        when(archiveService.openResource(location)).thenReturn(new ByteArrayInputStream("data".getBytes()));
+        when(authorityService.getPermissions(TenancyChain.fromString(tenancyChainStr)))
+                .thenReturn(newHashSet(new Permission(GroupWritePermission, PermissionScope.STATEWIDE)));
+        when(validationService.validate(any(), eq(PermissionScope.STATEWIDE), any())).thenReturn(newArrayList());
+
+        assertThat(service.resubmitImports(query)).isEqualTo(1);
+
+        final ArgumentCaptor<RdwImport> updateCaptor = ArgumentCaptor.forClass(RdwImport.class);
+        verify(repository).update(updateCaptor.capture());
+        assertThat(updateCaptor.getValue().getStatus()).isEqualTo(ImportStatus.ACCEPTED);
+
+        verify(importSource).submitContent(rdwImport.getDigest().getBytes(UTF_8), rdwImport.getContent(), rdwImport.getContentType(), rdwImport.getId());
     }
 }


### PR DESCRIPTION
Found this bug while testing the large student group file upload: the default behavior when resubmitting an import is to read the payload from the archive (S3) and then put it in the message body. But groups don't do that, they just put the digest (archive location) in the message.