### PR TITLE
remove extra languages (and filtering based on display_order)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.3.0-105"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-401"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.3.0-402"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/common/src/main/resources/application.sql.yml
+++ b/common/src/main/resources/application.sql.yml
@@ -7,7 +7,7 @@ sql:
   # JdbcLanguageRepository
   language:
     findIdByCode: >-
-      SELECT id FROM language WHERE (code = LOWER(:code) OR altcode = :code) AND display_order IS NOT NULL
+      SELECT id FROM language WHERE (code = LOWER(:code) OR altcode = :code)
 
   # JdbcImportRepository
   import:

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/common/repository/LanguageRepositoryIT.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/common/repository/LanguageRepositoryIT.java
@@ -22,8 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Sql(statements = {
         "INSERT INTO language (id, code, altcode, display_order, name) VALUES (-99, 'abc', 'a1', 0, 'Language abc');",
         "INSERT INTO language (id, code, altcode, display_order, name) VALUES (-88, 'def', NULL, 1, 'Language def');",
-        "INSERT INTO language (id, code, altcode, display_order, name) VALUES (-55, 'cac', NULL, 2, 'Language cac');",
-        "INSERT INTO language (id, code, altcode, display_order, name) VALUES (-44, 'ggg', NULL, NULL, 'Language ggg');"
+        "INSERT INTO language (id, code, altcode, display_order, name) VALUES (-55, 'cac', NULL, 2, 'Language cac');"
 })
 public class LanguageRepositoryIT {
 
@@ -43,11 +42,6 @@ public class LanguageRepositoryIT {
     @Test(expected = IllegalArgumentException.class)
     public void itShouldThrowExceptionWhenCodeIsUnknown() {
         repository.findIdByCode("zz");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void itShouldNotFindLanguagesWithNoDisplayOrder() {
-        repository.findIdByCode("ggg");
     }
 
     @Test

--- a/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -158,7 +158,7 @@ sql:
               SELECT
                 id,
                 code
-              FROM language WHERE display_order IS NOT NULL
+              FROM language
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/language'
               FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
               LINES TERMINATED BY '\n'

--- a/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-reporting/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -74,7 +74,6 @@ sql:
           sql:
             warehouseRead: >-
               SELECT wl.id, wl.code, wl.altcode, wl.display_order, wl.name FROM language wl
-                WHERE wl.display_order IS NOT NULL
 
             stagingInsert: >-
               INSERT INTO staging_language (id, code, altcode, display_order, name) VALUES


### PR DESCRIPTION
I think having conditional migration like that is going to be problematic: it allows the client to effectively remove a language without violating the db constraints in the warehouse, which will lead to a db constraint violation in reporting ... bad.

I also added a blurb to the RDW documentation about how to tweak languages: https://github.com/SmarterApp/RDW/blob/develop/docs/Runbook.SystemConfiguration.md#language-codes