### PR TITLE
RP-25, add migrate end-points

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.3.0-104"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-393"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-394"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {
@@ -78,10 +78,11 @@ subprojects {
             dependency 'com.google.code.gson:gson:2.8.5'
             dependency 'com.google.guava:guava:27.0.1-jre'
             dependency 'commons-io:commons-io:2.6'
+            dependency 'mysql:mysql-connector-java:5.1.46'
+            dependency 'net.sf.saxon:Saxon-HE:9.7.0-21'
             dependency 'org.apache.commons:commons-csv:1.6'
             dependency 'org.apache.commons:commons-lang3:3.8.1'
             dependency 'org.slf4j:slf4j-api:1.7.25'
-            dependency 'net.sf.saxon:Saxon-HE:9.7.0-21'
 
             // commonly used test libraries
             dependency 'junit:junit:4.12'

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateEndpoint.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateEndpoint.java
@@ -1,0 +1,104 @@
+package org.opentestsystem.rdw.migrate.common;
+
+import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.Executors;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+/**
+ * {@link Endpoint} to trigger migration and/or re-enable disabled migration.
+ */
+@Component
+@ConfigurationProperties(prefix = "endpoints.migrate")
+public class MigrateEndpoint extends AbstractEndpoint<String> {
+    private static final Logger logger = LoggerFactory.getLogger(MigrateEndpoint.class);
+
+    private final MigrateLifecycle jobRunner;
+    private final MigrateRepository repository;
+
+    public MigrateEndpoint(final MigrateLifecycle jobRunner, final MigrateRepository repository) {
+        super("migrate");
+        this.jobRunner = jobRunner;
+        this.repository = repository;
+    }
+
+    @Override
+    public String invoke() {
+        final StringBuilder builder = new StringBuilder("Migrate: ");
+        builder.append(jobRunner.isRunning() ? "running" : "paused")
+            .append(", ").append(jobRunner.isEnabled() ? "enabled" : "disabled");
+
+        final Migrate lastMigrate = repository.findLast();
+        if (lastMigrate != null) {
+            builder.append(". Last migrate: ").append(lastMigrate.getStatus())
+                   .append(" to ").append(asOffsetDateTime(lastMigrate.getLastAt()));
+
+            if (lastMigrate.getStatus() != MigrateStatus.COMPLETED) {
+                final Instant lastMigratedAt = repository.findLastMigratedAt();
+                if (lastMigratedAt != null) {
+                    builder.append(". Last successful migrate to ").append(asOffsetDateTime(lastMigratedAt));
+                }
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String asOffsetDateTime(final Instant value) {
+        return ISO_LOCAL_DATE_TIME.format(value.atOffset(ZoneOffset.UTC));
+    }
+
+    /**
+     * Trigger migration.
+     *
+     * @return true if migration was triggered, false otherwise
+     */
+    public boolean migrate() {
+        if (!jobRunner.isEnabled()) {
+            logger.info("Ignoring /migrate request since migrate is not enabled");
+            return false;
+        }
+        if (!jobRunner.isRunning()) {
+            logger.info("Ignoring /migrate request since migrate is not running");
+            return false;
+        }
+
+        Executors.newSingleThreadExecutor().execute(jobRunner::run);
+
+        logger.info("Migrate triggered by /migrate request");
+        return true;
+    }
+
+    /**
+     * Enable migration.
+     * <p>
+     * Migration is enabled by updating the FAILED migrate record to ABANDONED state.
+     * </p>
+     *
+     * @return true if migration was re-enabled, false otherwise
+     */
+    public boolean enable() {
+        if (jobRunner.isEnabled()) {
+            logger.info("Ignoring /migrate/enable request since migrate is not disabled");
+            return false;
+        }
+
+        final Migrate migrate = repository.findLast();
+        if (migrate.getStatus() != MigrateStatus.FAILED) {
+            logger.warn("Ignoring /migrate/enable request since last migrate is not FAILED");
+            return false;
+        }
+
+        logger.info("Marking migrate {} as ABANDONED", migrate.getId());
+        repository.updateStatusById(migrate.getId(), MigrateStatus.ABANDONED);
+        return true;
+    }
+}

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateMvcEndpoint.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateMvcEndpoint.java
@@ -1,0 +1,51 @@
+package org.opentestsystem.rdw.migrate.common;
+
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Component
+@ConfigurationProperties(prefix = "endpoints.migrate")
+public class MigrateMvcEndpoint extends EndpointMvcAdapter {
+
+    private final MigrateEndpoint delegate;
+
+    /**
+     * @param delegate the underlying {@link Endpoint} to adapt.
+     */
+    public MigrateMvcEndpoint(final MigrateEndpoint delegate) {
+        super(delegate);
+        this.delegate = delegate;
+    }
+
+    @Override
+    @GetMapping(produces = MediaType.TEXT_PLAIN_VALUE)
+    public Object invoke() {
+        return super.invoke();
+    }
+
+    @PostMapping()
+    @ResponseBody
+    public Object migrate() {
+        if (!getDelegate().isEnabled()) {
+            // Shouldn't happen - MVC endpoint shouldn't be registered when delegate's disabled
+            return getDisabledResponse();
+        }
+        return delegate.migrate();
+    }
+
+    @PostMapping(path = "/enable")
+    @ResponseBody
+    public Object enable() {
+        if (!getDelegate().isEnabled()) {
+            // Shouldn't happen - MVC endpoint shouldn't be registered when delegate's disabled
+            return getDisabledResponse();
+        }
+        return delegate.enable();
+    }
+}

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/repository/JdbcMigrateRepository.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/repository/JdbcMigrateRepository.java
@@ -5,6 +5,7 @@ import org.opentestsystem.rdw.migrate.common.MigrateStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -30,8 +31,8 @@ class JdbcMigrateRepository implements MigrateRepository {
     @Value("${sql.reporting.migrate.updateStatusById}")
     private String updateStatusById;
 
-    @Value("${sql.reporting.migrate.lastStatus}")
-    private String lastMigrateStatus;
+    @Value("${sql.reporting.migrate.findLast}")
+    private String findLast;
 
     private final NamedParameterJdbcTemplate migrateJdbcTemplate;
 
@@ -68,7 +69,7 @@ class JdbcMigrateRepository implements MigrateRepository {
 
     @Override
     public void delete(final long id) {
-        migrateJdbcTemplate.update(delete, new MapSqlParameterSource().addValue("id", id));
+        migrateJdbcTemplate.update(delete, new MapSqlParameterSource("id", id));
     }
 
     @Override
@@ -83,10 +84,30 @@ class JdbcMigrateRepository implements MigrateRepository {
     @Override
     public MigrateStatus findLastStatus() {
         try {
-            return MigrateStatus.fromValue(migrateJdbcTemplate.getJdbcOperations().queryForObject(lastMigrateStatus, Integer.class));
-        } catch (final IncorrectResultSizeDataAccessException | IllegalArgumentException e) {
+            return findLast().getStatus();
+        } catch (final IncorrectResultSizeDataAccessException | IllegalArgumentException | NullPointerException e) {
             // edge cases: no migrate rows, bad data
             return null;
         }
     }
+
+    @Override
+    public Migrate findLast() {
+        try {
+            return migrateJdbcTemplate.queryForObject(findLast, new MapSqlParameterSource(), MigrateRowMapper);
+        } catch (final IncorrectResultSizeDataAccessException e) {
+            return null;
+        }
+    }
+
+    private static final RowMapper<Migrate> MigrateRowMapper = (rs, rowNum) -> Migrate.builder()
+            .id(rs.getLong("id"))
+            .jobId(rs.getLong("job_id"))
+            .status(MigrateStatus.fromValue(rs.getInt("status")))
+            .firstAt(rs.getTimestamp("first_at").toInstant())
+            .lastAt(rs.getTimestamp("last_at").toInstant())
+            .size(rs.getInt("size"))
+            .migrateCodes(rs.getBoolean("migrate_codes"))
+            .migrateEmbargo(rs.getBoolean("migrate_embargo"))
+            .build();
 }

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/repository/MigrateRepository.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/repository/MigrateRepository.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 public interface MigrateRepository {
 
     /**
-     * @return the last migrate import id, null if no successful migrations
+     * @return the timestamp of the last successful migrate, null if no successful migrations
      */
     Instant findLastMigratedAt();
 
@@ -42,4 +42,9 @@ public interface MigrateRepository {
      * @return return status of last migrate, may be null if no rows
      */
     MigrateStatus findLastStatus();
+
+    /**
+     * @return last migrate, may be null
+     */
+    Migrate findLast();
 }

--- a/migrate-common/src/main/resources/application.sql.yml
+++ b/migrate-common/src/main/resources/application.sql.yml
@@ -15,8 +15,9 @@ sql:
         UPDATE migrate SET status = :status
           WHERE id = :id
 
-      lastStatus: >-
-        SELECT status FROM migrate ORDER BY id DESC LIMIT 1
+      findLast: >-
+        SELECT id, job_id, status, first_at, last_at, size, migrate_codes, migrate_embargo
+          FROM migrate ORDER BY id DESC LIMIT 1
 
   warehouse:
     import:

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateEndpointTest.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateEndpointTest.java
@@ -1,0 +1,110 @@
+package org.opentestsystem.rdw.migrate.common;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MigrateEndpointTest {
+
+    private MigrateLifecycle jobRunner;
+    private MigrateRepository repository;
+    private MigrateEndpoint endpoint;
+
+    @Before
+    public void createEndpoint() {
+        jobRunner = mock(MigrateLifecycle.class);
+        repository = mock(MigrateRepository.class);
+        endpoint = new MigrateEndpoint(jobRunner, repository);
+    }
+
+    @Test
+    public void itShouldGetGoodMigrateInfo() {
+        final Migrate lastMigrate = mock(Migrate.class);
+        when(lastMigrate.getStatus()).thenReturn(MigrateStatus.COMPLETED);
+        when(lastMigrate.getLastAt()).thenReturn(Instant.now());
+        when(repository.findLast()).thenReturn(lastMigrate);
+
+        when(jobRunner.isRunning()).thenReturn(true);
+        when(jobRunner.isEnabled()).thenReturn(true);
+
+        assertThat(endpoint.invoke())
+                .contains("running, enabled")
+                .contains("COMPLETED")
+                .doesNotContain("Last successful");
+    }
+
+    @Test
+    public void itShouldBadGoodMigrateInfo() {
+        final Migrate lastMigrate = mock(Migrate.class);
+        when(lastMigrate.getStatus()).thenReturn(MigrateStatus.FAILED);
+        when(lastMigrate.getLastAt()).thenReturn(Instant.now());
+        when(repository.findLast()).thenReturn(lastMigrate);
+        when(repository.findLastMigratedAt()).thenReturn(Instant.now());
+
+        when(jobRunner.isRunning()).thenReturn(true);
+        when(jobRunner.isEnabled()).thenReturn(false);
+
+        assertThat(endpoint.invoke())
+                .contains("running, disabled")
+                .contains("FAILED")
+                .contains("Last successful");
+    }
+
+    @Test
+    public void itShouldNotMigrateIfDisabled() {
+        when(jobRunner.isEnabled()).thenReturn(false);
+        assertThat(endpoint.migrate()).isFalse();
+    }
+
+    @Test
+    public void itShouldNotMigrateIfPaused() {
+        when(jobRunner.isEnabled()).thenReturn(true);
+        when(jobRunner.isRunning()).thenReturn(false);
+        assertThat(endpoint.migrate()).isFalse();
+    }
+
+    @Test
+    public void itShouldMigrate() {
+        when(jobRunner.isEnabled()).thenReturn(true);
+        when(jobRunner.isRunning()).thenReturn(true);
+        assertThat(endpoint.migrate()).isTrue();
+        verify(jobRunner).run();
+    }
+
+    @Test
+    public void itShouldNotEnableIfEnabled() {
+        when(jobRunner.isEnabled()).thenReturn(true);
+        assertThat(endpoint.enable()).isFalse();
+    }
+
+    @Test
+    public void itShouldNotEnableIfLastMigrateIsNotFailed() {
+        when(jobRunner.isEnabled()).thenReturn(false);
+
+        final Migrate lastMigrate = mock(Migrate.class);
+        when(lastMigrate.getStatus()).thenReturn(MigrateStatus.COMPLETED);
+        when(repository.findLast()).thenReturn(lastMigrate);
+
+        assertThat(endpoint.enable()).isFalse();
+    }
+
+    @Test
+    public void itShouldEnable() {
+        when(jobRunner.isEnabled()).thenReturn(false);
+
+        final Migrate lastMigrate = mock(Migrate.class);
+        when(lastMigrate.getId()).thenReturn(42L);
+        when(lastMigrate.getStatus()).thenReturn(MigrateStatus.FAILED);
+        when(repository.findLast()).thenReturn(lastMigrate);
+
+        assertThat(endpoint.enable()).isTrue();
+        verify(repository).updateStatusById(42L, MigrateStatus.ABANDONED);
+    }
+}

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/SimpleMigrateLifecycle.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/SimpleMigrateLifecycle.java
@@ -1,0 +1,41 @@
+package org.opentestsystem.rdw.migrate.common;
+
+/**
+ * This is a simple MigrateLifecycle that can be used to construct MigrateEndpoint.
+ * I'm not quite sure why i can't keep MigrateEndpoint out of the context for
+ * tests in migrate-olap and migrate-reporting but i can't. So this can be used
+ * to fulfill the autowire requirement in tests.
+ */
+public class SimpleMigrateLifecycle implements MigrateLifecycle {
+    private boolean running = true;
+    private boolean enabled = true;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public void enable(final boolean flag) {
+        enabled = flag;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public void start() {
+        running = true;
+    }
+
+    @Override
+    public void stop() {
+        running = false;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/TestAppConfig.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/TestAppConfig.java
@@ -1,13 +1,15 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting;
 
-
 import org.opentestsystem.rdw.ingest.migrate.reporting.repository.DataSourceConfiguration;
 import org.opentestsystem.rdw.ingest.migrate.reporting.step.StagingToReportingStepsConfig;
+import org.opentestsystem.rdw.migrate.common.MigrateLifecycle;
+import org.opentestsystem.rdw.migrate.common.SimpleMigrateLifecycle;
 import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
 import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -27,4 +29,12 @@ import org.springframework.context.annotation.Import;
 })
 @EnableBatchProcessing
 class TestAppConfig {
+
+    /**
+     * This is needed because of MigrateEndpoint being in the application context.
+     */
+    @Bean
+    public MigrateLifecycle simpleMigrateLifecycle() {
+        return new SimpleMigrateLifecycle();
+    }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcReportingMigrateRepositoryIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcReportingMigrateRepositoryIT.java
@@ -99,4 +99,20 @@ public class JdbcReportingMigrateRepositoryIT extends RepositoryIT {
     public void itShouldReturnNullLastStatusIfBadData() {
         assertThat(repository.findLastStatus()).isNull();
     }
+
+    @Sql(statements = "INSERT INTO migrate (id, job_id, status, first_at, last_at) VALUES\n" +
+            "  (-1, -99, -20, '2017-07-18 19:45:33.966000', '2017-07-18 19:45:43.966000');")
+    @Test
+    public void itShouldFindLast() {
+        final Migrate migrate = repository.findLast();
+        assertThat(migrate).isNotNull();
+        assertThat(migrate.getId()).isEqualTo(-1);
+    }
+
+    @Sql(statements = "DELETE FROM migrate")
+    @Test
+    public void itShouldNotFindLast() {
+        final Migrate migrate = repository.findLast();
+        assertThat(migrate).isNull();
+    }
 }


### PR DESCRIPTION
This adds Spring actuator-style end-points to the migrate services to trigger a migrate, see the migrate job status, or re-enable a disabled migrate service.