### PR TITLE
modifications for configurable subjects for migrate-olap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-109"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-413"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-SNAPSHOT"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
 String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-109"
-String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-SNAPSHOT"
+String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-414"
 String dockerPrefix = "smarterbalanced"
 
 allprojects {

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/step/OlapReportingMigrateStepsConfig.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/step/OlapReportingMigrateStepsConfig.java
@@ -57,7 +57,7 @@ public class OlapReportingMigrateStepsConfig {
             "elas", "ethnicity", "gender", "grade", "language", "military_connected", "school_year");
 
     static final List<String> warehouseEntities = newArrayList(
-            "subject", "target", "subject_score", "subject_asmt_type",
+            "subject", "target", "subject_score", "subject_asmt_type", "subject_asmt_scoring",
             "asmt", "asmt_target_exclusion", "asmt_target",
             "district_group", "school_group", "school", "district",
             "student", "student_ethnicity",
@@ -110,8 +110,8 @@ public class OlapReportingMigrateStepsConfig {
                 .addNext("subject", "insert")
                 .addNext("target", "deleteAsPartOfParentUpdate")
                 .addNext("target", "insert")
-                .addNext("subject_claim_score", "deleteAsPartOfParentUpdate")
-                .addNext("subject_claim_score", "insert")
+                .addNext("subject_score", "deleteAsPartOfParentUpdate")
+                .addNext("subject_score", "insert")
                 .addNext("subject_asmt_type", "deleteAsPartOfParentUpdate")
                 .addNext("subject_asmt_type", "update")
                 .addNext("subject_asmt_type", "insert");

--- a/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
+++ b/migrate-olap/src/main/resources/application.staging.to.reporting.sql.yml
@@ -243,51 +243,61 @@ sql:
               WHERE ss.id = target.subject_id AND
                 NOT EXISTS(SELECT 1 FROM staging_target st WHERE st.id = target.id AND st.subject_id = ss.id)
 
-      # ------------ subject_claim_score -----------------------------------------------------------------------
-        subject_claim_score:
+      # ------------ subject_score -----------------------------------------------------------------------
+        subject_score:
           sql:
             insert: >-
-              INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code)
+              INSERT INTO subject_score (id, subject_id, asmt_type_id, score_type_id, code)
                 SELECT DISTINCT
                   sscs.id,
                   sscs.subject_id,
                   sscs.asmt_type_id,
+                  sscs.score_type_id,
                   sscs.code
-                FROM staging_subject_claim_score sscs
-                  LEFT JOIN subject_claim_score rscs ON rscs.id = sscs.id
+                FROM staging_subject_score sscs
+                  LEFT JOIN subject_score rscs ON rscs.id = sscs.id
                 WHERE rscs.id IS NULL;
 
             deleteAsPartOfParentUpdate: >-
-              DELETE FROM subject_claim_score
+              DELETE FROM subject_score
                 USING staging_subject ss
-              WHERE ss.id = subject_claim_score.subject_id AND
-                NOT EXISTS(SELECT 1 FROM staging_subject_claim_score sscs WHERE sscs.id = subject_claim_score.id AND sscs.subject_id = ss.id)
+              WHERE ss.id = subject_score.subject_id AND
+                NOT EXISTS(SELECT 1 FROM staging_subject_score sscs WHERE sscs.id = subject_score.id AND sscs.subject_id = ss.id)
 
-      # ------------ subject_asmt_type -----------------------------------------------------------------------
+        # ------------ subject_asmt_type -----------------------------------------------------------------------
+        # This has the subject_asmt_scoring denormalized into it.
         subject_asmt_type:
           sql:
             insert: >-
-              INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report)
+              INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, alt_score_performance_level_count, claim_score_performance_level_count, target_report)
                 SELECT DISTINCT
                   ssat.asmt_type_id,
                   ssat.subject_id,
-                  ssat.performance_level_count,
-                  ssat.performance_level_standard_cutoff,
-                  ssat.claim_score_performance_level_count,
+                  ssas1.performance_level_count,
+                  ssas1.performance_level_standard_cutoff,
+                  ssas2.performance_level_count AS alt_score_performance_level_count,
+                  ssas3.performance_level_count AS claim_score_performance_level_count,
                   ssat.target_report
                 FROM staging_subject_asmt_type ssat
-                  LEFT JOIN subject_asmt_type rsat ON (rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id)
+                  LEFT JOIN staging_subject_asmt_scoring ssas1 ON ssas1.subject_id = ssat.subject_id AND ssas1.asmt_type_id = ssat.asmt_type_id AND ssas1.score_type_id=1
+                  LEFT JOIN staging_subject_asmt_scoring ssas2 ON ssas2.subject_id = ssat.subject_id AND ssas2.asmt_type_id = ssat.asmt_type_id AND ssas2.score_type_id=2
+                  LEFT JOIN staging_subject_asmt_scoring ssas3 ON ssas3.subject_id = ssat.subject_id AND ssas3.asmt_type_id = ssat.asmt_type_id AND ssas3.score_type_id=3
+                  LEFT JOIN subject_asmt_type rsat ON rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id
                 WHERE rsat.asmt_type_id IS NULL;
 
             update: >-
               UPDATE subject_asmt_type
               SET
-                performance_level_count  = ssat.performance_level_count,
-                performance_level_standard_cutoff = ssat.performance_level_standard_cutoff,
-                claim_score_performance_level_count = ssat.claim_score_performance_level_count,
+                performance_level_count  = ssas1.performance_level_count,
+                performance_level_standard_cutoff = ssas1.performance_level_standard_cutoff,
+                alt_score_performance_level_count = ssas2.performance_level_count,
+                claim_score_performance_level_count = ssas3.performance_level_count,
                 target_report = ssat.target_report
               FROM staging_subject_asmt_type ssat
-                JOIN subject_asmt_type rsat ON (rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id);
+                LEFT JOIN staging_subject_asmt_scoring ssas1 ON ssas1.subject_id = ssat.subject_id AND ssas1.asmt_type_id = ssat.asmt_type_id AND ssas1.score_type_id=1
+                LEFT JOIN staging_subject_asmt_scoring ssas2 ON ssas2.subject_id = ssat.subject_id AND ssas2.asmt_type_id = ssat.asmt_type_id AND ssas2.score_type_id=2
+                LEFT JOIN staging_subject_asmt_scoring ssas3 ON ssas3.subject_id = ssat.subject_id AND ssas3.asmt_type_id = ssat.asmt_type_id AND ssas3.score_type_id=3
+                JOIN subject_asmt_type rsat ON rsat.subject_id = ssat.subject_id AND rsat.asmt_type_id = ssat.asmt_type_id;
 
             deleteAsPartOfParentUpdate: >-
               DELETE FROM subject_asmt_type
@@ -350,7 +360,7 @@ sql:
                 USING staging_student ss
               WHERE ss.id = student_ethnicity.student_id AND ss.deleted = 1;
 
-      # ------------ asmt -----------------------------------------------------------------------
+        # ------------ asmt -----------------------------------------------------------------------
         asmt:
           sql:
             insert: >-
@@ -690,36 +700,17 @@ sql:
                 USING staging_exam se
               WHERE se.id = exam.id and se.deleted = 1;
 
-      # ------------ exam_claim_score -----------------------------------------------------------------------
+        # ------------ exam_claim_score -----------------------------------------------------------------------
+        # Aggregate reporting doesn't deal with alt scores so the exam scores are just CLAIMs for now.
+        # That's why the table has not yet been renamed to exam_score.
+        # And that's why "AND ss.score_type_id=3" is there to filter to just CLAIM scores.
         exam_claim_score:
           sql:
             insert: >-
-              INSERT INTO exam_claim_score (
-                id,
-                exam_id,
-                subject_claim_score_id,
-                asmt_id,
-                student_id,
-                school_year,
-                category,
-                completed_at,
-                updated,
-                update_import_id,
-                migrate_id
-                )
-                SELECT DISTINCT
-                  scs.id,
-                  scs.exam_id,
-                  scs.subject_claim_score_id,
-                  se.asmt_id,
-                  se.student_id,
-                  se.school_year,
-                  scs.category,
-                  se.completed_at,
-                  se.updated,
-                  se.update_import_id,
-                  se.migrate_id
-                FROM staging_exam_claim_score scs
+              INSERT INTO exam_claim_score (id, exam_id, subject_claim_score_id, asmt_id, student_id, school_year, category, completed_at, updated, update_import_id, migrate_id)
+                SELECT DISTINCT scs.id, scs.exam_id, scs.subject_score_id AS subject_claim_score_id, se.asmt_id, se.student_id, se.school_year, scs.performance_level AS category, se.completed_at, se.updated, se.update_import_id, se.migrate_id
+                FROM staging_exam_score scs
+                  JOIN subject_score ss ON ss.id = scs.subject_score_id AND ss.score_type_id = 3
                   JOIN staging_exam se ON se.id = scs.exam_id
                   LEFT JOIN exam_claim_score e ON e.student_id = se.student_id and e.asmt_id = se.asmt_id and e.school_year = se.school_year
                 WHERE se.type_id IN (1, 3) AND se.latest = true AND e.exam_id IS NULL;

--- a/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
+++ b/migrate-olap/src/main/resources/application.warehouse.to.staging.sql.yml
@@ -12,8 +12,9 @@ sql:
       - delete from staging_military_connected
       - delete from staging_school_year
       - delete from staging_subject
-      - delete from staging_subject_claim_score
+      - delete from staging_subject_score
       - delete from staging_subject_asmt_type
+      - delete from staging_subject_asmt_scoring
       - delete from staging_target
       - delete from staging_school
       - delete from staging_district
@@ -27,7 +28,7 @@ sql:
       - delete from staging_asmt_target
       - delete from staging_asmt_target_exclusion
       - delete from staging_exam
-      - delete from staging_exam_claim_score
+      - delete from staging_exam_score
       - delete from staging_exam_target_score
 
     entities:
@@ -225,8 +226,7 @@ sql:
               FROM subject ws
                 WHERE ws.created > ? AND ws.created <= ?
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-                             LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_subject(
@@ -254,8 +254,7 @@ sql:
               FROM subject ws
               WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_update'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-                             LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_subject(
@@ -323,30 +322,19 @@ sql:
               DELIMITER ','
               COMPUPDATE OFF
 
-        # ------------ subject asmt type  ---------------------------------------------------------------------------------------
+        # ------------ subject_asmt_type  ---------------------------------------------------------------------------------------
         subject_asmt_type:
           sql:
-            # TODO - deal with subject_asmt_scoring and get rid of joins here
             warehouseRead: >-
-              SELECT
-                wsat.asmt_type_id,
-                wsat.subject_id,
-                wsas1.performance_level_count,
-                wsas1.performance_level_standard_cutoff,
-                wsas3.performance_level_count AS claim_score_performance_level_count,
-                wsat.target_report,
-                ? as migrate_id
+              SELECT wsat.subject_id, wsat.asmt_type_id, wsat.target_report, ? as migrate_id
               FROM subject_asmt_type wsat
                 JOIN subject ws ON ws.id = wsat.subject_id
-                LEFT JOIN subject_asmt_scoring wsas1 ON wsas1.subject_id = wsat.subject_id AND wsas1.asmt_type_id = wsat.asmt_type_id AND wsas1.score_type_id=1
-                LEFT JOIN subject_asmt_scoring wsas3 ON wsas3.subject_id = wsat.subject_id AND wsas3.asmt_type_id = wsat.asmt_type_id AND wsas3.score_type_id=3
               WHERE ws.created > ? AND ws.created <= ?
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_asmt_type'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-              LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, migrate_id)
+              COPY staging_subject_asmt_type (subject_id, asmt_type_id, target_report, migrate_id)
                 FROM '${archive.root}/${migrate.aws.location}/subject_asmt_type.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
@@ -355,28 +343,54 @@ sql:
 
         subject_asmt_type_update:
           sql:
-            # TODO - deal with subject_asmt_scoring and get rid of joins here
             warehouseRead: >-
-              SELECT
-                wsat.asmt_type_id,
-                wsat.subject_id,
-                wsas1.performance_level_count,
-                wsas1.performance_level_standard_cutoff,
-                wsas3.performance_level_count AS claim_score_performance_level_count,
-                wsat.target_report,
-                ? as migrate_id
+              SELECT wsat.asmt_type_id, wsat.subject_id, wsat.target_report, ? as migrate_id
               FROM subject_asmt_type wsat
                 JOIN subject ws ON ws.id = wsat.subject_id
-                LEFT JOIN subject_asmt_scoring wsas1 ON wsas1.subject_id = wsat.subject_id AND wsas1.asmt_type_id = wsat.asmt_type_id AND wsas1.score_type_id=1
-                LEFT JOIN subject_asmt_scoring wsas3 ON wsas3.subject_id = wsat.subject_id AND wsas3.asmt_type_id = wsat.asmt_type_id AND wsas3.score_type_id=3
               WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_asmt_type_update'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-              LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, migrate_id)
+              COPY staging_subject_asmt_type (subject_id, asmt_type_id, target_report, migrate_id)
                 FROM '${archive.root}/${migrate.aws.location}/subject_asmt_type_update.part_00000'
+              CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
+              FORMAT AS CSV
+              DELIMITER ','
+              COMPUPDATE OFF
+
+        # ------------ subject_asmt_scoring  ---------------------------------------------------------------------------------------
+        subject_asmt_scoring:
+          sql:
+            warehouseRead: >-
+              SELECT wsas.subject_id, wsas.asmt_type_id, wsas.score_type_id, wsas.min_score, wsas.max_score, wsas.performance_level_count, wsas.performance_level_standard_cutoff, ? as migrate_id
+              FROM subject_asmt_scoring wsas
+                JOIN subject ws ON ws.id = wsas.subject_id
+              WHERE ws.created > ? AND ws.created <= ?
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_asmt_scoring'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
+
+            stagingInsert: >-
+              COPY staging_subject_asmt_scoring (subject_id, asmt_type_id, score_type_id, min_score, max_score, performance_level_count, performance_level_standard_cutoff, migrate_id)
+                FROM '${archive.root}/${migrate.aws.location}/subject_asmt_scoring.part_00000'
+              CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
+              FORMAT AS CSV
+              DELIMITER ','
+              COMPUPDATE OFF
+
+        subject_asmt_scoring_update:
+          sql:
+            warehouseRead: >-
+              SELECT wsas.subject_id, wsas.asmt_type_id, wsas.score_type_id, wsas.min_score, wsas.max_score, wsas.performance_level_count, wsas.performance_level_standard_cutoff, ? as migrate_id
+              FROM subject_asmt_scoring wsas
+                JOIN subject ws ON ws.id = wsas.subject_id
+              WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_asmt_scoring_update'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
+
+            stagingInsert: >-
+              COPY staging_subject_asmt_scoring (subject_id, asmt_type_id, score_type_id, min_score, max_score, performance_level_count, performance_level_standard_cutoff, migrate_id)
+                FROM '${archive.root}/${migrate.aws.location}/subject_asmt_scoring_update.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
               DELIMITER ','
@@ -385,25 +399,24 @@ sql:
         # ------------ subject_score ---------------------------------------------------------------------------
         subject_score:
           sql:
-            # TODO - deal with score_type_id and remove "AND score_type_id=3" which gets just CLAIM entries
             warehouseRead: >-
               SELECT
-                wscs.id,
-                wscs.subject_id,
-                wscs.asmt_type_id,
-                wscs.code,
+                wss.id,
+                wss.subject_id,
+                wss.asmt_type_id,
+                wss.score_type_id,
+                wss.code,
                 ? as migrate_id
-              FROM subject_score wscs
-                JOIN subject ws ON ws.id = wscs.subject_id
+              FROM subject_score wss
+                JOIN subject ws ON ws.id = wss.subject_id
               WHERE ws.created > ? AND ws.created <= ?
-                AND wscs.score_type_id=3
-              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_claim_score'
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_score'
               FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
               LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_subject_claim_score (id, subject_id, asmt_type_id, code, migrate_id)
-                FROM '${archive.root}/${migrate.aws.location}/subject_claim_score.part_00000'
+              COPY staging_subject_score (id, subject_id, asmt_type_id, score_type_id, code, migrate_id)
+                FROM '${archive.root}/${migrate.aws.location}/subject_score.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
               DELIMITER ','
@@ -411,25 +424,24 @@ sql:
 
         subject_score_update:
           sql:
-            # TODO - deal with score_type_id and remove "AND score_type_id=3" which gets just CLAIM entries
             warehouseRead: >-
               SELECT
-                wscs.id,
-                wscs.subject_id,
-                wscs.asmt_type_id,
-                wscs.code,
+                wss.id,
+                wss.subject_id,
+                wss.asmt_type_id,
+                wss.score_type_id,
+                wss.code,
                 ? as migrate_id
-              FROM subject_score wscs
-                JOIN subject ws ON ws.id = wscs.subject_id
+              FROM subject_score wss
+                JOIN subject ws ON ws.id = wss.subject_id
               WHERE ws.updated > ? AND ws.updated <= ? AND ws.updated <> ws.created
-                AND wscs.score_type_id=3
-              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_claim_score_update'
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/subject_score_update'
               FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
               LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_subject_claim_score (id, subject_id, asmt_type_id, code, migrate_id)
-                FROM '${archive.root}/${migrate.aws.location}/subject_claim_score_update.part_00000'
+              COPY staging_subject_score (id, subject_id, asmt_type_id, score_type_id, code, migrate_id)
+                FROM '${archive.root}/${migrate.aws.location}/subject_score_update.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
               DELIMITER ','
@@ -549,10 +561,10 @@ sql:
               DELIMITER ','
               COMPUPDATE OFF
 
-        # ------------ asmt  -------------------------------------------------------------------
+        # ------------ asmt -------------------------------------------------------------------
+        # NOTE: "AND was.subject_score_id IS NULL" selects just the OVERALL score info
         asmt:
           sql:
-            # TODO - deal with olap reporting changes and remove "AND was.subject_score_id IS NULL"
             warehouseRead: >-
               SELECT
                 wa.id,
@@ -573,12 +585,10 @@ sql:
                 wa.updated,
                 wa.update_import_id,
                 ? as migrate_id
-              FROM asmt wa JOIN asmt_score was ON wa.id = was.asmt_id
-                AND was.subject_score_id IS NULL
+              FROM asmt wa JOIN asmt_score was ON wa.id = was.asmt_id AND was.subject_score_id IS NULL
               WHERE wa.created > ? AND wa.created <= ?
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/asmt'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-                             LINES TERMINATED BY '\n'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
               COPY staging_asmt(
@@ -609,7 +619,6 @@ sql:
 
         asmt_update:
           sql:
-            # TODO - deal with olap reporting changes and remove "AND was.subject_score_id IS NULL"
             warehouseRead: >-
               SELECT
                 wa.id,
@@ -630,8 +639,7 @@ sql:
                 wa.updated,
                 wa.update_import_id,
                 ? as migrate_id
-              FROM asmt wa JOIN asmt_score was ON wa.id = was.asmt_id
-                AND was.subject_score_id IS NULL
+              FROM asmt wa JOIN asmt_score was ON wa.id = was.asmt_id AND was.subject_score_id IS NULL
               WHERE wa.updated > ? AND wa.updated <= ? AND wa.updated <> wa.created
               INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/asmt_update'
               FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
@@ -1187,26 +1195,25 @@ sql:
               SELECT
                 ecs.id,
                 ecs.exam_id,
-                ecs.subject_score_id AS subject_claim_score_id,
-                ecs.performance_level AS category,
+                ecs.subject_score_id,
+                ecs.performance_level,
                 ? as migrate_id
               FROM exam_score ecs
                 JOIN exam we ON we.id = ecs.exam_id
                WHERE we.created > ? AND we.deleted = 0 AND we.created <= ?
                 AND we.scale_score IS NOT NULL AND we.scale_score_std_err IS NOT NULL AND we.performance_level IS NOT NULL
                 AND ecs.performance_level IS NOT NULL
-              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_claim_score'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-              LINES TERMINATED BY '\n'
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_score'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_exam_claim_score(
+              COPY staging_exam_score(
                 id,
                 exam_id,
-                subject_claim_score_id,
-                category,
+                subject_score_id,
+                performance_level,
                 migrate_id)
-              FROM '${archive.root}/${migrate.aws.location}/exam_claim_score.part_00000'
+              FROM '${archive.root}/${migrate.aws.location}/exam_score.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
               DELIMITER ','
@@ -1218,34 +1225,33 @@ sql:
               SELECT
                 ecs.id,
                 ecs.exam_id,
-                ecs.subject_score_id AS subject_claim_score_id,
-                ecs.performance_level AS category,
+                ecs.subject_score_id,
+                ecs.performance_level,
                 ? as migrate_id
               FROM exam_score ecs
                 JOIN exam we ON we.id = ecs.exam_id
               WHERE we.updated > ? AND we.deleted = 0 AND we.updated <= ? AND we.updated <> we.created
                 AND we.scale_score IS NOT NULL AND we.scale_score_std_err IS NOT NULL AND we.performance_level IS NOT NULL
                 AND ecs.performance_level IS NOT NULL
-              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_claim_score_update'
-              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-              LINES TERMINATED BY '\n'
+              INTO OUTFILE S3 '${archive.root}/${migrate.aws.location}/exam_score_update'
+              FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n'
 
             stagingInsert: >-
-              COPY staging_exam_claim_score(
+              COPY staging_exam_score(
                 id,
                 exam_id,
-                subject_claim_score_id,
-                category,
+                subject_score_id,
+                performance_level,
                 migrate_id)
-              FROM '${archive.root}/${migrate.aws.location}/exam_claim_score_update.part_00000'
+              FROM '${archive.root}/${migrate.aws.location}/exam_score_update.part_00000'
               CREDENTIALS 'aws_iam_role=${migrate.aws.redshift.role}'
               FORMAT AS CSV
               DELIMITER ','
               COMPUPDATE OFF
 
- # ------------ exam_target_score  -------------------------------------------------------------------
-       # Only Summative target scores are included
-       # For Smarter Balanced Math, only the Concepts and Procedures targets are included
+        # ------------ exam_target_score  -------------------------------------------------------------------
+        # Only Summative target scores are included
+        # For Smarter Balanced Math, only the Concepts and Procedures targets are included
         exam_target_score:
           sql:
             warehouseRead: >-

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
@@ -155,10 +155,10 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_asmt_type", -1, "subject_id = -3 and asmt_type_id = 2 and performance_level_count = 3"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_asmt_type", 1, "subject_id = -3 and asmt_type_id = 2 and performance_level_count = 8"));
 
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", 0, "subject_id in(-2)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", -1, "subject_id = -3 and id in (-60)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", 0, "subject_id = -3 and id in (-15)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", 1, "subject_id = -3 and id in (-16)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", 0, "subject_id in(-2)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", -1, "subject_id = -3 and id in (-60)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", 0, "subject_id = -3 and id in (-15)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", 1, "subject_id = -3 and id in (-16)"));
 
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "target", 3, "id in ( -2, -3, -4, -68, -69)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "target", 1, "id in (-67)"));

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEntitiesStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEntitiesStepRST.java
@@ -77,8 +77,8 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
         // exam with id -88 is deleted, -86 has out of range 'created' and 'updated'
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam", 6, "id in (-88, -87, -85, -68, -84, -83)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam", 0, "id in (-86, -10, -11, -12, -15, -16, -17)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_claim_score", 3, "exam_id in (-268, -87, -85)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_claim_score", 0, "exam_id in (-88, -86, -6, -7, -8, -9)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_score", 3, "exam_id in (-268, -87, -85)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_score", 0, "exam_id in (-88, -86, -6, -7, -8, -9)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_target_score", 8, "exam_id in (-311)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_target_score", 1, "exam_id in (-209)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_target_score", 0, "exam_id not in (-311, -209)"));
@@ -113,9 +113,9 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject", 1, "id = -3"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject", 0, "id = -2"));
 
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_claim_score", 3, "subject_id = -1"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_claim_score", 3, "subject_id = -3"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_claim_score", 0, "subject_id = -2"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_score", 3, "subject_id = -1"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_score", 3, "subject_id = -3"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_score", 0, "subject_id = -2"));
 
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_asmt_type", 1, "subject_id = -1"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_asmt_type", 2, "subject_id = -3"));
@@ -140,7 +140,8 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
         launchStep(extractEntitiesStep);
 
         for (final String table : warehouseEntities) {
-            assertThat(archiveService.exists(location + "/" + tableNameToFileName(table) + ".part_00000")).isTrue();
+            final String location = this.location + "/" + tableNameToFileName(table) + ".part_00000";
+            assertThat(archiveService.exists(location)).as(location).isTrue();
         }
 
         launchStep(loadEntitiesToStagingStep);
@@ -163,7 +164,7 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
         // Collect counts of rows in each staging table before the step call and the expected change.
         final List<TableTestCountHelper> tableTestCounts = newArrayList();
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam", 0, "id in (-88, -87, -86, -85)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_claim_score", 0, "exam_id in (-268, -88, -87, -86, -85, -6, -7, -8, -9)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_score", 0, "exam_id in (-268, -88, -87, -86, -85, -6, -7, -8, -9)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_exam_target_score", 0, "exam_id < 0"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_student", 0, "id in (-89, -88, -87, -86, -33, -11)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_student_ethnicity", 0, "student_id in (-89, -88, -87, -86, -33, -11)"));
@@ -173,7 +174,7 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_asmt_target", 0, "asmt_id < 0"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_asmt_target_exclusion", 0, "asmt_id < 0"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject", 0, "1=1"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_claim_score", 0, "1=1"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_subject_score", 0, "1=1"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "staging_target", 0, "1=1"));
 
         getStepExecutionContext().put(ExecutionParams.migrate,
@@ -188,7 +189,8 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
 
         //note that empty files are still generated
         for (final String table : warehouseEntities) {
-            assertThat(archiveService.exists(location + "/" + tableNameToFileName(table) + ".part_00000")).isTrue();
+            final String location = this.location + "/" + tableNameToFileName(table) + ".part_00000";
+            assertThat(archiveService.exists(location)).as(location).isTrue();
         }
 
         launchStep(loadEntitiesToStagingStep);
@@ -260,8 +262,6 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
         if (tableName.equals("school_group")) return "schgroup";
         if (tableName.equals("district_group")) return "dstrgroup";
         if (tableName.equals("asmt_target_exclusion")) return "exclusion_asmt_target";
-        if (tableName.equals("subject_score")) return "subject_claim_score";
-        if (tableName.equals("exam_score")) return "exam_claim_score";
         return tableName;
     }
 }

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/TruncateStageStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/TruncateStageStepRST.java
@@ -53,10 +53,7 @@ public class TruncateStageStepRST extends MigrateStepRST {
         assertThat(olapJdbcTemplate.getJdbcOperations().queryForObject("SELECT COUNT(0) FROM staging_state_embargo", Integer.class)).isZero();
     }
 
-    // TODO - once/if staging tables are updated we can clean this up
     private static String toStagingTableName(final String entity) {
-        if (entity.equals("subject_score")) return "staging_subject_claim_score";
-        else if (entity.equals("exam_score")) return "staging_exam_claim_score";
         return "staging_" + entity;
     }
 }

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertSubjectsStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertSubjectsStepRST.java
@@ -43,10 +43,10 @@ public class UpsertSubjectsStepRST extends MigrateStepRST {
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_asmt_type", -1, "subject_id = -3 and asmt_type_id = 2 and performance_level_count = 3"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_asmt_type", 1, "subject_id = -3 and asmt_type_id = 2 and performance_level_count = 8"));
 
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", 0, "subject_id in(-2)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", -1, "subject_id = -3 and id in (-60)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", 0, "subject_id = -3 and id in (-15)"));
-        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_claim_score", 1, "subject_id = -3 and id in (-16)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", 0, "subject_id in(-2)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", -1, "subject_id = -3 and id in (-60)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", 0, "subject_id = -3 and id in (-15)"));
+        tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "subject_score", 1, "subject_id = -3 and id in (-16)"));
 
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "target", 4, "id in (-1, -2, -3, -4, -68, -69)"));
         tableTestCounts.add(new TableTestCountHelper(olapJdbcTemplate.getJdbcOperations(), "target", 1, "id in (-67)"));

--- a/migrate-olap/src/test/resources/OlapAndStagingEntitiesTeardown.sql
+++ b/migrate-olap/src/test/resources/OlapAndStagingEntitiesTeardown.sql
@@ -1,7 +1,7 @@
 -- ----------------------------------------------------------------------------------------------------------------
 -- CLEAN UP staging
 -- ------------------------------------------  Exams --------------------------------------------------------------
-DELETE FROM staging_exam_claim_score where exam_id < 0;
+DELETE FROM staging_exam_score where exam_id < 0;
 DELETE FROM staging_exam_target_score where exam_id < 0;
 DELETE FROM staging_exam where id < 0;
 
@@ -22,8 +22,9 @@ DELETE FROM staging_student where id < 0;
 
 -- ------------------------------------------ Subject -------------------------------------------------------------
 DELETE FROM staging_target;
-DELETE FROM staging_subject_claim_score;
-DELETE FROM subject_asmt_type;
+DELETE FROM staging_subject_score;
+DELETE FROM staging_subject_asmt_type;
+DELETE FROM staging_subject_asmt_scoring;
 DELETE FROM staging_subject;
 
 -- ----------------------------------------------------------------------------------------------------------------
@@ -56,6 +57,6 @@ DELETE FROM asmt_active_year where asmt_id < 0;
 -- Ideally, with the configurable subjects introduction, there should not be any data pre-loaded into warehouse
 -- But this is not the case...
 DELETE FROM subject_asmt_type WHERE subject_id < 0;
-DELETE FROM subject_claim_score WHERE subject_id < 0;
+DELETE FROM subject_score WHERE subject_id < 0;
 DELETE FROM target WHERE subject_id < 0;
 DELETE FROM subject WHERE id < 0;

--- a/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/OlapEntitiesSetup.sql
@@ -21,7 +21,7 @@ INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count
    -- updated entry
   (2, -3, 3, 3, 3, false);
 
-INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code) VALUES
+INSERT INTO subject_score (id, subject_id, asmt_type_id, score_type_id, code) VALUES
 -- NOTE: Because of the life BEFORE configurable subject, some subjects are pre-loaded into the report
 --  (1,  1, 1, '1'),
 --  (2,  1, 1, 'SOCK_2'),
@@ -38,11 +38,11 @@ INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code) VALUES
 --  (13, 2, 3, '2-W'),
 --  (14, 2, 3, '4-CR'),
 
-  (-4,  -2, 3, 'Score4'),
-  (-5,  -2, 3, 'Score5'),
-  (-6,  -2, 3, 'Score6'),
-  (-15, -3, 3, 'Update'),
-  (-60, -3, 3, 'Delete');
+  (-4,  -2, 3, 3, 'Score4'),
+  (-5,  -2, 3, 3, 'Score5'),
+  (-6,  -2, 3, 3, 'Score6'),
+  (-15, -3, 3, 3, 'Update'),
+  (-60, -3, 3, 3, 'Delete');
 
 
 INSERT INTO target(id, subject_id, natural_id, claim_code) VALUES

--- a/migrate-olap/src/test/resources/StagingEntitiesForDeleteSetup.sql
+++ b/migrate-olap/src/test/resources/StagingEntitiesForDeleteSetup.sql
@@ -15,5 +15,5 @@ DELETE from staging_student_ethnicity where student_id = -89;
 
 -- ------------------------------------------  Exams ---------------------------------------------------------------------------------------------
 UPDATE staging_exam SET deleted = 1 WHERE id in (-88, -68, -268);
-DELETE from staging_exam_claim_score WHERE exam_id = -88;
+DELETE from staging_exam_score WHERE exam_id = -88;
 DELETE from staging_exam_target_score WHERE exam_id = -88;

--- a/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/StagingEntitiesSetup.sql
@@ -4,20 +4,26 @@ INSERT INTO staging_subject (id, code, update_import_id, migrate_id, updated) VA
   (-3, 'Update', -99, -99, now());
 
 -- add subjects' related data for the new subjects
-INSERT INTO staging_subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report, migrate_id) VALUES
-  (1, -1, 10, 3, 6, false, -99),
-   -- new entry
-  (1, -3, 8, 2, 7, false, -99),
-   -- updated entry
-  (2, -3, 8, 2, 7, false, -99);
+INSERT INTO staging_subject_asmt_type (subject_id, asmt_type_id, target_report, migrate_id) VALUES
+  (-1, 1, false, -99),
+  (-3, 1, false, -99),   -- new entry
+  (-3, 2, false, -99);   -- updated entry
 
-INSERT INTO staging_subject_claim_score (id, subject_id, asmt_type_id, code, migrate_id) VALUES
-  (-1,  -1, 1, 'Score1', -99),
-  (-2,  -1, 1, 'Score2', -99),
-  (-3,  -1, 1, 'Score3', -99),
-  (-14, -3, 3, 'Score7', -99),
-  (-15, -3, 3, 'Update', -99),
-  (-16, -3, 3, 'New',    -99);
+INSERT INTO staging_subject_asmt_scoring (subject_id, asmt_type_id, score_type_id, performance_level_count, performance_level_standard_cutoff) VALUES
+(-1, 1, 1, 10, 3),
+(-1, 1, 3, 6, null),
+(-3, 1, 1, 8, 2),
+(-3, 1, 3, 7, null),
+(-3, 2, 1, 8, 2),
+(-3, 2, 3, 7, null);
+
+INSERT INTO staging_subject_score (id, subject_id, asmt_type_id, score_type_id, code, migrate_id) VALUES
+  (-1,  -1, 1, 3, 'Score1', -99),
+  (-2,  -1, 1, 3, 'Score2', -99),
+  (-3,  -1, 1, 3, 'Score3', -99),
+  (-14, -3, 3, 3, 'Score7', -99),
+  (-15, -3, 3, 3, 'Update', -99),
+  (-16, -3, 3, 3, 'New',    -99);
 
 INSERT INTO staging_target(id, subject_id, natural_id, claim_code, migrate_id) VALUES
   (-1, -1, 'F',  't1',   -99),
@@ -179,7 +185,7 @@ INSERT INTO  staging_exam ( id, type_id, school_year, asmt_id, asmt_grade_id, su
 
 -- Note: ids are irrelevant to the migrate, we are migrating based on the latest student's exam per school year/assessment.
 -- To better understand the use cases, refer to the comments in staging_exam table.
-INSERT INTO staging_exam_claim_score (id, exam_id, subject_claim_score_id, category, migrate_id) VALUES
+INSERT INTO staging_exam_score (id, exam_id, subject_score_id, performance_level, migrate_id) VALUES
   (-881, -88, 1, 4, -99),
   (-882, -88, 2, 1, -99),
   (-883, -88, 3, 2, -99),

--- a/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
+++ b/migrate-olap/src/test/resources/WarehouseEntitiesSetup.sql
@@ -16,10 +16,8 @@ WHERE id IN (1,2);
 INSERT INTO subject_asmt_type (subject_id, asmt_type_id, target_report, printed_report) VALUES
   (-1, 1, 0, 1),
   (-2, 1, 0, 1),
-   -- new entry
-  (-3, 1, 0, 1),
-   -- updated entry
-  (-3, 2, 0, 1);
+  (-3, 1, 0, 1),    -- new entry
+  (-3, 2, 0, 1);    -- updated entry
 
 INSERT INTO subject_asmt_scoring (subject_id, asmt_type_id, score_type_id, performance_level_count, performance_level_standard_cutoff) VALUES
   (-1, 1, 1, 10, 3),


### PR DESCRIPTION
There are no changes to aggregate reports for alt scores, so there aren't many required changes here. However, i chose to push the subject metadata and i tried to make the staging tables reflect the warehouse schema per our general staging philosophy.

A lot of the changes are tests and their data set up. The real changes are the SQL changes and the migrate configuration.

I've run all the tests multiple times but i admit there is a chance that, when deployed to awsqa, i may have to debug some more. 