### PR TITLE
RP-183: Add XML helper methods to script framework

### DIFF
--- a/script-common/README.md
+++ b/script-common/README.md
@@ -2,13 +2,13 @@
 
 ### Helper functions for XML
 XML support can be added to a Script class by calling:
- ```script.addXmlExtensions()```. We assume that an XML document
+ `script.addXmlExtensions()`. We assume that an XML document
  will be converted into another XML document, and all elements, including
- commentsnot, not specifically altered, should appear in the converted
+ comments not specifically altered, should appear in the converted
  document exactly as they appear in the original. 
 
 This will automatically parse the input into a JDOM 2 Document, 
- which is made available to the scripts in the inherent variable ```document```.
+ which is made available to the scripts in the inherent variable `document`.
  However, it will also enable some helper functions that act implicitly
  on the document, and may ease writing XML transformation scripts and
  make it unnecessary for the script writer to ever reference the
@@ -24,13 +24,13 @@ transform '//Movie' by { movie ->
 }
 ```
 
-Here ```//Movie``` is an XPath expression that returns all Movie elements
+Here `//Movie` is an XPath expression that returns all Movie elements
 in the document. The code within the braces will be applied to each
-matched elements, and follows general Groovy syntax rules. The ```movie ->```
+matched elements, and follows general Groovy syntax rules. The `movie ->`
 syntax just
 assigns a name for the element that the code within the braces can use.
 It can be any string that makes sense for the script, or it can also be omitted. In this case,
-the element is automatically assigned the name ```it```. 
+the element is automatically assigned the name `it`. 
 
 For example, this script works exactly the same as the first one:
 
@@ -42,11 +42,11 @@ transform '//Movie' by {
 }
 ```
 
-The syntax ```movie.title``` (or ```it.title```) refers to the title
-attribute of the movie element. It is shorthand for ```movie.getAttributeValue()```,
-and ```movie.title = 'some text'``` is shorthand for ```movie.setAttribute('title', 'some text')```.
-An exception to this rule is ```movie.text```, which is shorthand for
-```movie.getText()```, and returns the text content of the movie element
+The syntax `movie.title` (or `it.title`) refers to the title
+attribute of the movie element. It is shorthand for `movie.getAttributeValue('title')`,
+and `movie.title = 'some text'` is shorthand for `movie.setAttribute('title', 'some text')`.
+An exception to this rule is `movie.text`, which is shorthand for
+`movie.getText()`, and returns the text content of the movie element
 instead of an attribute value.
 
 For the transformation rule, any legal Groovy (or Java) syntax is allowed.
@@ -92,9 +92,9 @@ writing Groovy rules. Therefore, a helper function for XSL has been provided:
 applyXsl xsl
 ```
 
-The ```xsl``` variable here is defined in the configuration for the script,
+The `xsl` variable here is defined in the configuration for the script,
 and can be a string containing XSL rules, a file represented as a
-```java.io.File``` object, or a ```java.io.InputStream``` object.
+`java.io.File` object, or a `java.io.InputStream` object.
 
 It is also possible to combine XSL transformations with additional
 Groovy rules:

--- a/script-common/README.md
+++ b/script-common/README.md
@@ -1,0 +1,131 @@
+## RDW Ingest - Script Pipeline
+
+### Helper functions for XML
+XML support can be added to a Script class by calling:
+ ```script.addXmlExtensions()```. We assume that an XML document
+ will be converted into another XML document, and all elements, including
+ commentsnot, not specifically altered, should appear in the converted
+ document exactly as they appear in the original. 
+
+This will automatically parse the input into a JDOM 2 Document, 
+ which is made available to the scripts in the inherent variable ```document```.
+ However, it will also enable some helper functions that act implicitly
+ on the document, and may ease writing XML transformation scripts and
+ make it unnecessary for the script writer to ever reference the
+ document object explicitly. 
+ 
+ Some examples follow:
+#### Transform
+ ```groovy
+transform '//Movie' by { movie -> 
+    if (movie.title == 'Jaws') {
+        movie.title = movie.title.toUpperCase()
+    }
+}
+```
+
+Here ```//Movie``` is an XPath expression that returns all Movie elements
+in the document. The code within the braces will be applied to each
+matched elements, and follows general Groovy syntax rules. The ```movie ->```
+syntax just
+assigns a name for the element that the code within the braces can use.
+It can be any string that makes sense for the script, or it can also be omitted. In this case,
+the element is automatically assigned the name ```it```. 
+
+For example, this script works exactly the same as the first one:
+
+ ```groovy
+transform '//Movie' by {  
+    if (it.title == 'Jaws') {
+        it.title = it.title.toUpperCase()
+    }
+}
+```
+
+The syntax ```movie.title``` (or ```it.title```) refers to the title
+attribute of the movie element. It is shorthand for ```movie.getAttributeValue()```,
+and ```movie.title = 'some text'``` is shorthand for ```movie.setAttribute('title', 'some text')```.
+An exception to this rule is ```movie.text```, which is shorthand for
+```movie.getText()```, and returns the text content of the movie element
+instead of an attribute value.
+
+For the transformation rule, any legal Groovy (or Java) syntax is allowed.
+This includes if-then-else blocks, regular expressions, calls to external
+services, etc.
+
+It is also possible to delete an element in a transformation rule. 
+For example:
+
+ ```groovy
+transform '//Movie' by { movie -> 
+    if (movie.actor == 'Keanu Reeves') {
+        delete movie
+    }
+}
+```
+
+#### Filter
+Although deleting elements as part of a transform rule is possible, 
+it is also possible to filter elements based on an in-or-out rule:
+
+```groovy
+delete '//Movie' when { movie -> 
+    movie.actor == 'Keanu Reeves'
+}
+```
+
+It is also possible to reverse this logic to delete all elements
+(matching the XPath expression) that don't match the rule:
+ 
+```groovy
+delete '//Movie' unless { movie -> 
+    movie.actor == 'Richard Basehart'
+}
+```
+
+#### XSL transformations
+Although the script pipeline is meant to replace XSL transformations,
+it might happen that performing some work in XSL is preferable to 
+writing Groovy rules. Therefore, a helper function for XSL has been provided:
+
+```groovy
+applyXsl xsl
+```
+
+The ```xsl``` variable here is defined in the configuration for the script,
+and can be a string containing XSL rules, a file represented as a
+```java.io.File``` object, or a ```java.io.InputStream``` object.
+
+It is also possible to combine XSL transformations with additional
+Groovy rules:
+
+```groovy
+applyXsl preprocessing
+
+transform '//Movie' {movie ->
+    if (movie.rating > 2) {
+        movie.recommend = true
+    } else {
+        movie.recommend = false
+    }
+}
+
+applyXsl postprocessing
+```
+
+#### Getting the results
+Once all transformations have been applied to the XML document, it is
+necessary to convert it back to a string and return it. The helper 
+function outputXml does this, and should be the last statement
+in the script:
+
+```groovy
+transform '//Movie' by {  
+    if (it.title == 'Jaws') {
+        it.title = it.title.toUpperCase()
+    }
+}
+
+
+outputXml
+```

--- a/script-common/build.gradle
+++ b/script-common/build.gradle
@@ -15,5 +15,10 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-all'
     compile 'org.jdom:jdom2:2.0.5'
     compile 'jaxen:jaxen:1.1.4'
+    compile 'net.sf.saxon:Saxon-HE'
+
+    testCompile 'org.xmlunit:xmlunit-core'
+    testCompile 'org.xmlunit:xmlunit-matchers'
+    testCompile 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/script-common/build.gradle
+++ b/script-common/build.gradle
@@ -19,6 +19,6 @@ dependencies {
 
     testCompile 'org.xmlunit:xmlunit-core'
     testCompile 'org.xmlunit:xmlunit-matchers'
-    testCompile 'org.springframework.boot:spring-boot-starter-test'
+    testCompile 'org.springframework.boot:spring-boot-starter-test' 
 }
 

--- a/script-common/src/main/groovy/org/opentestsystem/rdw/ingest/script/DSLScriptBase.groovy
+++ b/script-common/src/main/groovy/org/opentestsystem/rdw/ingest/script/DSLScriptBase.groovy
@@ -47,8 +47,8 @@ abstract class DSLScriptBase extends Script {
 
         this.setProperty("document", document)
 
-        // Unescapes up embedded XML in TRT values so it can treated as regular XML.
-        String.metaClass.unescapeXml {
+        // Unescapes up embedded HTML tags in embedded  in TRT values.
+        String.metaClass.unescapeHtmlTags {
             delegate.replaceAll('&lt;','<').replaceAll('&gt;','>')
         }
 

--- a/script-common/src/main/groovy/org/opentestsystem/rdw/ingest/script/DSLScriptBase.groovy
+++ b/script-common/src/main/groovy/org/opentestsystem/rdw/ingest/script/DSLScriptBase.groovy
@@ -1,7 +1,22 @@
 package org.opentestsystem.rdw.ingest.script
 
+import org.apache.tools.ant.util.ReaderInputStream
+import org.jdom2.Document
+import org.jdom2.Element
+import org.jdom2.input.SAXBuilder
+import org.jdom2.output.Format
+import org.jdom2.output.LineSeparator
+import org.jdom2.output.XMLOutputter
+import org.jdom2.transform.JDOMResult
+import org.jdom2.transform.JDOMSource
+import org.jdom2.xpath.XPathFactory
+
+import javax.xml.transform.Transformer
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.stream.StreamSource
+
 /**
- * Base class for Groovy pipeline scripts.
+ * Base class for Groovy pipeline scripts. Provides a DSL that will be available to the scripts.
  */
 abstract class DSLScriptBase extends Script {
 
@@ -19,7 +34,116 @@ abstract class DSLScriptBase extends Script {
         this.setProperty("input", input)
         return this
     }
+
+    /**
+     * Adds XML parsing, transformation, formatting helper methods to the script class.
+     *
+     * See readme for specific examples of using these helper methods.
+     *
+     * @return reference to the script class (for chained calls).
+     */
+    DSLScriptBase enableXmlExtensions() {
+        Document document = new SAXBuilder().build(getProperty("input"))
+
+        this.setProperty("document", document)
+
+        // Unescapes up embedded XML in TRT values so it can treated as regular XML.
+        String.metaClass.unescapeXml {
+            delegate.replaceAll('&lt;','<').replaceAll('&gt;','>')
+        }
+
+        // Allows text content to be accessed as element.text and attributes values to be accessed as element.propName
+        Element.metaClass.getProperty { property ->
+            if (property == 'text') {
+                delegate.coalesceText(true)
+                delegate.getText()
+            } else {
+                delegate.getAttributeValue(property)
+            }
+        }
+
+        // Allows text content to set by assignment to element.text and attributes by assignment to element.propName
+        Element.metaClass.setProperty { property, value ->
+            if (property == 'text') {
+                delegate.setText(value)
+            } else {
+                delegate.setAttribute(property, value)
+            }
+        }
+
+        // Helper method for modifying XML documents. Loops through elements matching given XPath expression and
+        // applies the rule to each of them.
+        this.metaClass.transform {xpath ->
+            [by: {rule ->
+                if (rule instanceof Closure) {
+                    def elements = XPathFactory.instance().compile(xpath as String).evaluate(getProperty('document'))
+                    elements.each { rule(it) }
+                }
+            }]
+        }
+
+        // Helper method for modifying XML documents. Filters the elements matching the provided rule. When modified
+        // with "when", all elements matching the rule are removed from the document. When modified with "unless"
+        // all the elements not matching the rule will be removed from the document.
+        this.metaClass.delete {xpath ->
+            [when: {rule ->
+                if (rule instanceof Closure) {
+                    def elements = XPathFactory.instance().compile(xpath as String).evaluate(getProperty('document'))
+                    elements.each {
+                        if(rule(it)) {
+                            delete(it)
+                        }
+                    }
+                }
+            },
+            unless: {rule ->
+                if (rule instanceof Closure) {
+                    def elements = XPathFactory.instance().compile(xpath as String).evaluate(getProperty('document'))
+                    elements.each {
+                        if(!rule(it)) {
+                            delete(it)
+                        }
+                    }
+                }
+            }]
+        }
+
+        // Helper to delete a single element form a document with: delete element
+        this.metaClass.delete {Element element ->
+            if (element != null) {
+                element.detach()
+            }
+        }
+
+        // Converts the document object to a string. Typically this should be the last statement in a script.
+        this.metaClass.getOutputXml {
+            StringWriter stringWriter = new StringWriter()
+
+            new XMLOutputter().with {
+                format = Format.getRawFormat()
+                format.setLineSeparator(LineSeparator.NONE)
+                output(getProperty('document'), stringWriter)
+            }
+
+            return stringWriter.toString()
+        }
+
+        // Apply as XSL transformation to the document by: apply xsl
+        // where xsl is a String containing the XSL document, a file represented by a java.io.File object,
+        // or an open java.io.InputStream.
+        this.metaClass.applyXsl {xsl ->
+            if (xsl instanceof String) {
+                xsl = new ReaderInputStream(new StringReader(xsl))
+            }
+
+            JDOMSource source = new JDOMSource((Document)getProperty('document'))
+            Transformer transformer = TransformerFactory.newInstance().newTransformer(new StreamSource(xsl))
+            JDOMResult out = new JDOMResult()
+            transformer.transform(source, out)
+
+            setProperty('document', out.document)
+        }
+
+        return this
+    }
 }
-
-
-

--- a/script-common/src/test/groovy/org/opentestsystem/rdw/ingest/script/DSLScriptBaseTest.groovy
+++ b/script-common/src/test/groovy/org/opentestsystem/rdw/ingest/script/DSLScriptBaseTest.groovy
@@ -1,42 +1,42 @@
-package org.opentestsystem.rdw.ingest.script;
+package org.opentestsystem.rdw.ingest.script
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is
+import static org.junit.Assert.assertThat
 
 class DSLScriptBaseTest {
-    private DSLScriptBase script;
+    private DSLScriptBase script
 
     @Mock
-    private InputStream inputStream;
+    private InputStream inputStream
 
     @Before
     void setUp() {
         script = new DSLScriptBase() {
             @Override
             Object run() {
-                return null;
+                return null
             }
-        };
+        }
     }
 
     @Test
-    void itShoulBindProperties() {
-        Map<String,Object> properties = new HashMap<>();
-        properties.put("key", "value");
-        properties.put("key2", "value2");
-        script.bindProperties(properties);
+    void itShouldBindProperties() {
+        Map<String,Object> properties = new HashMap<>()
+        properties.put("key", "value")
+        properties.put("key2", "value2")
+        script.bindProperties(properties)
 
-        assertThat(script.getProperty("key"), is("value"));
-        assertThat(script.getProperty("key2"), is("value2"));
+        assertThat(script.getProperty("key"), is("value"))
+        assertThat(script.getProperty("key2"), is("value2"))
     }
 
     @Test
     void itShouldBindInputStream() {
-        script.bindInput(inputStream);
-        assertThat(script.getProperty("input"), is(inputStream));
+        script.bindInput(inputStream)
+        assertThat(script.getProperty("input"), is(inputStream))
     }
 }

--- a/script-common/src/test/java/org/opentestsystem/rdw/ingest/script/ScriptCompilerTest.java
+++ b/script-common/src/test/java/org/opentestsystem/rdw/ingest/script/ScriptCompilerTest.java
@@ -28,14 +28,14 @@ public class ScriptCompilerTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void getScriptClass() {
+    public void itShouldCompileTheScriptIntoClass() {
         compiler = new ScriptCompiler("return 1");
 
         assertNotNull(compiler.getScriptClass());
     }
 
     @Test
-    public void getInstance() {
+    public void itShouldBeAbleToRunAnInstance() {
         compiler = new ScriptCompiler("return 'Hello ' + input.getText()");
         InputStream input = new StringInputStream("Test User");
         Script script = compiler.getInstance(input);
@@ -43,7 +43,7 @@ public class ScriptCompilerTest {
     }
 
     @Test
-    public void getInstanceWithProperties() {
+    public void itShouldBindPropertiesToScript() {
         compiler = new ScriptCompiler("return greeting + ' ' + title + ' ' + input.getText()");
         InputStream input = new StringInputStream("Test User");
         Map<String,Object> map = new HashMap<>();

--- a/script-common/src/test/java/org/opentestsystem/rdw/ingest/script/ScriptXmlTest.java
+++ b/script-common/src/test/java/org/opentestsystem/rdw/ingest/script/ScriptXmlTest.java
@@ -4,7 +4,6 @@ import groovy.lang.Script;
 import org.apache.tools.ant.util.FileUtils;
 import org.apache.tools.ant.util.ReaderInputStream;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -34,7 +33,8 @@ import java.util.stream.StreamSupport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.Assert.assertThat;
 import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
 
 
@@ -105,15 +105,15 @@ public class ScriptXmlTest {
                         "}" + LF +
                 "outputXml";
 
-        Assert.assertThat(originalXml, hasXPath("//Item[@key='37115']", not(isEmptyOrNullString())));
-        Assert.assertThat(originalXml, hasXPath("//Item[@key='92135']", not(isEmptyOrNullString())));
+        assertThat(originalXml, hasXPath("//Item[@key='37115']", not(isEmptyOrNullString())));
+        assertThat(originalXml, hasXPath("//Item[@key='92135']", not(isEmptyOrNullString())));
 
         ScriptCompiler compiler = new ScriptCompiler(scriptDefinition);
         Script script = compiler.getInstance(input).enableXmlExtensions();
         String newXml = (String)script.run();
 
-        Assert.assertThat(newXml, hasXPath("//Item[@key='37115']", isEmptyOrNullString()));
-        Assert.assertThat(newXml, hasXPath("//Item[@key='92135']", isEmptyOrNullString()));
+        assertThat(newXml, hasXPath("//Item[@key='37115']", isEmptyOrNullString()));
+        assertThat(newXml, hasXPath("//Item[@key='92135']", isEmptyOrNullString()));
     }
 
     @Test
@@ -126,13 +126,13 @@ public class ScriptXmlTest {
                         "}" + LF +
                 "outputXml";
 
-        Assert.assertThat(originalXml, hasXPath("//Item[@key='37115']", not(isEmptyOrNullString())));
+        assertThat(originalXml, hasXPath("//Item[@key='37115']", not(isEmptyOrNullString())));
 
         ScriptCompiler compiler = new ScriptCompiler(scriptDefinition);
         Script script = compiler.getInstance(input).enableXmlExtensions();
         String newXml = (String)script.run();
 
-        Assert.assertThat(newXml, hasXPath("//Item[not(@key='37115')]", isEmptyOrNullString()));
+        assertThat(newXml, hasXPath("//Item[not(@key='37115')]", isEmptyOrNullString()));
     }
 
     // Used by the various transform tests
@@ -140,18 +140,18 @@ public class ScriptXmlTest {
         //
         // Item Bank Key transformation 10200 --> 200
         //
-        Assert.assertThat(xml, hasXPath("//Item/@bankKey", equalTo("200")));
-        Assert.assertThat(xml, not(hasXPath("//Item/@bankKey", equalTo("10200"))));
+        assertThat(xml, hasXPath("//Item/@bankKey", equalTo("200")));
+        assertThat(xml, not(hasXPath("//Item/@bankKey", equalTo("10200"))));
 
         //
         // Several response transformations based on type:
         //
 
         // MC
-        Assert.assertThat(xml, hasXPath("//Response[@junit='mc']/text()", equalTo("A")));
+        assertThat(xml, hasXPath("//Response[@junit='mc']/text()", equalTo("A")));
 
         // MS
-        Assert.assertThat(xml, hasXPath("//Response[@junit='ms']/text()", equalTo("A,C,D")));
+        assertThat(xml, hasXPath("//Response[@junit='ms']/text()", equalTo("A,C,D")));
 
 
         DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -162,17 +162,17 @@ public class ScriptXmlTest {
 
         //EBSR
         final String ebsrXml = getEmbeddedXml(doc, "//Response[@junit='ebsr']");
-        Assert.assertThat(ebsrXml, hasXPath("count(/itemResponse/response)", equalTo("2")));
-        Assert.assertThat(ebsrXml, hasXPath("count(/itemResponse/response[@id='EBSR1']/value)", equalTo("1")));
-        Assert.assertThat(ebsrXml, hasXPath("/itemResponse/response[@id='EBSR1']/value/text()", equalTo("B")));
-        Assert.assertThat(ebsrXml, hasXPath("count(/itemResponse/response[@id='EBSR2']/value)", equalTo("1")));
-        Assert.assertThat(ebsrXml, hasXPath("/itemResponse/response[@id='EBSR2']/value/text()", equalTo("A")));
+        assertThat(ebsrXml, hasXPath("count(/itemResponse/response)", equalTo("2")));
+        assertThat(ebsrXml, hasXPath("count(/itemResponse/response[@id='EBSR1']/value)", equalTo("1")));
+        assertThat(ebsrXml, hasXPath("/itemResponse/response[@id='EBSR1']/value/text()", equalTo("B")));
+        assertThat(ebsrXml, hasXPath("count(/itemResponse/response[@id='EBSR2']/value)", equalTo("1")));
+        assertThat(ebsrXml, hasXPath("/itemResponse/response[@id='EBSR2']/value/text()", equalTo("A")));
 
         //MI
         final Source miXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='mi']")).build();
-        Assert.assertThat(miXML, hasXPath("count(/itemResponse/response)", equalTo("1")));
-        Assert.assertThat(miXML, hasXPath("/itemResponse/response/@id", equalTo("RESPONSE")));
-        Assert.assertThat(miXML, hasXPath("count(/itemResponse/response/value)", equalTo("5")));
+        assertThat(miXML, hasXPath("count(/itemResponse/response)", equalTo("1")));
+        assertThat(miXML, hasXPath("/itemResponse/response/@id", equalTo("RESPONSE")));
+        assertThat(miXML, hasXPath("count(/itemResponse/response/value)", equalTo("5")));
 
         final List<String> miValues = new ArrayList<>();
 
@@ -184,8 +184,8 @@ public class ScriptXmlTest {
 
         //TI
         final Source tiXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='ti']")).build();
-        Assert.assertThat(tiXML, hasXPath("count(/responseSpec/responseTable/tr/th)", equalTo("11")));
-        Assert.assertThat(tiXML, hasXPath("count(/responseSpec/responseTable/tr/td)", equalTo("11")));
+        assertThat(tiXML, hasXPath("count(/responseSpec/responseTable/tr/th)", equalTo("11")));
+        assertThat(tiXML, hasXPath("count(/responseSpec/responseTable/tr/td)", equalTo("11")));
 
         final List<String> tiValues = new ArrayList<>();
         new JAXPXPathEngine()
@@ -195,8 +195,8 @@ public class ScriptXmlTest {
 
         //HTQ
         final Source htqXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='htq']")).build();
-        Assert.assertThat(htqXML, hasXPath("/itemResponse/response/@id", equalTo("1")));
-        Assert.assertThat(htqXML, hasXPath("count(/itemResponse/response[@id='1']/value)", equalTo("2")));
+        assertThat(htqXML, hasXPath("/itemResponse/response/@id", equalTo("1")));
+        assertThat(htqXML, hasXPath("count(/itemResponse/response[@id='1']/value)", equalTo("2")));
         final List<String> htqValues = new ArrayList<>();
 
         new JAXPXPathEngine()
@@ -212,26 +212,26 @@ public class ScriptXmlTest {
                 .findFirst()
                 .orElseThrow(() -> new NoSuchElementException("Cannot find EQ Math node"));
         assertThat(mathNode.getNamespaceURI()).isEqualTo("http://www.w3.org/1998/Math/MathML");
-        Assert.assertThat(eqXML, hasXPath("/response/*[name()='math']/@title", equalTo("50")));
-        Assert.assertThat(eqXML, hasXPath("/response/*[name()='math']/*[name()='mstyle']/*[name()='mn']/text()", equalTo("50")));
+        assertThat(eqXML, hasXPath("/response/*[name()='math']/@title", equalTo("50")));
+        assertThat(eqXML, hasXPath("/response/*[name()='math']/*[name()='mstyle']/*[name()='mn']/text()", equalTo("50")));
 
         //GI
         final Source giXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='gi']")).build();
-        Assert.assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/@id", equalTo("1")));
+        assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/@id", equalTo("1")));
         final List<String> atomicObjectValues = StreamSupport.stream(new JAXPXPathEngine()
                 .selectNodes("/AnswerSet/Question/QuestionPart/ObjectSet/AtomicObject", giXML)
                 .spliterator(), false)
                 .map(Node::getTextContent)
                 .collect(Collectors.toList());
         assertThat(atomicObjectValues).containsExactly("{AminusB(91,49)}", "{BC(193,49)}", "{C(299,49)}");
-        Assert.assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/ObjectSet/RegionGroupObject/@name", equalTo("PartA")));
+        assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/ObjectSet/RegionGroupObject/@name", equalTo("PartA")));
         final List<String> regionObjectValues = StreamSupport.stream(new JAXPXPathEngine()
                 .selectNodes("/AnswerSet/Question/QuestionPart/ObjectSet/RegionGroupObject/RegionObject/@name", giXML)
                 .spliterator(), false)
                 .map(Node::getTextContent)
                 .collect(Collectors.toList());
         assertThat(regionObjectValues).containsExactly("Step1", "Step2", "Step3", "Step4");
-        Assert.assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/SnapPoint/text()", equalTo("70@91,361;193,361;299,361;407,361;299,345;299,377")));
+        assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/SnapPoint/text()", equalTo("70@91,361;193,361;299,361;407,361;299,345;299,377")));
 
         //SA | ER | WER
         assertThat(getEmbeddedXml(doc, "//Response[@junit='wer']"))

--- a/script-common/src/test/java/org/opentestsystem/rdw/ingest/script/ScriptXmlTest.java
+++ b/script-common/src/test/java/org/opentestsystem/rdw/ingest/script/ScriptXmlTest.java
@@ -1,0 +1,258 @@
+package org.opentestsystem.rdw.ingest.script;
+
+import groovy.lang.Script;
+import org.apache.tools.ant.util.FileUtils;
+import org.apache.tools.ant.util.ReaderInputStream;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Source;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+
+
+public class ScriptXmlTest {
+    private static final String LF = System.lineSeparator();
+    private String originalXml;
+    private InputStream input;
+
+    @Before
+    public  void setup() throws Exception {
+        originalXml = loadFromResourceFile("/sample_xml/TDSReport.iab.2018_AIR_format.xml");
+        input = new ReaderInputStream(new StringReader(originalXml));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        input.close();
+    }
+
+    @Test
+    public void itShouldTransformByScriptCommands() throws Exception {
+        // Transform sample TRT file using the Groovy script commands with XML helper methods.
+        // Test the results using equivalent tests to those in the Exam Processor module for testing
+        // XSL transformation
+        String scriptDefinition = loadFromResourceFile("/scripts/exam_script.groovy");
+        ScriptCompiler compiler = new ScriptCompiler(scriptDefinition);
+        Script script =  compiler.getInstance(input).enableXmlExtensions();
+        String results = (String)script.run();
+
+        verifyTransformedXml(results);
+    }
+
+    @Test
+    public void itShouldTransformByXslScript() throws Exception {
+        // Transform the same TRT file as above, but instead use a script that applies an XSL transformation
+        // instead of Groovy commands for the transformation. Use the same tests to verify this transformation.
+        String scriptDefinition = loadFromResourceFile("/scripts/exam_script_xsl.groovy");
+        String xsl = loadFromResourceFile("/xsl/exam.xsl");
+        Script script = new ScriptCompiler(scriptDefinition)
+                .getInstance(input, Collections.singletonMap("xslAllRules", xsl))
+                .enableXmlExtensions();
+        String results = (String)script.run();
+
+        verifyTransformedXml(results);
+    }
+
+    @Test
+    public void itShouldTransformByHybridScript() throws Exception {
+        // Transform the same TRT using a hybrid approach. An XSL is applied to transform the Item bank keys,
+        // and then Groovy rules are applied to do the rest of the transformations that reformat the response values.
+        String scriptDefinition = loadFromResourceFile("/scripts/exam_script_hybrid.groovy");
+        String xsl = loadFromResourceFile("/xsl/exam_items_only.xsl");
+        Script script = new ScriptCompiler(scriptDefinition)
+                .getInstance(input, Collections.singletonMap("xslItemRulesOnly", xsl))
+                .enableXmlExtensions();
+        String results = (String)script.run();
+
+        verifyTransformedXml(results);
+    }
+
+    @Test
+    public void itShouldFilterOutElements() {
+        // Test ability to filter out elements with a boolean rule. All elements matching the XPath expression
+        // and also matching this rule will be removed.
+        String scriptDefinition =
+                "delete '//Item' when { item ->" + LF +
+                "    item.key == '37115' || item.key == '92135'" + LF +
+                        "}" + LF +
+                "outputXml";
+
+        Assert.assertThat(originalXml, hasXPath("//Item[@key='37115']", not(isEmptyOrNullString())));
+        Assert.assertThat(originalXml, hasXPath("//Item[@key='92135']", not(isEmptyOrNullString())));
+
+        ScriptCompiler compiler = new ScriptCompiler(scriptDefinition);
+        Script script = compiler.getInstance(input).enableXmlExtensions();
+        String newXml = (String)script.run();
+
+        Assert.assertThat(newXml, hasXPath("//Item[@key='37115']", isEmptyOrNullString()));
+        Assert.assertThat(newXml, hasXPath("//Item[@key='92135']", isEmptyOrNullString()));
+    }
+
+    @Test
+    public void itShouldFilterInElements() {
+        // Test filter in with a boolean rule. All elements matching the XPath expression, but not matching the rule
+        // will be removed.
+        String scriptDefinition =
+                "delete '//Item' unless { item ->" + LF +
+                        "    item.key == '37115'" + LF +
+                        "}" + LF +
+                "outputXml";
+
+        Assert.assertThat(originalXml, hasXPath("//Item[@key='37115']", not(isEmptyOrNullString())));
+
+        ScriptCompiler compiler = new ScriptCompiler(scriptDefinition);
+        Script script = compiler.getInstance(input).enableXmlExtensions();
+        String newXml = (String)script.run();
+
+        Assert.assertThat(newXml, hasXPath("//Item[not(@key='37115')]", isEmptyOrNullString()));
+    }
+
+    // Used by the various transform tests
+    private void verifyTransformedXml(String xml) throws Exception {
+        //
+        // Item Bank Key transformation 10200 --> 200
+        //
+        Assert.assertThat(xml, hasXPath("//Item/@bankKey", equalTo("200")));
+        Assert.assertThat(xml, not(hasXPath("//Item/@bankKey", equalTo("10200"))));
+
+        //
+        // Several response transformations based on type:
+        //
+
+        // MC
+        Assert.assertThat(xml, hasXPath("//Response[@junit='mc']/text()", equalTo("A")));
+
+        // MS
+        Assert.assertThat(xml, hasXPath("//Response[@junit='ms']/text()", equalTo("A,C,D")));
+
+
+        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        InputSource is = new InputSource();
+        is.setCharacterStream(new StringReader(xml));
+        Document doc = db.parse(is);
+
+
+        //EBSR
+        final String ebsrXml = getEmbeddedXml(doc, "//Response[@junit='ebsr']");
+        Assert.assertThat(ebsrXml, hasXPath("count(/itemResponse/response)", equalTo("2")));
+        Assert.assertThat(ebsrXml, hasXPath("count(/itemResponse/response[@id='EBSR1']/value)", equalTo("1")));
+        Assert.assertThat(ebsrXml, hasXPath("/itemResponse/response[@id='EBSR1']/value/text()", equalTo("B")));
+        Assert.assertThat(ebsrXml, hasXPath("count(/itemResponse/response[@id='EBSR2']/value)", equalTo("1")));
+        Assert.assertThat(ebsrXml, hasXPath("/itemResponse/response[@id='EBSR2']/value/text()", equalTo("A")));
+
+        //MI
+        final Source miXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='mi']")).build();
+        Assert.assertThat(miXML, hasXPath("count(/itemResponse/response)", equalTo("1")));
+        Assert.assertThat(miXML, hasXPath("/itemResponse/response/@id", equalTo("RESPONSE")));
+        Assert.assertThat(miXML, hasXPath("count(/itemResponse/response/value)", equalTo("5")));
+
+        final List<String> miValues = new ArrayList<>();
+
+        new JAXPXPathEngine()
+                .selectNodes("/itemResponse/response/value/text()", miXML)
+                .forEach(valueNode -> miValues.add(valueNode.getTextContent()));
+        assertThat(miValues).containsExactly("1 a", "2 b", "3 b", "4 a", "5 a");
+
+
+        //TI
+        final Source tiXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='ti']")).build();
+        Assert.assertThat(tiXML, hasXPath("count(/responseSpec/responseTable/tr/th)", equalTo("11")));
+        Assert.assertThat(tiXML, hasXPath("count(/responseSpec/responseTable/tr/td)", equalTo("11")));
+
+        final List<String> tiValues = new ArrayList<>();
+        new JAXPXPathEngine()
+                .selectNodes("/responseSpec/responseTable/tr/td", tiXML)
+                .forEach(valueNode -> tiValues.add(valueNode.getTextContent()));
+        assertThat(tiValues).containsExactly("", "B", "", "", "A", "", "", "C", "", "", "D");
+
+        //HTQ
+        final Source htqXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='htq']")).build();
+        Assert.assertThat(htqXML, hasXPath("/itemResponse/response/@id", equalTo("1")));
+        Assert.assertThat(htqXML, hasXPath("count(/itemResponse/response[@id='1']/value)", equalTo("2")));
+        final List<String> htqValues = new ArrayList<>();
+
+        new JAXPXPathEngine()
+                .selectNodes("/itemResponse/response/value", htqXML)
+                .forEach(valueNode -> htqValues.add(valueNode.getTextContent()));
+        assertThat(htqValues).containsExactly("2", "4");
+
+        //EQ
+        final Source eqXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='eq']")).build();
+        final Node mathNode = StreamSupport.stream(new JAXPXPathEngine()
+                .selectNodes("/response/*[name()='math']", eqXML)
+                .spliterator(), false)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("Cannot find EQ Math node"));
+        assertThat(mathNode.getNamespaceURI()).isEqualTo("http://www.w3.org/1998/Math/MathML");
+        Assert.assertThat(eqXML, hasXPath("/response/*[name()='math']/@title", equalTo("50")));
+        Assert.assertThat(eqXML, hasXPath("/response/*[name()='math']/*[name()='mstyle']/*[name()='mn']/text()", equalTo("50")));
+
+        //GI
+        final Source giXML = Input.fromString(getEmbeddedXml(doc, "//Response[@junit='gi']")).build();
+        Assert.assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/@id", equalTo("1")));
+        final List<String> atomicObjectValues = StreamSupport.stream(new JAXPXPathEngine()
+                .selectNodes("/AnswerSet/Question/QuestionPart/ObjectSet/AtomicObject", giXML)
+                .spliterator(), false)
+                .map(Node::getTextContent)
+                .collect(Collectors.toList());
+        assertThat(atomicObjectValues).containsExactly("{AminusB(91,49)}", "{BC(193,49)}", "{C(299,49)}");
+        Assert.assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/ObjectSet/RegionGroupObject/@name", equalTo("PartA")));
+        final List<String> regionObjectValues = StreamSupport.stream(new JAXPXPathEngine()
+                .selectNodes("/AnswerSet/Question/QuestionPart/ObjectSet/RegionGroupObject/RegionObject/@name", giXML)
+                .spliterator(), false)
+                .map(Node::getTextContent)
+                .collect(Collectors.toList());
+        assertThat(regionObjectValues).containsExactly("Step1", "Step2", "Step3", "Step4");
+        Assert.assertThat(giXML, hasXPath("/AnswerSet/Question/QuestionPart/SnapPoint/text()", equalTo("70@91,361;193,361;299,361;407,361;299,345;299,377")));
+
+        //SA | ER | WER
+        assertThat(getEmbeddedXml(doc, "//Response[@junit='wer']"))
+                .contains("<p><strong><em><u>&nbsp;")
+                .contains("classroom that they can&#39;t see,")
+                .contains("their teacher&#39;s endless");
+    }
+
+    private String loadFromResourceFile(String name) throws Exception {
+        Reader scriptReader = new InputStreamReader(this.getClass().getResourceAsStream(name));
+        return FileUtils.readFully(scriptReader);
+    }
+
+    // Some of the Item types include escaped XML embedded into text values. This function parses
+    // these values into regular XML, so it can be tested with XmlUnit assertions.
+    private String getEmbeddedXml(Document d, String xpathExpression) throws Exception {
+        XPathFactory factory = XPathFactory.newInstance();
+        XPath xpath = factory.newXPath();
+        XPathExpression expr = xpath.compile(xpathExpression);
+        Object result = expr.evaluate(d, XPathConstants.NODE);
+        Node node = (Node)result;
+        return node.getTextContent();
+    }
+}

--- a/script-common/src/test/resources/sample_xml/TDSReport.iab.2018_AIR_format.xml
+++ b/script-common/src/test/resources/sample_xml/TDSReport.iab.2018_AIR_format.xml
@@ -1,0 +1,315 @@
+<!-- Node junit attributes added to original file to enable tests -->
+<TDSReport>
+    <Test grade="4" mode="online" contract="SBAC" bankKey="10200" testId="SBAC-IAB-FIXED-G4M-G-MATH-4" subject="MATH"
+          name="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" handScoreProject="0" assessmentType="interim" academicYear="2016" assessmentVersion="9786"/>
+    <Examinee isDemo="0" key="4054">
+        <ExamineeAttribute name="Birthdate" value="1900-01-01" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="FirstName" value="Name116" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="Sex" value="Female" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="GradeLevelWhenAssessed" value="04" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="LastOrSurname" value="LastName116" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="StudentIdentifier" value="AFOURTHGRADER17" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="MiddleName" value="MiddleName116" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="AlternateSSID" value="FOURTHGRADER17" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="HispanicOrLatinoEthnicity" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="AmericanIndianOrAlaskaNative" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="Asian" value="YES" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="BlackOrAfricanAmerican" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="White" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="NativeHawaiianOrOtherPacificIslander" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="DemographicRaceTwoOrMoreRaces" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="IDEAIndicator" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="LEPStatus" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="Section504Status" value="Unknown/Cannot Provide" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="EconomicDisadvantageStatus" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="MigrantStatus" value="NO" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="LanguageCode" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="EnglishLanguageProficiencyLevel" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="FirstEntryDateIntoUSSchool" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="LimitedEnglishProficiencyEntryDate" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="LEPExitDate" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="TitleIIILanguageInstructionProgramType" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="PrimaryDisabilityType" value="" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeAttribute name="Birthdate" value="1900-01-01" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="FirstName" value="Name116" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="Sex" value="Female" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="GradeLevelWhenAssessed" value="04" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="LastOrSurname" value="LastName116" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="StudentIdentifier" value="AFOURTHGRADER17" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="MiddleName" value="MiddleName116" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="AlternateSSID" value="FOURTHGRADER17" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="HispanicOrLatinoEthnicity" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="AmericanIndianOrAlaskaNative" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="Asian" value="YES" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="BlackOrAfricanAmerican" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="White" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="NativeHawaiianOrOtherPacificIslander" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="DemographicRaceTwoOrMoreRaces" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="IDEAIndicator" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="LEPStatus" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="Section504Status" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="EconomicDisadvantageStatus" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="MigrantStatus" value="NO" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="LanguageCode" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="EnglishLanguageProficiencyLevel" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="FirstEntryDateIntoUSSchool" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="LimitedEnglishProficiencyEntryDate" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="LEPExitDate" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="TitleIIILanguageInstructionProgramType" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeAttribute name="PrimaryDisabilityType" value="" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeRelationship name="ResponsibleDistrictIdentifier" value="UCLALS" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeRelationship name="OrganizationName" value="UCLA" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeRelationship name="ResponsibleInstitutionIdentifier" value="APTEST1" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeRelationship name="NameOfInstitution" value="APTESTSCHOOL" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeRelationship name="StateName" value="ARMED FORCES PACIFIC" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeRelationship name="StateAbbreviation" value="AP" context="INITIAL" contextDate="2016-10-12T21:51:46.003"/>
+        <ExamineeRelationship name="ResponsibleDistrictIdentifier" value="UCLALS" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeRelationship name="OrganizationName" value="UCLA" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeRelationship name="ResponsibleInstitutionIdentifier" value="APTEST1" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeRelationship name="NameOfInstitution" value="APTESTSCHOOL" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeRelationship name="StateName" value="ARMED FORCES PACIFIC" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+        <ExamineeRelationship name="StateAbbreviation" value="AP" context="FINAL" contextDate="2016-10-12T22:00:49.069"/>
+    </Examinee>
+    <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
+                 server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
+                 assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
+        <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
+                 algorithmVersion="0"/>
+        <Accommodation code="ENU" type="Language" value="English" segment="0"/>
+        <Accommodation code="NEA0" type="Non-Embedded Accommodations" value="None" segment="0"/>
+        <Accommodation code="NEDS0" type="Non-Embedded Designated Supports" value="None" segment="0"/>
+        <Accommodation code="TDS_APC_PSP" type="Audio Playback Controls" value="Play Stop and Pause" segment="0"/>
+        <Accommodation code="TDS_ASL0" type="American Sign Language" value="Do not show ASL videos" segment="0"/>
+        <Accommodation code="TDS_ClosedCap0" type="Closed Captioning" value="Closed Captioning Not Available" segment="0"/>
+        <Accommodation code="TDS_ExpandablePassages1" type="Expandable Passages" value="Expandable Passages On" segment="0"/>
+        <Accommodation code="TDS_FT_Serif" type="Font Type" value="Times New Roman" segment="0"/>
+        <Accommodation code="TDS_F_S14" type="Passage Font Size" value="14pt" segment="0"/>
+        <Accommodation code="TDS_GN1" type="Global Notes" value="Global Notes On" segment="0"/>
+        <Accommodation code="TDS_Highlight1" type="Highlight" value="True" segment="0"/>
+        <Accommodation code="TDS_HWPlayback" type="Hardware Checks" value="Check Playback Capabilities" segment="0"/>
+        <Accommodation code="TDS_IF_S14" type="Item Font Size" value="14pt Items" segment="0"/>
+        <Accommodation code="TDS_ITM1" type="Item Tools Menu" value="On" segment="0"/>
+        <Accommodation code="TDS_ITTC0" type="IntraTest TTS Controls" value="IntraTest TTS Controls Off" segment="0"/>
+        <Accommodation code="TDS_MfR1" type="Mark for Review" value="True" segment="0"/>
+        <Accommodation code="TDS_Other" type="Other" value="None" segment="0"/>
+        <Accommodation code="TDS_PM0" type="Permissive Mode" value="Permissive Mode Disabled" segment="0"/>
+        <Accommodation code="TDS_PS_L0" type="Print Size" value="No default zoom applied" segment="0"/>
+        <Accommodation code="TDS_RSL_ListView" type="Review Screen Layout" value="List" segment="0"/>
+        <Accommodation code="TDS_SCNotepad" type="Student Comments" value="On" segment="0"/>
+        <Accommodation code="TDS_ST1" type="Strikethrough" value="True" segment="0"/>
+        <Accommodation code="TDS_SVC1" type="System Volume Control" value="Show widget" segment="0"/>
+        <Accommodation code="TDS_TPI_ResponsesFix" type="Test Progress Indicator" value="Show indicator as a fraction and adjust to test length" segment="0"/>
+        <Accommodation code="TDS_TS_Universal" type="Test Shell" value="Universal Shell" segment="0"/>
+        <Accommodation code="TDS_WL_Glossary" type="Word List" value="English Glossary" segment="0"/>
+        <Score measureOf="Overall" measureLabel="Attempted" value="Y" standardError=""/>
+        <Score measureOf="Overall" measureLabel="ThetaScore" value="1.02243078695094" standardError="0.641280451016051"/>
+        <Score measureOf="Overall" measureLabel="ScaleScore" value="2595.97876140521" standardError="50.8535397655728"/>
+        <Score measureOf="Overall" measureLabel="PerformanceLevel" value="3" standardError=""/>
+        <Score measureOf="Print Size|TDS_PS_L0" measureLabel="Accommodation" value="3" standardError="0"/>
+        <!-- Sample Multiple Choice (MC) -->
+        <Item adminDate="2018-08-27T15:38:47.967-05:00" bankKey="10200" clientId="" dropped="0" format="IAT"
+              isSelected="1" key="46849" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="1"
+              pageTime="4300" pageVisits="1" position="1" responseDuration="4300" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-ICA-ELA-COMBINED-6-SEG1-Winter-2018-2019">
+            <Response junit="mc" date="2018-08-27T15:38:51.637-05:00" key="1a43cab1-baea-4b6d-9d28-34f447e6b53e" type="">&lt;itemResponse&gt;&lt;response
+                id="choiceInteraction_1.RESPONSE"&gt;&lt;value&gt;choiceInteraction_1-choice-A&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt;
+            </Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Multiple Select (MS) -->
+        <Item adminDate="2018-08-27T15:38:47.973-05:00" bankKey="10200" clientId="" dropped="0" format="IAT"
+              isSelected="1" key="41340" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2"
+              pageTime="2600" pageVisits="1" position="2" responseDuration="2600" score="0" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-ICA-ELA-COMBINED-6-SEG1-Winter-2018-2019">
+            <Response junit="ms" date="2018-08-27T15:38:54.433-05:00" key="3e6f56d2-53d5-497e-a34d-a7a332fbfd96" type="">&lt;itemResponse&gt;&lt;response
+                id="choiceInteraction_1.RESPONSE"&gt;&lt;value&gt;choiceInteraction_1-choice-A&lt;/value&gt;&lt;value&gt;choiceInteraction_1-choice-C&lt;/value&gt;&lt;value&gt;choiceInteraction_1-choice-D&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt;
+            </Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="0" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample EBSR -->
+        <Item adminDate="2018-08-27T15:38:51.64-05:00" bankKey="10200" clientId="" dropped="0" format="IAT"
+              isSelected="1" key="37115" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="4"
+              pageTime="22400" pageVisits="1" position="5" responseDuration="22400" score="0" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-ICA-ELA-COMBINED-6-SEG1-Winter-2018-2019">
+            <Response junit="ebsr" date="2018-08-27T15:39:05.14-05:00" key="3d3b10b9-df2d-4410-8751-88080d832347" type="">&lt;itemResponse&gt;&lt;response
+                id="choiceInteraction_1.RESPONSE"&gt;&lt;value&gt;choiceInteraction_1-choice-B&lt;/value&gt;&lt;/response&gt;&lt;response
+                id="choiceInteraction_2.RESPONSE"&gt;&lt;value&gt;choiceInteraction_2-choice-A&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt;
+            </Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="0" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Match Interaction (MI) -->
+        <Item adminDate="2018-09-05T16:42:07.67-05:00" bankKey="10200" clientId="" dropped="0" format="IAT" isSelected="1"
+              key="92135" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2" pageTime="21100"
+              pageVisits="1" position="2" responseDuration="21100" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-IAB-MA-NS-8-Winter-2018-2019">
+            <Response junit="mi" date="2018-09-05T16:42:48.843-05:00" key="dde221bd-1840-4da2-8e58-335ed79a22c7" type="">&lt;itemResponse&gt;&lt;response
+                id="matchInteraction_1.RESPONSE"&gt;&lt;value&gt;matchInteraction_1-1 matchInteraction_1-a&lt;/value&gt;&lt;value&gt;matchInteraction_1-2
+                matchInteraction_1-b&lt;/value&gt;&lt;value&gt;matchInteraction_1-3 matchInteraction_1-b&lt;/value&gt;&lt;value&gt;matchInteraction_1-4
+                matchInteraction_1-a&lt;/value&gt;&lt;value&gt;matchInteraction_1-5 matchInteraction_1-a&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt;
+            </Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Table Interaction (TI) (from xls, no sample in TRTs) -->
+        <Item adminDate="2018-09-05T16:42:07.67-05:00" bankKey="10200" clientId="" dropped="0" format="IAT" isSelected="1"
+              key="92135" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2" pageTime="21100"
+              pageVisits="1" position="2" responseDuration="21100" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-IAB-MA-NS-8-Winter-2018-2019">
+            <Response junit="ti" date="2018-09-05T16:42:48.843-05:00" key="dde221bd-1840-4da2-8e58-335ed79a22c7" type="">&lt;itemResponse&gt;
+                &lt;response id="tableInteraction_1.CUSTOM"&gt;&lt;value&gt;&amp;lt;responseSpec&amp;gt;&amp;lt;responseTable&amp;gt;&amp;lt;tr&amp;gt;&amp;lt;th id="col0" /&amp;gt;&amp;lt;th id="col1" /&amp;gt;&amp;lt;th id="col2" /&amp;gt;&amp;lt;th id="col3" /&amp;gt;&amp;lt;th id="col4" /&amp;gt;&amp;lt;th id="col5" /&amp;gt;&amp;lt;th id="col6" /&amp;gt;&amp;lt;th id="col7" /&amp;gt;&amp;lt;th id="col8" /&amp;gt;&amp;lt;th id="col9" /&amp;gt;&amp;lt;th id="col10" /&amp;gt;&amp;lt;/tr&amp;gt;&amp;lt;tr&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td&amp;gt;B&amp;lt;/td&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td&amp;gt;A&amp;lt;/td&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td&amp;gt;C&amp;lt;/td&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td /&amp;gt;&amp;lt;td&amp;gt;D&amp;lt;/td&amp;gt;&amp;lt;/tr&amp;gt;&amp;lt;/responseTable&amp;gt;&amp;lt;/responseSpec&amp;gt;&lt;/value&gt;
+                &lt;/response&gt;
+            &lt;/itemResponse&gt;
+            </Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Hot Text Interaction (HTQ) (from xls, no sample in TRTs) -->
+        <Item adminDate="2018-09-05T16:42:07.67-05:00" bankKey="10200" clientId="" dropped="0" format="IAT" isSelected="1"
+              key="92135" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2" pageTime="21100"
+              pageVisits="1" position="2" responseDuration="21100" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-IAB-MA-NS-8-Winter-2018-2019">
+            <Response junit="htq" date="2018-09-05T16:42:48.843-05:00" key="dde221bd-1840-4da2-8e58-335ed79a22c7" type="">&lt;itemResponse&gt;
+                &lt;response id="hotTextInteraction_1.RESPONSE"&gt;&lt;value&gt;hotTextInteraction_1-hottext-2&lt;/value&gt;&lt;value&gt;hotTextInteraction_1-hottext-4&lt;/value&gt;
+                &lt;/response&gt;
+                &lt;/itemResponse&gt;
+            </Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Equation Interaction (EQ) (from xls, no sample in TRTs) -->
+        <Item adminDate="2018-09-05T16:42:07.67-05:00" bankKey="10200" clientId="" dropped="0" format="IAT" isSelected="1"
+              key="92135" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2" pageTime="21100"
+              pageVisits="1" position="2" responseDuration="21100" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-IAB-MA-NS-8-Winter-2018-2019">
+            <Response junit="eq" date="2018-09-05T16:42:48.843-05:00" key="dde221bd-1840-4da2-8e58-335ed79a22c7" type="">&lt;itemResponse&gt;
+                &lt;response id="equationInteraction_1.CUSTOM"&gt;
+                &lt;value&gt;&amp;lt;response&amp;gt;&amp;lt;math xmlns="http://www.w3.org/1998/Math/MathML" title="50"&amp;gt;&amp;lt;mstyle&amp;gt;&amp;lt;mn&amp;gt;50&amp;lt;/mn&amp;gt;&amp;lt;/mstyle&amp;gt;&amp;lt;/math&amp;gt;&amp;lt;/response&amp;gt;
+                &lt;/value&gt;
+            &lt;/response&gt;
+            &lt;/itemResponse&gt;</Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Grid Interaction (GI) (from xls, no sample in TRTs) -->
+        <Item adminDate="2018-09-05T16:42:07.67-05:00" bankKey="10200" clientId="" dropped="0" format="IAT" isSelected="1"
+              key="92135" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2" pageTime="21100"
+              pageVisits="1" position="2" responseDuration="21100" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-IAB-MA-NS-8-Winter-2018-2019">
+            <Response junit="gi" date="2018-09-05T16:42:48.843-05:00" key="dde221bd-1840-4da2-8e58-335ed79a22c7" type="">&lt;itemResponse&gt;
+                &lt;response id="gridInteraction_1.CUSTOM"&gt;
+                &lt;value&gt;&amp;lt;?xml version="1.0" encoding="UTF-8"?&amp;gt;&amp;lt;AnswerSet&amp;gt;&amp;lt;Question id=""&amp;gt;&amp;lt;QuestionPart id="1"&amp;gt;&amp;lt;ObjectSet&amp;gt;&amp;lt;AtomicObject&amp;gt;{AminusB(91,49)}&amp;lt;/AtomicObject&amp;gt;&amp;lt;AtomicObject&amp;gt;{BC(193,49)}&amp;lt;/AtomicObject&amp;gt;&amp;lt;AtomicObject&amp;gt;{C(299,49)}&amp;lt;/AtomicObject&amp;gt;&amp;lt;RegionGroupObject name="PartA" numselected="1"&amp;gt;&amp;lt;RegionObject name="Step1" isselected="false" /&amp;gt;&amp;lt;RegionObject name="Step2" isselected="true" /&amp;gt;&amp;lt;RegionObject name="Step3" isselected="false" /&amp;gt;&amp;lt;RegionObject name="Step4" isselected="false" /&amp;gt;&amp;lt;/RegionGroupObject&amp;gt;&amp;lt;/ObjectSet&amp;gt;&amp;lt;SnapPoint&amp;gt;70@91,361;193,361;299,361;407,361;299,345;299,377&amp;lt;/SnapPoint&amp;gt;&amp;lt;/QuestionPart&amp;gt;&amp;lt;/Question&amp;gt;&amp;lt;/AnswerSet&amp;gt;&lt;/value&gt;
+            &lt;/response&gt;
+            &lt;/itemResponse&gt;</Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <!-- Sample Writing Extended Response Interaction (WER) (from xls, no sample in TRTs) -->
+        <Item adminDate="2018-09-05T16:42:07.67-05:00" bankKey="10200" clientId="" dropped="0" format="IAT" isSelected="1"
+              key="92135" mimeType="text/xml" numberVisits="1" operational="1" pageNumber="2" pageTime="21100"
+              pageVisits="1" position="2" responseDuration="21100" score="1" scoreStatus="SCORED"
+              segmentId="(SBAC)SBAC-GEN-INTR-IAB-MA-NS-8-Winter-2018-2019">
+            <Response junit="wer" date="2018-09-05T16:42:48.843-05:00" key="dde221bd-1840-4da2-8e58-335ed79a22c7" type="">&lt;itemResponse&gt;
+                &lt;response id="textEntryInteraction_1.CUSTOM"&gt;
+                &lt;value&gt;&amp;lt;p&amp;gt;&amp;lt;strong&amp;gt;&amp;lt;em&amp;gt;&amp;lt;u&amp;gt;&amp;nbsp;&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; The Help of a Tablet &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;&amp;nbsp;&amp;lt;/u&amp;gt;&amp;lt;/em&amp;gt;&amp;lt;/strong&amp;gt;&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;&amp;nbsp; &amp;nbsp; My thesis of the help a tablet can provide is this, a tablet can help children with different learning styles, create a better learning environment, and introduce the children into a world of knowledge. Using the tablets can introduce the students into the biggest library of all. They can see, hear, and observe anything thing that they might be studying. Here is more information and in more detail.&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;&amp;nbsp; &amp;nbsp; Children with different learning styles have a hard time in a classroom that they can&amp;#39;t see, hear or fully understand what their topic is about. It can be difficult for a child with a different learning style that is struggling to learn. mobile technology for a classroom is an interesting addition to a class. It not only provides a lot of knowledge but helps the children with different learning styles tremendously. A tablet can give a student the pictures that the might need that they didn&amp;#39;t have before, or students could listen to some video or audio on their topic.&amp;nbsp;&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;&amp;nbsp; &amp;nbsp; A mobile technology device can introduce a new and improved learning environment for the students. Instead of the children getting bored with their teacher&amp;#39;s endless talking and gesturing, the children can now find the kind of informational form of their topic in a way that suites them the best. Yes, the teachers are still there, but now the student&amp;#39;s can have the best of both worlds with their teacher and their tablet.&amp;nbsp;&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;&amp;nbsp; &amp;nbsp; Lastly, a mobile technology device has so much information on it. A child&amp;nbsp;can learn so much just by looking it up.&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;If they were doing a project on the states they could have so much information at their finger tips that they would be an expert on their state if they researched just for a month when it would have taken way longer without the mobile devices. The students could have all of that information right there waiting for them. It is as if they had just walked into the biggest library on earth.&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;&amp;nbsp; &amp;nbsp; The tablets will introduce so much knowledge and creativity for the students, and it&amp;#39;s all just waiting for them. The tablets help children with different learning styles, create a better learning environment, and introduce them into a world of knowledge. The tablets will be a wonderful addition to the school as well as the classrooms and will make learning fun, for everyone.&amp;lt;/p&amp;gt;
+
+                &amp;lt;p&amp;gt;&amp;nbsp;&amp;lt;/p&amp;gt;
+                &lt;/value&gt;
+                &lt;/response&gt;
+                &lt;/itemResponse&gt;</Response>
+            <ScoreInfo maxScore="1" scoreDimension="overall" scorePoint="1" scoreStatus="Scored">
+                <ScoreRationale/>
+            </ScoreInfo>
+        </Item>
+        <Item responseDuration="27" pageTime="0" pageNumber="7" pageVisits="0" numberVisits="2" format="MI" adminDate="2016-10-12T21:56:15.723" clientId=""
+              key="90323" bankKey="10200" position="7" contentLevel="1|S|TS07|L-4" strand="1" scoreStatus="SCORED" operational="1" dropped="0" isSelected="1" score="1"
+              mimeType="text/plain" segmentId="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017">
+            <Response date="2016-10-12T22:00:09.434" type="value"> &lt;itemResponse&gt;&lt;response id="RESPONSE"&gt;&lt;value&gt;1 b&lt;/value&gt;&lt;value&gt;1 c&lt;/value&gt;&lt;value&gt;2
+                a&lt;/value&gt;&lt;value&gt;2 c&lt;/value&gt;&lt;value&gt;3 a&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt; </Response>
+            <ScoreInfo scorePoint="1" maxScore="1" scoreDimension="overall" scoreStatus="Scored">
+                <ScoreRationale>
+                    <Message>
+                        successfully scored
+                    </Message>
+                </ScoreRationale>
+            </ScoreInfo>
+        </Item>
+        <Item responseDuration="24" pageTime="0" pageNumber="8" pageVisits="0" numberVisits="2" format="MI" adminDate="2016-10-12T21:56:22.726" clientId=""
+              key="89142" bankKey="10200" position="8" contentLevel="1|S|TS07|L-4" strand="1" scoreStatus="SCORED" operational="1" dropped="0" isSelected="1" score="0"
+              mimeType="text/plain" segmentId="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017">
+            <Response date="2016-10-12T22:00:07.272" type="value"> &lt;itemResponse&gt;&lt;response id="RESPONSE"&gt;&lt;value&gt;1 b&lt;/value&gt;&lt;value&gt;2 c&lt;/value&gt;&lt;value&gt;3
+                e&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt; </Response>
+            <ScoreInfo scorePoint="0" maxScore="1" scoreDimension="overall" scoreStatus="Scored">
+                <ScoreRationale>
+                    <Message>
+                        successfully scored
+                    </Message>
+                </ScoreRationale>
+            </ScoreInfo>
+        </Item>
+        <Item responseDuration="49" pageTime="0" pageNumber="9" pageVisits="0" numberVisits="3" format="MI" adminDate="2016-10-12T21:56:44.024" clientId=""
+              key="82292" bankKey="10200" position="9" contentLevel="1|S|TS07|L-4" strand="1" scoreStatus="SCORED" operational="1" dropped="0" isSelected="1" score="0"
+              mimeType="text/plain" segmentId="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017">
+            <Response date="2016-10-12T22:00:06.739" type="value"> &lt;itemResponse&gt;&lt;response id="RESPONSE"&gt;&lt;value&gt;1 b&lt;/value&gt;&lt;value&gt;2 f&lt;/value&gt;&lt;value&gt;3
+                c&lt;/value&gt;&lt;value&gt;3 f&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt; </Response>
+            <ScoreInfo scorePoint="0" maxScore="1" scoreDimension="overall" scoreStatus="Scored">
+                <ScoreRationale>
+                    <Message>
+                        successfully scored
+                    </Message>
+                </ScoreRationale>
+            </ScoreInfo>
+        </Item>
+        <Item responseDuration="56" pageTime="0" pageNumber="10" pageVisits="0" numberVisits="3" format="MI" adminDate="2016-10-12T21:57:09.309" clientId=""
+              key="82656" bankKey="10200" position="10" contentLevel="1|S|TS07|L-4" strand="1" scoreStatus="SCORED" operational="1" dropped="0" isSelected="1" score="1"
+              mimeType="text/plain" segmentId="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017">
+            <Response date="2016-10-12T22:00:06.173" type="value"> &lt;itemResponse&gt;&lt;response id="RESPONSE"&gt;&lt;value&gt;1 a&lt;/value&gt;&lt;value&gt;1 b&lt;/value&gt;&lt;value&gt;2
+                a&lt;/value&gt;&lt;value&gt;2 c&lt;/value&gt;&lt;value&gt;3 b&lt;/value&gt;&lt;value&gt;3
+                c&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt; </Response>
+            <ScoreInfo scorePoint="1" maxScore="1" scoreDimension="overall" scoreStatus="Scored">
+                <ScoreRationale>
+                    <Message>
+                        successfully scored
+                    </Message>
+                </ScoreRationale>
+            </ScoreInfo>
+        </Item>
+        <Item responseDuration="49" pageTime="0" pageNumber="11" pageVisits="0" numberVisits="2" format="MI" adminDate="2016-10-12T21:57:33.065" clientId=""
+              key="91720" bankKey="10200" position="11" contentLevel="1|S|TS07|L-4" strand="1" scoreStatus="SCORED" operational="1" dropped="0" isSelected="1" score="0"
+              mimeType="text/plain" segmentId="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017">
+            <Response date="2016-10-12T22:00:05.481" type="value"> &lt;itemResponse&gt;&lt;response id="RESPONSE"&gt;&lt;value&gt;1 b&lt;/value&gt;&lt;value&gt;2 b&lt;/value&gt;&lt;value&gt;3
+                a&lt;/value&gt;&lt;/response&gt;&lt;/itemResponse&gt; </Response>
+            <ScoreInfo scorePoint="0" maxScore="1" scoreDimension="overall" scoreStatus="Scored">
+                <ScoreRationale>
+                    <Message>
+                        successfully scored
+                    </Message>
+                </ScoreRationale>
+            </ScoreInfo>
+        </Item>
+    </Opportunity>
+</TDSReport>

--- a/script-common/src/test/resources/scripts/exam_script.groovy
+++ b/script-common/src/test/resources/scripts/exam_script.groovy
@@ -34,7 +34,7 @@ transform '//Response' by { response ->
                 text.contains('textEntryInteraction_')) {
         response.text = text
                 .replaceAll(~/(?s).+<value>(.+)<\/value>.+/, '$1')
-                .unescapeXml()
+                .unescapeHtmlTags()
     }
 }
 

--- a/script-common/src/test/resources/scripts/exam_script.groovy
+++ b/script-common/src/test/resources/scripts/exam_script.groovy
@@ -1,0 +1,41 @@
+transform '//Item' by { item ->
+    if (item.bankKey.startsWith('10')) {
+        item.bankKey = item.bankKey.substring(2)
+    }
+}
+
+transform '//Response' by { response ->
+    def text = response.text
+
+    if (text.contains('choiceInteraction_1') && text.contains('choiceInteraction_2')) {
+        response.text = text
+                .replaceAll(~/choiceInteraction_(\d).RESPONSE/, 'EBSR$1')
+                .replaceAll(~/choiceInteraction_\d-choice-(\w)/, '$1')
+
+    } else if (text.contains('choiceInteraction_1')) {
+        def matches = text =~ /choiceInteraction_1-choice-(\w)/
+        if (matches.count > 0) {
+            response.text = matches.collect { it[1] }.join(',')
+        }
+
+    } else if (text.contains('matchInteraction')) {
+        response.text = text
+                .replaceAll(~/matchInteraction_\d.RESPONSE/, 'RESPONSE')
+                .replaceAll(~/matchInteraction_\d-(\d)\W*matchInteraction_\d-(\w)/, '$1 $2')
+
+    } else if (text.contains('hotTextInteraction_')) {
+        response.text = text
+                .replaceAll(~/hotTextInteraction_(\d).RESPONSE/, '$1')
+                .replaceAll(~/hotTextInteraction_\d-hottext-(\d)/, '$1')
+
+    } else if ( text.contains('equationInteraction_') ||
+                text.contains('tableInteraction_') ||
+                text.contains('gridInteraction_') ||
+                text.contains('textEntryInteraction_')) {
+        response.text = text
+                .replaceAll(~/(?s).+<value>(.+)<\/value>.+/, '$1')
+                .unescapeXml()
+    }
+}
+
+outputXml

--- a/script-common/src/test/resources/scripts/exam_script_hybrid.groovy
+++ b/script-common/src/test/resources/scripts/exam_script_hybrid.groovy
@@ -30,7 +30,7 @@ transform '//Response' by { response ->
                 text.contains('textEntryInteraction_')) {
         response.text = text
                 .replaceAll(~/(?s).+<value>(.+)<\/value>.+/, '$1')
-                .unescapeXml()
+                .unescapeHtmlTags()
     }
 }
 

--- a/script-common/src/test/resources/scripts/exam_script_hybrid.groovy
+++ b/script-common/src/test/resources/scripts/exam_script_hybrid.groovy
@@ -1,0 +1,37 @@
+applyXsl xslItemRulesOnly
+
+transform '//Response' by { response ->
+    def text = response.text
+
+    if (text.contains('choiceInteraction_1') && text.contains('choiceInteraction_2')) {
+        response.text = text
+                .replaceAll(~/choiceInteraction_(\d).RESPONSE/, 'EBSR$1')
+                .replaceAll(~/choiceInteraction_\d-choice-(\w)/, '$1')
+
+    } else if (text.contains('choiceInteraction_1')) {
+        def matches = text =~ /choiceInteraction_1-choice-(\w)/
+        if (matches.count > 0) {
+            response.text = matches.collect { it[1] }.join(',')
+        }
+
+    } else if (text.contains('matchInteraction')) {
+        response.text = text
+                .replaceAll(~/matchInteraction_\d.RESPONSE/, 'RESPONSE')
+                .replaceAll(~/matchInteraction_\d-(\d)\W*matchInteraction_\d-(\w)/, '$1 $2')
+
+    } else if (text.contains('hotTextInteraction_')) {
+        response.text = text
+                .replaceAll(~/hotTextInteraction_(\d).RESPONSE/, '$1')
+                .replaceAll(~/hotTextInteraction_\d-hottext-(\d)/, '$1')
+
+    } else if ( text.contains('equationInteraction_') ||
+                text.contains('tableInteraction_') ||
+                text.contains('gridInteraction_') ||
+                text.contains('textEntryInteraction_')) {
+        response.text = text
+                .replaceAll(~/(?s).+<value>(.+)<\/value>.+/, '$1')
+                .unescapeXml()
+    }
+}
+
+outputXml

--- a/script-common/src/test/resources/scripts/exam_script_xsl.groovy
+++ b/script-common/src/test/resources/scripts/exam_script_xsl.groovy
@@ -1,0 +1,3 @@
+applyXsl xslAllRules
+
+outputXml

--- a/script-common/src/test/resources/xsl/exam.xsl
+++ b/script-common/src/test/resources/xsl/exam.xsl
@@ -1,0 +1,174 @@
+<!DOCTYPE xsl:stylesheet >
+<xsl:stylesheet
+    version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:trt="urn:trt">
+  <xsl:output method="xml" omit-xml-declaration="yes" indent="yes"/>
+
+  <!--
+    These are characters that must be converted when "unescaping" embedded
+    XML response data. (e.g. "&amp;lt;" will result in "<")
+    Characters not present in the map below are left un-touched (e.g. "&amp;#39;" will result in "&#39;" rather than "'")
+  -->
+  <xsl:variable name="escapedChars">
+    <entry key="&amp;lt;">&lt;</entry>
+    <entry key="&amp;gt;">&gt;</entry>
+    <entry key="&amp;amp;">&amp;</entry>
+    <entry key="&amp;quot;">&quot;</entry>
+  </xsl:variable>
+
+  <!-- Helper function for "unescaping" wrapped XML content -->
+  <xsl:function name="trt:unescape">
+    <xsl:param name="escapedContent"/>
+    <xsl:analyze-string regex="(&amp;[^;]+;)" select="$escapedContent">
+      <xsl:matching-substring>
+        <xsl:variable name="unescapedCharacter" select="$escapedChars/entry[@key=regex-group(1)]/text()"/>
+        <xsl:choose>
+          <xsl:when test="string-length($unescapedCharacter) > 0">
+            <xsl:value-of select="$unescapedCharacter"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="regex-group(1)"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+        <xsl:value-of select="."/>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
+  </xsl:function>
+
+  <!-- identity rule copies everything by default -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- this rule removes leading 10 from item bank key -->
+  <xsl:template match="Item[starts-with(@bankKey, '10')]/@bankKey">
+    <xsl:attribute name="bankKey">
+      <xsl:value-of select="substring(., 3)"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <!-- this rule converts IAT multiple-choice and multiple-select responses to the expected format ("A,C,D") -->
+  <xsl:template match="Response[contains(text(),'choiceInteraction_1') and not(contains(text(), 'choiceInteraction_2'))]/text()">
+    <xsl:variable name="choices" select="replace(., '\s*&lt;(?!/?value)[^&gt;]+&gt;\s*', '', ';j')"/>
+    <xsl:variable name="choiceCharacters" select="replace($choices, '&lt;[^&lt;]+-choice-(\w)&lt;[^&gt;]+&gt;', '$1,')"/>
+    <xsl:value-of select="substring($choiceCharacters, 1, string-length($choiceCharacters)-1)"/>
+  </xsl:template>
+
+  <!--
+    This rule converts EBSR multiple-choice and multiple-select responses to the expected format:
+    <itemResponse>
+      <response id="EBSR1">
+        <value>A</value>
+      </response>
+      <response id="EBSR2">
+        <value>C</value>
+      </response>
+    </itemResponse>
+  -->
+  <xsl:template match="Response[contains(text(),'choiceInteraction_1') and contains(text(), 'choiceInteraction_2')]/text()">
+    <xsl:variable name="convertedResponses" select="replace(., 'choiceInteraction_(\d).RESPONSE', 'EBSR$1')"/>
+    <xsl:value-of select="replace($convertedResponses, 'choiceInteraction_\d-choice-(\w)', '$1')"/>
+  </xsl:template>
+
+  <!--
+    This rule converts Match Interaction (MI) responses to the expected format:
+    <itemResponse>
+      <response id="RESPONSE">
+        <value>1 a</value>
+        <value>2 b</value>
+        <value>3 a</value>
+        <value>4 b</value>
+      </response>
+    </itemResponse>
+  -->
+  <xsl:template match="Response[contains(text(),'matchInteraction_')]/text()">
+    <xsl:variable name="convertedResponses" select="replace(., 'matchInteraction_\d.RESPONSE', 'RESPONSE')"/>
+    <xsl:value-of select="replace($convertedResponses, 'matchInteraction_\d-(\d)\W*matchInteraction_\d-(\w)', '$1 $2')"/>
+  </xsl:template>
+
+  <!--
+    This rule converts Table Interaction (TI) responses to the expected format:
+    <responseSpec>
+      <responseTable>
+        <tr><th id="col0" /><th id="col1" /><th id="col2" /><th id="col3" /><th id="col4" /><th id="col5" /><th id="col6" /><th id="col7" /><th id="col8" /><th id="col9" /><th id="col10" /></tr>
+        <tr><td /><td>B</td><td /><td /><td>A</td><td /><td /><td>C</td><td /><td /><td>D</td></tr>
+      </responseTable>
+    </responseSpec>
+  -->
+  <xsl:template match="Response[contains(text(),'tableInteraction_')]/text()">
+    <xsl:variable name="escapedResponse" select="replace(., '.+&lt;value&gt;(.+)&lt;/value&gt;.+', '$1', 's')"/>
+    <xsl:value-of select="trt:unescape($escapedResponse)"/>
+  </xsl:template>
+
+  <!--
+    This rule converts Hot Text Interaction (HTQ) responses to the expected format:
+    <itemResponse>
+      <response id="1">
+        <value>2</value>
+        <value>4</value>
+      </response>
+    </itemResponse>
+  -->
+  <xsl:template match="Response[contains(text(),'hotTextInteraction_')]/text()">
+    <xsl:variable name="convertedIds" select="replace(., 'hotTextInteraction_(\d).RESPONSE', '$1')"/>
+    <xsl:value-of select="replace($convertedIds, 'hotTextInteraction_\d-hottext-(\d)', '$1')"/>
+  </xsl:template>
+
+  <!--
+    This rule converts Equation Interaction (EQ) responses to the expected format:
+    <response>
+      <math xmlns="http://www.w3.org/1998/Math/MathML" title="50">
+        <mstyle><mn>50</mn></mstyle>
+      </math>
+    </response>
+  -->
+  <xsl:template match="Response[contains(text(),'equationInteraction_')]/text()">
+    <xsl:variable name="escapedResponse" select="replace(., '.+&lt;value&gt;(.+)&lt;/value&gt;.+', '$1', 's')"/>
+    <xsl:value-of select="trt:unescape($escapedResponse)"/>
+  </xsl:template>
+
+  <!--
+    This rule converts Grid Interaction (GI) responses to the expected format:
+    <?xml version="1.0" encoding="UTF-8"?>
+    <AnswerSet>
+      <Question id="">
+        <QuestionPart id="1">
+          <ObjectSet>
+            <AtomicObject>{AminusB(91,49)}</AtomicObject>
+            <AtomicObject>{BC(193,49)}</AtomicObject>
+            <AtomicObject>{C(299,49)}</AtomicObject>
+            <RegionGroupObject name="PartA" numselected="1">
+              <RegionObject name="Step1" isselected="false" />
+              <RegionObject name="Step2" isselected="true" />
+              <RegionObject name="Step3" isselected="false" />
+              <RegionObject name="Step4" isselected="false" />
+            </RegionGroupObject>
+          </ObjectSet>
+          <SnapPoint>70@91,361;193,361;299,361;407,361;299,345;299,377</SnapPoint>
+        </QuestionPart>
+      </Question>
+    </AnswerSet>
+  -->
+  <xsl:template match="Response[contains(text(),'gridInteraction_')]/text()">
+    <xsl:variable name="escapedResponse" select="replace(., '.+&lt;value&gt;(.+)&lt;/value&gt;.+', '$1', 's')"/>
+    <xsl:value-of select="trt:unescape($escapedResponse)"/>
+  </xsl:template>
+
+  <!--
+    This rule converts Short Answer / Writing Extended Response Interaction (SA|ER|WER) responses to the expected WYSIWYG format:
+    <p>&nbsp; This is <strong>free-entry</strong> text that <i>students</i> can:
+    <ul><li>enter</li><li>style</li><li>organize</li></ul>
+    <p>however they like. We can&#39;t unescape everything.
+  -->
+  <xsl:template match="Response[contains(text(),'textEntryInteraction_')]/text()">
+    <xsl:variable name="escapedResponse" select="replace(., '.+&lt;value&gt;(.+)&lt;/value&gt;.+', '$1', 's')"/>
+    <xsl:value-of select="trt:unescape($escapedResponse)"/>
+  </xsl:template>
+
+
+</xsl:stylesheet>

--- a/script-common/src/test/resources/xsl/exam_items_only.xsl
+++ b/script-common/src/test/resources/xsl/exam_items_only.xsl
@@ -1,0 +1,22 @@
+<!DOCTYPE xsl:stylesheet >
+<xsl:stylesheet
+    version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:trt="urn:trt">
+  <xsl:output method="xml" omit-xml-declaration="yes" indent="yes"/>
+
+  <!-- identity rule copies everything by default -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- this rule removes leading 10 from item bank key -->
+  <xsl:template match="Item[starts-with(@bankKey, '10')]/@bankKey">
+    <xsl:attribute name="bankKey">
+      <xsl:value-of select="substring(., 3)"/>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This is the first phase toward creating a basic DSL for the script pipeline, and I've included a README.md to demonstrate some samples of how the scripts for XML transformation could be written. I'd appreciate any feedback on the approach and general and more specific design elements. E.g., does it make sense to dynamically add XML methods to the script class or would it be better to have separate base classes based on the type of  input being processed? Also, are there other helper methods that we could add? 