### PR TITLE
remove propdeps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,11 @@ buildscript {
     repositories {
         jcenter()
         mavenLocal()
-        maven { url 'http://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath("com.bmuschko:gradle-docker-plugin:3.6.2")
         classpath("io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE")
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.18.RELEASE")
-        classpath('org.springframework.build.gradle:propdeps-plugin:0.0.7')
     }
 }
 
@@ -23,7 +21,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-107"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-108"
 String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-411"
 String dockerPrefix = "smarterbalanced"
 
@@ -32,9 +30,6 @@ allprojects {
     version = '1.4.0-SNAPSHOT'
 
     apply plugin: 'idea'
-    apply plugin: 'propdeps'
-    apply plugin: 'propdeps-maven'
-    apply plugin: 'propdeps-idea'
     apply plugin: "com.jfrog.artifactory"
 
     if (project.hasProperty("buildNumber")) {
@@ -98,6 +93,9 @@ subprojects {
     }
 
     dependencies {
+        // handy for creating metadata with @ConfigurationProperties
+        compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
+
         compile 'com.google.guava:guava'
         compile 'org.slf4j:slf4j-api'
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,9 +10,6 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-model'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
 
-    // handy for creating metadata with @ConfigurationProperties
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
-
     // for @NotNull
     compile 'javax.validation:validation-api'
 

--- a/exam-processor/build.gradle
+++ b/exam-processor/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional "org.springframework.boot:spring-boot-configuration-processor"
-
     compile 'org.springframework.boot:spring-boot-starter-aop'
     compile 'org.springframework.boot:spring-boot-starter-cache'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/group-processor/build.gradle
+++ b/group-processor/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
-
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.cloud:spring-cloud-starter-stream-rabbit'
     compile 'org.springframework.cloud:spring-cloud-starter-config'

--- a/import-service/build.gradle
+++ b/import-service/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional "org.springframework.boot:spring-boot-configuration-processor"
-
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.boot:spring-boot-starter-hateoas'
     compile 'org.springframework.boot:spring-boot-starter-web'

--- a/migrate-common/build.gradle
+++ b/migrate-common/build.gradle
@@ -7,9 +7,6 @@ bootRun.enabled = false
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-batch'
 
-    // handy for creating metadata with @ConfigurationProperties
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
-
     compile project(':rdw-ingest-common')
 
     compile 'org.opentestsystem.rdw.common:rdw-common-status'

--- a/migrate-olap/build.gradle
+++ b/migrate-olap/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional "org.springframework.boot:spring-boot-configuration-processor"
-
     compile 'org.springframework.boot:spring-boot-starter-batch'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.cloud:spring-cloud-starter-config'

--- a/migrate-reporting/build.gradle
+++ b/migrate-reporting/build.gradle
@@ -7,9 +7,6 @@ createDockerfile {
 }
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional "org.springframework.boot:spring-boot-configuration-processor"
-
     compile 'org.springframework.boot:spring-boot-starter-batch'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.cloud:spring-cloud-starter-config'

--- a/package-processor/build.gradle
+++ b/package-processor/build.gradle
@@ -3,9 +3,6 @@ import org.gradle.internal.jvm.Jvm
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional 'org.springframework.boot:spring-boot-configuration-processor'
-
     compile 'org.springframework.boot:spring-boot-starter-cache'
     compile 'org.springframework.boot:spring-boot-starter-jdbc'
     compile 'org.springframework.cloud:spring-cloud-starter-stream-rabbit'

--- a/task-service/build.gradle
+++ b/task-service/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    // handy for creating metadata with @ConfigurationProperties
-    optional "org.springframework.boot:spring-boot-configuration-processor"
-
     compile 'org.springframework.cloud:spring-cloud-starter-config'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
 


### PR DESCRIPTION
Similar to change in common: Dave had trouble with the repo for propdeps not being available. Since we don't really use the `optional` and `provided` features, it seems prudent to stop trying to get it. Note that we do pull in the spring boot `spring-boot-configuration-processor` using `optional`, so i switched that to `compileOnly` which is morally equivalent. I also pulled that common dependency into the root build file since every module was repeating it.