### PR TITLE
fix migrate enable to actually enable the job runner 

### DIFF
--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateEndpoint.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateEndpoint.java
@@ -99,6 +99,7 @@ public class MigrateEndpoint extends AbstractEndpoint<String> {
 
         logger.info("Marking migrate {} as ABANDONED", migrate.getId());
         repository.updateStatusById(migrate.getId(), MigrateStatus.ABANDONED);
+        jobRunner.enable(true);
         return true;
     }
 }

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateEndpointTest.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateEndpointTest.java
@@ -41,7 +41,7 @@ public class MigrateEndpointTest {
     }
 
     @Test
-    public void itShouldBadGoodMigrateInfo() {
+    public void itShouldGetBadMigrateInfo() {
         final Migrate lastMigrate = mock(Migrate.class);
         when(lastMigrate.getStatus()).thenReturn(MigrateStatus.FAILED);
         when(lastMigrate.getLastAt()).thenReturn(Instant.now());
@@ -109,5 +109,6 @@ public class MigrateEndpointTest {
 
         assertThat(endpoint.enable()).isTrue();
         verify(repository).updateStatusById(42L, MigrateStatus.ABANDONED);
+        verify(jobRunner).enable(true);
     }
 }


### PR DESCRIPTION
Missed this corner case: after using the actuator end-point to enable migrate, triggering a migrate using the actuator end-point doesn't work. 