### PR TITLE
Task/add performance level attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.2.0-91"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.2.0-92"
 String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.2.0-372"
 
 String dockerPrefix = "smarterbalanced"

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultSubjectTranslationService.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultSubjectTranslationService.java
@@ -93,7 +93,10 @@ class DefaultSubjectTranslationService implements SubjectTranslationService {
         for (final PerformanceLevel performanceLevel : performanceLevels.getPerformanceLevels()) {
             context.push(String.valueOf(performanceLevel.getLevel()));
             context.setMessage("name", performanceLevel.getName());
+            context.setMessage("short-name", isBlank(performanceLevel.getShortName()) ? performanceLevel.getName() : performanceLevel.getShortName());
+            context.setMessage("suffix", performanceLevel.getSuffix() == null ? "" : performanceLevel.getSuffix());
             context.setMessage("color", performanceLevel.getColor());
+
             context.pop();
         }
         context.pop();
@@ -223,7 +226,7 @@ class DefaultSubjectTranslationService implements SubjectTranslationService {
         }
 
         void setMessage(final String lastPath, final String message) {
-            if (isBlank(message)) return;
+            if (null == message) return;
 
             final String messageKey = getMessageKey(lastPath);
             final String existingMessage = existingMessages.remove(messageKey);

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultSubjectTranslationServiceTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultSubjectTranslationServiceTest.java
@@ -115,18 +115,30 @@ public class DefaultSubjectTranslationServiceTest {
         verify(repository).create(eq(SubjectCode), messageCaptor.capture());
         assertThat(messageCaptor.getValue()).contains(
                 entry("subject.mysub.asmt-type.ica.level.1.name", "Level 1"),
+                entry("subject.mysub.asmt-type.ica.level.1.short-name", "Level 1"),
+                entry("subject.mysub.asmt-type.ica.level.1.suffix", ""),
                 entry("subject.mysub.asmt-type.ica.level.1.color", "Color 1"),
                 entry("subject.mysub.asmt-type.ica.level.2.name", "Level 2"),
+                entry("subject.mysub.asmt-type.ica.level.2.short-name", "Short Level 2"),
+                entry("subject.mysub.asmt-type.ica.level.2.suffix", "Suffix"),
                 entry("subject.mysub.asmt-type.ica.level.2.color", "Color 2"),
                 entry("subject.mysub.asmt-type.ica.level.3.name", "Level 3"),
                 entry("subject.mysub.asmt-type.ica.level.3.color", "Color 3"),
                 entry("subject.mysub.asmt-type.ica.claim-score.level.1.name", "Level 1"),
+                entry("subject.mysub.asmt-type.ica.claim-score.level.1.short-name", "Level 1"),
+                entry("subject.mysub.asmt-type.ica.claim-score.level.1.suffix", ""),
                 entry("subject.mysub.asmt-type.ica.claim-score.level.1.color", "Color 1"),
                 entry("subject.mysub.asmt-type.ica.claim-score.level.2.name", "Level 2"),
+                entry("subject.mysub.asmt-type.ica.claim-score.level.2.short-name", "Short Level 2"),
+                entry("subject.mysub.asmt-type.ica.claim-score.level.2.suffix", "Suffix"),
                 entry("subject.mysub.asmt-type.ica.claim-score.level.2.color", "Color 2"),
                 entry("subject.mysub.asmt-type.iab.level.1.name", "Level 1"),
+                entry("subject.mysub.asmt-type.iab.level.1.short-name", "Level 1"),
+                entry("subject.mysub.asmt-type.iab.level.1.suffix", ""),
                 entry("subject.mysub.asmt-type.iab.level.1.color", "Color 1"),
                 entry("subject.mysub.asmt-type.iab.level.2.name", "Level 2"),
+                entry("subject.mysub.asmt-type.iab.level.2.short-name", "Short Level 2"),
+                entry("subject.mysub.asmt-type.iab.level.2.suffix", "Suffix"),
                 entry("subject.mysub.asmt-type.iab.level.2.color", "Color 2")
         );
     }
@@ -242,6 +254,8 @@ public class DefaultSubjectTranslationServiceTest {
             levels.add(PerformanceLevel.builder()
                     .level(i)
                     .name("Level " + i)
+                    .shortName(i == 1 ? null : "Short Level " + i)
+                    .suffix(i == 1 ? null : "Suffix")
                     .color("Color " + i)
                     .build());
         }


### PR DESCRIPTION
Add "shortName" and "suffix" attribute handling to the PerformanceLevel subject element.

This PR defaults a performance level's optional "shortName" text to the "name" text and defaults the optional "suffix" text to an empty string.