### PR TITLE
RP-29, RP-30 add target_report handling, including ingest and migrate.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.3.0-104"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-394"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.3.0-105"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-395"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/exam-processor/src/test/resources/PreloadCustomSubject.sql
+++ b/exam-processor/src/test/resources/PreloadCustomSubject.sql
@@ -1,8 +1,8 @@
 
 INSERT INTO subject(id, code, import_id, update_import_id) VALUES (-1, 'Custom', 1, 1);
 
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-  (1, -1, 10, 3, 6);
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+  (1, -1, 10, 3, 6, 0);
 
 INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code, display_order) VALUES
   (-1,  -1, 1, 'Score1', 1) ,

--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -223,13 +223,14 @@ sql:
         subject_asmt_type:
           sql:
             insert: >-
-              INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count)
+              INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report)
                 SELECT DISTINCT
                   ssat.asmt_type_id,
                   ssat.subject_id,
                   ssat.performance_level_count,
                   ssat.performance_level_standard_cutoff,
-                  ssat.claim_score_performance_level_count
+                  ssat.claim_score_performance_level_count,
+                  ssat.target_report
                 FROM staging_subject_asmt_type ssat
                   LEFT JOIN subject_asmt_type rsat ON (rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id)
                 WHERE rsat.asmt_type_id IS NULL;
@@ -239,7 +240,8 @@ sql:
               SET
                 performance_level_count  = ssat.performance_level_count,
                 performance_level_standard_cutoff = ssat.performance_level_standard_cutoff,
-                claim_score_performance_level_count = ssat.claim_score_performance_level_count
+                claim_score_performance_level_count = ssat.claim_score_performance_level_count,
+                target_report = ssat.target_report
               FROM staging_subject_asmt_type ssat
                 JOIN subject_asmt_type rsat ON (rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id);
 

--- a/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -291,6 +291,7 @@ sql:
                 wsat.performance_level_count,
                 wsat.performance_level_standard_cutoff,
                 wsat.claim_score_performance_level_count,
+                wsat.target_report,
                 ? as migrate_id
               FROM subject_asmt_type wsat
                 JOIN subject ws ON ws.id = wsat.subject_id
@@ -300,7 +301,7 @@ sql:
               LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, migrate_id)
+              COPY staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, migrate_id)
                 FROM '${archive.root}/${migrate.aws.location}/subject_asmt_type.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
@@ -316,6 +317,7 @@ sql:
                 wsat.performance_level_count,
                 wsat.performance_level_standard_cutoff,
                 wsat.claim_score_performance_level_count,
+                wsat.target_report,
                 ? as migrate_id
               FROM subject_asmt_type wsat
                 JOIN subject ws ON ws.id = wsat.subject_id
@@ -325,7 +327,7 @@ sql:
               LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, migrate_id)
+              COPY staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, migrate_id)
                 FROM '${archive.root}/${migrate.aws.location}/subject_asmt_type_update.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV

--- a/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
@@ -6,20 +6,20 @@ INSERT INTO subject(id, code, updated, update_import_id, migrate_id) VALUES
   (-2, 'Old',    now(), -99, -99),
   (-3, 'Update', now(), -99, -99);
 
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
 -- NOTE: Because of the life BEFORE configurable subject, some subjects are pre-loaded into the report
---  (1,  1,  4, 3,    3),
---  (1,  2,  4, 3,    3),
---  (2,  1,  3, null, null),
---  (2,  2,  3, null, null),
---  (3,  1,  4, 3,    3),
---  (3,  2,  4, 3,    3),
+--  (1,  1,  4, 3,    3,    false),
+--  (1,  2,  4, 3,    3,    false),
+--  (2,  1,  3, null, null, false),
+--  (2,  2,  3, null, null, false),
+--  (3,  1,  4, 3,    3,    true),
+--  (3,  2,  4, 3,    3,    true),
 
-  (1, -2, 5, 2, 6),
+  (1, -2, 5, 2, 6, false),
    --  to delete
-  (3, -3, 7, 2, 7),
+  (3, -3, 7, 2, 7, true),
    -- updated entry
-  (2, -3, 3, 3, 3);
+  (2, -3, 3, 3, 3, false);
 
 INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code) VALUES
 -- NOTE: Because of the life BEFORE configurable subject, some subjects are pre-loaded into the report

--- a/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
@@ -4,12 +4,12 @@ INSERT INTO staging_subject (id, code, update_import_id, migrate_id, updated) VA
   (-3, 'Update', -99, -99, now());
 
 -- add subjects' related data for the new subjects
-INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, migrate_id) VALUES
-  (1, -1, 10, 3, 6, -99),
+INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, migrate_id) VALUES
+  (1, -1, 10, 3, 6, false, -99),
    -- new entry
-  (1, -3, 8, 2, 7, -99),
+  (1, -3, 8, 2, 7, false, -99),
    -- updated entry
-  (2, -3, 8, 2, 7, -99);
+  (2, -3, 8, 2, 7, false, -99);
 
 INSERT INTO staging_subject_claim_score (id, subject_id, asmt_type_id, code, migrate_id) VALUES
   (-1,  -1, 1, 'Score1', -99),

--- a/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
@@ -16,21 +16,21 @@ UPDATE subject
 WHERE id IN (1,2);
 
 -- add subjects' related data for the new subjects
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
 -- NOTE: Because of the life BEFORE 'configurable subjects' the below two subjects (and the related data) are pre-loaded by default
---  (1,  1,  4, 3,    3),
---  (1,  2,  4, 3,    3),
---  (2,  1,  3, null, null),
---  (2,  2,  3, null, null),
---  (3,  1,  4, 3,    3),
---  (3,  2,  4, 3,    3),
+--  (1,  1,  4, 3,    3,    0),
+--  (1,  2,  4, 3,    3,    0),
+--  (2,  1,  3, null, null, 0),
+--  (2,  2,  3, null, null, 0),
+--  (3,  1,  4, 3,    3,    1),
+--  (3,  2,  4, 3,    3,    1),
 
-  (1, -1, 10, 3, 6),
-  (1, -2, 5, 2, 6),
+  (1, -1, 10, 3, 6, 0),
+  (1, -2, 5, 2, 6, 0),
    -- new entry
-  (1, -3, 8, 2, 7),
+  (1, -3, 8, 2, 7, 0),
    -- updated entry
-  (2, -3, 8, 2, 7);
+  (2, -3, 8, 2, 7, 0);
 
 INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code, display_order, data_order) VALUES
   (-1,  -1, 1, 'Score1',   0, 1),

--- a/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-reporting/src/main/resources/application.staging.to.reporting.sql.yml
@@ -201,13 +201,14 @@ sql:
       subject_asmt_type:
         sql:
           insert: >-
-            INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count)
+            INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report)
               SELECT
                 ssat.asmt_type_id,
                 ssat.subject_id,
                 ssat.performance_level_count,
                 ssat.performance_level_standard_cutoff,
-                ssat.claim_score_performance_level_count
+                ssat.claim_score_performance_level_count,
+                ssat.target_report
               FROM staging_subject_asmt_type ssat
                 LEFT JOIN subject_asmt_type rsat ON (rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id)
               WHERE rsat.subject_id IS NULL;
@@ -218,7 +219,8 @@ sql:
            SET
              rsat.performance_level_count = ssat.performance_level_count,
              rsat.performance_level_standard_cutoff = ssat.performance_level_standard_cutoff,
-             rsat.claim_score_performance_level_count = ssat.claim_score_performance_level_count
+             rsat.claim_score_performance_level_count = ssat.claim_score_performance_level_count,
+             rsat.target_report = ssat.target_report
 
           deleteAsPartOfParentUpdate: >-
             DELETE rsat FROM subject_asmt_type rsat

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -195,14 +195,15 @@ sql:
                 wsat.subject_id,
                 wsat.performance_level_count,
                 wsat.performance_level_standard_cutoff,
-                wsat.claim_score_performance_level_count
+                wsat.claim_score_performance_level_count,
+                wsat.target_report
               FROM subject_asmt_type wsat
                 JOIN subject ws ON ws.id = wsat.subject_id
               WHERE ws.created > :first_at AND ws.created <= :last_at
 
             stagingInsert: >-
-              INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-                 ( :asmt_type_id, :subject_id, :performance_level_count, :performance_level_standard_cutoff, :claim_score_performance_level_count)
+              INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+                 ( :asmt_type_id, :subject_id, :performance_level_count, :performance_level_standard_cutoff, :claim_score_performance_level_count, :target_report)
 
         subject_asmt_type_by_update_import_id:
           sql:
@@ -212,14 +213,15 @@ sql:
                 wsat.subject_id,
                 wsat.performance_level_count,
                 wsat.performance_level_standard_cutoff,
-                wsat.claim_score_performance_level_count
+                wsat.claim_score_performance_level_count,
+                wsat.target_report
               FROM subject_asmt_type wsat
                  JOIN subject ws ON ws.id = wsat.subject_id
               WHERE ws.updated > :first_at AND ws.updated <= :last_at AND ws.updated <> ws.created
 
             stagingInsert: >-
-               INSERT IGNORE INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-                 ( :asmt_type_id, :subject_id, :performance_level_count, :performance_level_standard_cutoff, :claim_score_performance_level_count)
+               INSERT IGNORE INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+                 ( :asmt_type_id, :subject_id, :performance_level_count, :performance_level_standard_cutoff, :claim_score_performance_level_count, :target_report)
 
         # ---------------- subject_claim_score  -----------------------------------------------
         subject_claim_score:

--- a/migrate-reporting/src/test/resources/ReportingSubjectSetup.sql
+++ b/migrate-reporting/src/test/resources/ReportingSubjectSetup.sql
@@ -6,12 +6,12 @@ INSERT INTO subject(id, code, update_import_id, migrate_id) VALUES
     (-3, 'Update', -99, -99);
 
 -- add subjects' related data for the new subjects
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-  (1, -2, 5, 2, 6),
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+  (1, -2, 5, 2, 6, 0),
    --  to delete
-  (3, -3, 7, 2, 7),
+  (3, -3, 7, 2, 7, 1),
    -- updated entry
-  (2, -3, 3, 3, 3);
+  (2, -3, 3, 3, 3, 0);
 
 INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code, display_order, data_order) VALUES
   (-4,  -2, 3, 'Score4', 4, 1),

--- a/migrate-reporting/src/test/resources/StagingEntitiesSetup.sql
+++ b/migrate-reporting/src/test/resources/StagingEntitiesSetup.sql
@@ -4,12 +4,12 @@ INSERT INTO staging_subject(id, code, update_import_id, migrate_id, updated) VAL
     (-3, 'Update', -99, -99, now());
 
 -- add subjects' related data for the new subjects
-INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-  (1, -1, 10, 3, 6),
+INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+  (1, -1, 10, 3, 6, 0),
    -- new entry
-  (1, -3, 8, 2, 7),
+  (1, -3, 8, 2, 7, 0),
    -- updated entry
-  (2, -3, 8, 2, 7);
+  (2, -3, 8, 2, 7, 0);
 
 INSERT INTO staging_subject_claim_score (id, subject_id, asmt_type_id, code, display_order, data_order) VALUES
   (-1,  -1, 1, 'Score1',  0, 1),

--- a/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-reporting/src/test/resources/WarehouseEntitiesSetup.sql
@@ -16,13 +16,13 @@ UPDATE subject
 WHERE id IN (1,2);
 
 -- add subjects' related data for the new subjects
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-  (1, -1, 10, 3, 6),
-  (1, -2, 5, 2, 6),
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+  (1, -1, 10, 3, 6, 0),
+  (1, -2, 5, 2, 6, 0),
    -- new entry
-  (1, -3, 8, 2, 7),
+  (1, -3, 8, 2, 7, 0),
    -- updated entry
-  (2, -3, 8, 2, 7);
+  (2, -3, 8, 2, 7, 0);
 
 INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code, display_order, data_order) VALUES
   (-1,  -1, 1, 'Score1',   0, 1),

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/model/WarehouseSubjectAssessmentType.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/model/WarehouseSubjectAssessmentType.java
@@ -15,6 +15,7 @@ public class WarehouseSubjectAssessmentType {
     private int performanceLevelCount;
     private Integer performanceLevelCutoff;
     private Integer claimScorePerformanceLevelCount;
+    private boolean targetReport;
 
     public String getAssessmentTypeCode() {
         return assessmentTypeCode;
@@ -36,6 +37,10 @@ public class WarehouseSubjectAssessmentType {
         return claimScorePerformanceLevelCount;
     }
 
+    public boolean isTargetReport() {
+        return targetReport;
+    }
+
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) return true;
@@ -46,7 +51,8 @@ public class WarehouseSubjectAssessmentType {
                 && Objects.equals(subjectCode, other.subjectCode)
                 && Objects.equals(performanceLevelCount, other.performanceLevelCount)
                 && Objects.equals(performanceLevelCutoff, other.performanceLevelCutoff)
-                && Objects.equals(claimScorePerformanceLevelCount, other.claimScorePerformanceLevelCount);
+                && Objects.equals(claimScorePerformanceLevelCount, other.claimScorePerformanceLevelCount)
+                && Objects.equals(targetReport, other.targetReport);
     }
 
     @Override
@@ -56,7 +62,8 @@ public class WarehouseSubjectAssessmentType {
                 subjectCode,
                 performanceLevelCount,
                 performanceLevelCutoff,
-                claimScorePerformanceLevelCount);
+                claimScorePerformanceLevelCount,
+                targetReport);
     }
 
     public static Builder builder() {
@@ -69,6 +76,7 @@ public class WarehouseSubjectAssessmentType {
         private int performanceLevelCount;
         private Integer performanceLevelCutoff;
         private Integer claimScorePerformanceLevelCount;
+        private boolean targetReport;
 
         public WarehouseSubjectAssessmentType build() {
             final WarehouseSubjectAssessmentType type = new WarehouseSubjectAssessmentType();
@@ -77,6 +85,7 @@ public class WarehouseSubjectAssessmentType {
             type.performanceLevelCount = performanceLevelCount;
             type.performanceLevelCutoff = performanceLevelCutoff;
             type.claimScorePerformanceLevelCount = claimScorePerformanceLevelCount;
+            type.targetReport = targetReport;
 
             return type;
         }
@@ -87,6 +96,7 @@ public class WarehouseSubjectAssessmentType {
             performanceLevelCount = type.getPerformanceLevelCount();
             performanceLevelCutoff = type.getPerformanceLevelCutoff();
             claimScorePerformanceLevelCount = type.getClaimScorePerformanceLevelCount();
+            targetReport = type.isTargetReport();
 
             return this;
         }
@@ -95,11 +105,10 @@ public class WarehouseSubjectAssessmentType {
             this.assessmentTypeCode = type.getCode();
             this.performanceLevelCount = type.getPerformanceLevels().getPerformanceLevels().size();
             this.performanceLevelCutoff = type.getPerformanceLevels().getStandardCutoff();
-            if (type.getClaimScoring() == null) {
-                return this;
+            this.targetReport = type.isTargetReport();
+            if (type.getClaimScoring() != null) {
+                this.claimScorePerformanceLevelCount = type.getClaimScoring().getPerformanceLevels().getPerformanceLevels().size();
             }
-
-            this.claimScorePerformanceLevelCount = type.getClaimScoring().getPerformanceLevels().getPerformanceLevels().size();
             return this;
         }
 
@@ -125,6 +134,11 @@ public class WarehouseSubjectAssessmentType {
 
         public Builder claimScorePerformanceLevelCount(final Integer claimScorePerformanceLevelCount) {
             this.claimScorePerformanceLevelCount = claimScorePerformanceLevelCount;
+            return this;
+        }
+
+        public Builder targetReport(final boolean targetReport) {
+            this.targetReport = targetReport;
             return this;
         }
     }

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcSubjectAssessmentTypeRepository.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/impl/JdbcSubjectAssessmentTypeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
@@ -66,14 +67,7 @@ class JdbcSubjectAssessmentTypeRepository implements SubjectAssessmentTypeReposi
 
     @Override
     public WarehouseSubjectAssessmentType create(final WarehouseSubjectAssessmentType type) {
-        final int insertCount = template.update(sqlCreateAssessmentType,
-                new MapSqlParameterSource()
-                        .addValue("subject_code", type.getSubjectCode())
-                        .addValue("asmt_type_code", type.getAssessmentTypeCode())
-                        .addValue("performance_level_count", type.getPerformanceLevelCount())
-                        .addValue("performance_level_standard_cutoff", type.getPerformanceLevelCutoff())
-                        .addValue("claim_score_performance_level_count", type.getClaimScorePerformanceLevelCount())
-        );
+        final int insertCount = template.update(sqlCreateAssessmentType, paramsFor(type));
 
         if (insertCount != 1) {
             throw new IllegalArgumentException("Failed to create WarehouseSubjectAssessmentType for subject: " + type.getSubjectCode() + " assessment type: " + type.getAssessmentTypeCode());
@@ -83,15 +77,7 @@ class JdbcSubjectAssessmentTypeRepository implements SubjectAssessmentTypeReposi
 
     @Override
     public WarehouseSubjectAssessmentType update(final WarehouseSubjectAssessmentType type) {
-        final int updated = template.update(sqlUpdateAssessmentType,
-                new MapSqlParameterSource()
-                        .addValue("subject_code", type.getSubjectCode())
-                        .addValue("asmt_type_code", type.getAssessmentTypeCode())
-                        .addValue("performance_level_count", type.getPerformanceLevelCount())
-                        .addValue("performance_level_standard_cutoff", type.getPerformanceLevelCutoff())
-                        .addValue("claim_score_performance_level_count", type.getClaimScorePerformanceLevelCount())
-        );
-
+        final int updated = template.update(sqlUpdateAssessmentType, paramsFor(type));
         if (updated != 1) {
             throw new IllegalArgumentException("Failed to update WarehouseSubjectAssessmentType for subject: " + type.getSubjectCode() + " assessment type: " + type.getAssessmentTypeCode());
         }
@@ -124,6 +110,17 @@ class JdbcSubjectAssessmentTypeRepository implements SubjectAssessmentTypeReposi
                 .performanceLevelCount(row.getInt("performance_level_count"))
                 .performanceLevelCutoff(getNullable(row, row.getInt("performance_level_standard_cutoff")))
                 .claimScorePerformanceLevelCount(getNullable(row, row.getInt("claim_score_performance_level_count")))
+                .targetReport(row.getBoolean("target_report"))
                 .build();
+    }
+
+    private static SqlParameterSource paramsFor(final WarehouseSubjectAssessmentType type) {
+        return new MapSqlParameterSource()
+                .addValue("subject_code", type.getSubjectCode())
+                .addValue("asmt_type_code", type.getAssessmentTypeCode())
+                .addValue("performance_level_count", type.getPerformanceLevelCount())
+                .addValue("performance_level_standard_cutoff", type.getPerformanceLevelCutoff())
+                .addValue("claim_score_performance_level_count", type.getClaimScorePerformanceLevelCount())
+                .addValue("target_report", type.isTargetReport());
     }
 }

--- a/package-processor/src/main/resources/application.sql.yml
+++ b/package-processor/src/main/resources/application.sql.yml
@@ -468,7 +468,8 @@ sql:
           s.code as subject_code,
           sat.performance_level_count,
           sat.performance_level_standard_cutoff,
-          sat.claim_score_performance_level_count
+          sat.claim_score_performance_level_count,
+          sat.target_report
         FROM subject_asmt_type sat
           JOIN asmt_type at ON at.id = sat.asmt_type_id
           JOIN subject s ON s.id = sat.subject_id
@@ -480,20 +481,22 @@ sql:
           s.code as subject_code,
           sat.performance_level_count,
           sat.performance_level_standard_cutoff,
-          sat.claim_score_performance_level_count
+          sat.claim_score_performance_level_count,
+          sat.target_report
         FROM subject_asmt_type sat
           JOIN asmt_type at ON at.id = sat.asmt_type_id
           JOIN subject s ON s.id = sat.subject_id
         WHERE sat.subject_id = :subject_id AND sat.asmt_type_id = :asmt_type_id
 
       insert: >-
-        INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count)
+        INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report)
           SELECT
             asmt_type.id,
             subject.id,
             :performance_level_count,
             :performance_level_standard_cutoff,
-            :claim_score_performance_level_count
+            :claim_score_performance_level_count,
+            :target_report
           FROM subject
             JOIN asmt_type ON asmt_type.code = :asmt_type_code
           WHERE subject.code = :subject_code
@@ -505,7 +508,8 @@ sql:
         SET
           subject_asmt_type.performance_level_count = :performance_level_count,
           subject_asmt_type.performance_level_standard_cutoff = :performance_level_standard_cutoff,
-          subject_asmt_type.claim_score_performance_level_count = :claim_score_performance_level_count
+          subject_asmt_type.claim_score_performance_level_count = :claim_score_performance_level_count,
+          subject_asmt_type.target_report = :target_report
         WHERE subject.code = :subject_code
           AND asmt_type.code = :asmt_type_code
 

--- a/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultSubjectAssessmentTypeServiceTest.java
+++ b/package-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultSubjectAssessmentTypeServiceTest.java
@@ -175,6 +175,7 @@ public class DefaultSubjectAssessmentTypeServiceTest {
 
         return SubjectAssessmentType.builder()
                 .code(code)
+                .targetReport(code.equals("sum"))
                 .performanceLevels(PerformanceLevels.builder()
                         .performanceLevels(levels)
                         .standardCutoff(perfLevels > 3 ? 3 : null)
@@ -202,6 +203,7 @@ public class DefaultSubjectAssessmentTypeServiceTest {
                 .assessmentTypeCode(code)
                 .performanceLevelCount(perfLevels)
                 .performanceLevelCutoff(perfLevels > 3 ? 3 : null)
-                .claimScorePerformanceLevelCount(subPerfLevels > 0 ? subPerfLevels : null);
+                .claimScorePerformanceLevelCount(subPerfLevels > 0 ? subPerfLevels : null)
+                .targetReport(code.equals("sum"));
     }
 }

--- a/package-processor/src/test/resources/LoadTestSubject.sql
+++ b/package-processor/src/test/resources/LoadTestSubject.sql
@@ -2,6 +2,6 @@ INSERT INTO subject (id, code, import_id, update_import_id) VALUES
     (-1, 'test', 1, 1),
     (-2, 'test2', 1, 1);
 
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-  (1, -2, 1, 2, 5),
-  (2, -2, 10, 3, 6);
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+  (1, -2, 1, 2, 5, 0),
+  (2, -2, 10, 3, 6, 0);


### PR DESCRIPTION
Remarkably few code changes but lots of test changes.