### PR TITLE
change top-level for datasource properties; clean up data source beans a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,18 +134,16 @@ If you want to run the integration tests against Aurora (instead of the local My
 variables with the required credentials for the CI (or other appropriate) database instance. Note that the way things
 work for this, all the schemas must live in the same database server (so reporting and warehouse can't be separate
 servers). The users may be different (but for CI they are the same). The `ORG_GRADLE_PROJECT_*` variables are passed
-into the gradle environment so the RDW_Schema commands are applied to the correct database. The `SPRING_*_*` are used
-by the Spring Boot ITs. And the temporary variables are just to avoid some duplication.
+into the gradle environment so the RDW_Schema commands are applied to the correct database. The `DATASOURCES_*_*` are
+used by the Spring Boot ITs. And the temporary variables are just to avoid some duplication.
 ```bash
 (SERVER=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306; USER=sbac; PSWD=password; \
  export ORG_GRADLE_PROJECT_database_url=jdbc:mysql://$SERVER/; \
  export ORG_GRADLE_PROJECT_database_user=$USER; export ORG_GRADLE_PROJECT_database_password=$PSWD; \
- export SPRING_DATASOURCE_URL_SERVER=$SERVER; \
- export SPRING_DATASOURCE_USERNAME=$USER; export SPRING_DATASOURCE_PASSWORD=$PSWD; \
- export SPRING_REPORTING_DATASOURCE_URL_SERVER=$SERVER; \
- export SPRING_REPORTING_DATASOURCE_USERNAME=$USER; export SPRING_REPORTING_DATASOURCE_PASSWORD=$PSWD; \
- export SPRING_WAREHOUSE_DATASOURCE_URL_SERVER=$SERVER; \
- export SPRING_WAREHOUSE_DATASOURCE_USERNAME=$USER; export SPRING_WAREHOUSE_DATASOURCE_PASSWORD=$PSWD; \
+ export DATASOURCES_WAREHOUSE_RW_URL_SERVER=$SERVER; \
+ export DATASOURCES_WAREHOUSE_RW_USERNAME=$USER; export DATASOURCES_WAREHOUSE_RW_PASSWORD=$PSWD; \
+ export DATASOURCES_REPORTING_RW_URL_SERVER=$SERVER; \
+ export DATASOURCES_REPORTING_RW_USERNAME=$USER; export DATASOURCES_REPORTING_RW_PASSWORD=$PSWD; \
  ./gradlew it)
 ```
 
@@ -154,9 +152,9 @@ and they take a while to run. To run these tests you must set credentials -- ple
 migrate-olap/build.gradle. By default it uses the CI database instances:
 ```bash
 (export ARCHIVE_CLOUD_AWS_CREDENTIALS_SECRETKEY=secretkey; \
- export SPRING_MIGRATE_DATASOURCE_PASSWORD=password; \
- export SPRING_OLAP_DATASOURCE_PASSWORD=password; \
- export SPRING_WAREHOUSE_DATASOURCE_PASSWORD=password; \
+ export DATASOURCES_MIGRATE_RW_PASSWORD=password; \
+ export DATASOURCES_OLAP_RW_PASSWORD=password; \
+ export DATASOURCES_WAREHOUSE_RW_PASSWORD=password; \
  ./gradlew rst)
 ```
 

--- a/common/src/test/java/org/opentestsystem/rdw/ingest/common/repository/CommonTestConfiguration.java
+++ b/common/src/test/java/org/opentestsystem/rdw/ingest/common/repository/CommonTestConfiguration.java
@@ -2,8 +2,13 @@ package org.opentestsystem.rdw.ingest.common.repository;
 
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
 
 /**
  * This module is not a full spring application so have to provide a configuration.
@@ -12,4 +17,12 @@ import org.springframework.context.annotation.Import;
 @EnableCaching
 @Import({ YamlPropertiesConfigurator.class })
 public class CommonTestConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
+    public DataSource dataSource() {
+        return DataSourceBuilder
+                .create()
+                .build();
+    }
 }

--- a/common/src/test/resources/application-test.yml
+++ b/common/src/test/resources/application-test.yml
@@ -3,18 +3,19 @@ spring:
     type: SIMPLE
     cache-names: grade, language
 
-  datasource:
+datasources:
+  warehouse_rw:
     url: "\
-      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse_test}\
-      ?useSSL=${spring.datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.datasource.character-encoding:utf8}\
-      &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
-      &noAccessToProcedureBodies=${spring.datasource.no-access-to-procedure-bodies:true}\
-      &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:40000}\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse_test}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &rewriteBatchedStatements=${datasources.warehouse_rw.rewrite-batched-statements:true}\
+      &noAccessToProcedureBodies=${datasources.warehouse_rw.no-access-to-procedure-bodies:true}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:40000}\
       "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:30})"
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:30})"
     username: root
     password:
     testWhileIdle: true

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/DataSourceConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/repository/DataSourceConfiguration.java
@@ -27,14 +27,14 @@ import javax.sql.DataSource;
 public class DataSourceConfiguration {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource")
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource dataSource() {
         return DataSourceBuilder
                 .create()
                 .build();
     }
 
-    @Bean(name = "queryJdbcTemplate")
+    @Bean
     public NamedParameterJdbcTemplate queryJdbcTemplate() {
         return new NamedParameterJdbcTemplate(dataSource());
     }

--- a/exam-processor/src/main/resources/application.yml
+++ b/exam-processor/src/main/resources/application.yml
@@ -21,18 +21,27 @@ spring:
           destination: EXAM
           group: default
 
-  datasource:
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+
+  profiles:
+    include: ingest-common
+
+datasources:
+  warehouse_rw:
     url: "\
-      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse}\
-      ?useSSL=${spring.datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.datasource.character-encoding:utf8}\
-      &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
-      &noAccessToProcedureBodies=${spring.datasource.no-access-to-procedure-bodies:true}\
-      &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:40000}\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &rewriteBatchedStatements=${datasources.warehouse_rw.rewrite-batched-statements:true}\
+      &noAccessToProcedureBodies=${datasources.warehouse_rw.no-access-to-procedure-bodies:true}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:40000}\
       "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:30})"
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:30})"
     username: root
     password:
     testWhileIdle: true
@@ -42,17 +51,9 @@ spring:
     initialize: false
     initialSize: 6
     maxActive: 12
-    minIdle: ${spring.datasource.initialSize}
-    maxIdle: ${spring.datasource.maxActive}
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}
     maxWait: 10000
-
-  jackson:
-    default-property-inclusion: non_null
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
-
-  profiles:
-    include: ingest-common
 
 jdbc:
   retry:

--- a/exam-processor/src/test/resources/application-optional.yml
+++ b/exam-processor/src/test/resources/application-optional.yml
@@ -1,5 +1,5 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test
 
 validation:

--- a/exam-processor/src/test/resources/application-optional2.yml
+++ b/exam-processor/src/test/resources/application-optional2.yml
@@ -1,5 +1,5 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test
 
 validation:

--- a/exam-processor/src/test/resources/application-required.yml
+++ b/exam-processor/src/test/resources/application-required.yml
@@ -1,5 +1,5 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test
 
 validation:

--- a/exam-processor/src/test/resources/application-test.yml
+++ b/exam-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/configuration/DataSourceConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/configuration/DataSourceConfiguration.java
@@ -20,14 +20,14 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class DataSourceConfiguration {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource")
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource dataSource() {
         return DataSourceBuilder
                 .create()
                 .build();
     }
 
-    @Bean(name = "queryJdbcTemplate")
+    @Bean
     public NamedParameterJdbcTemplate queryJdbcTemplate() {
         return new NamedParameterJdbcTemplate(dataSource());
     }

--- a/group-processor/src/main/resources/application.yml
+++ b/group-processor/src/main/resources/application.yml
@@ -34,18 +34,24 @@ spring:
           destination: GROUPS
           group: default
 
-  datasource:
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+
+datasources:
+  warehouse_rw:
     url: "\
-      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse}\
-      ?useSSL=${spring.datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.datasource.character-encoding:utf8}\
-      &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
-      &sessionVariables=${spring.datasource.session-variables:group_concat_max_len=10000}\
-      &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:310000}\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &rewriteBatchedStatements=${datasources.warehouse_rw.rewrite-batched-statements:true}\
+      &sessionVariables=${datasources.warehouse_rw.session-variables:group_concat_max_len=10000}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:310000}\
       "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:300})"
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:300})"
     username: root
     password:
     testWhileIdle: true
@@ -55,10 +61,5 @@ spring:
     initialize: false
     initialSize: 4
     maxActive: 10
-    minIdle: ${spring.datasource.initialSize}
-    maxIdle: ${spring.datasource.maxActive}
-
-  jackson:
-    default-property-inclusion: non_null
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}

--- a/group-processor/src/test/resources/application-test.yml
+++ b/group-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/DataSourceConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/repository/DataSourceConfiguration.java
@@ -22,13 +22,14 @@ import javax.sql.DataSource;
 public class DataSourceConfiguration {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource")
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource dataSource() {
         return DataSourceBuilder
                 .create()
                 .build();
     }
 
+    // repositories pulled in from common require precise bean name
     @Bean(name = {"queryJdbcTemplate", "warehouseJdbcTemplate"})
     public NamedParameterJdbcTemplate queryJdbcTemplate() {
         return new NamedParameterJdbcTemplate(dataSource());

--- a/import-service/src/main/resources/application.yml
+++ b/import-service/src/main/resources/application.yml
@@ -77,29 +77,6 @@ spring:
           producer:
             requiredGroups: default
 
-  datasource:
-    url: "\
-      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse}\
-      ?useSSL=${spring.datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.datasource.character-encoding:utf8}\
-      &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:40000}\
-      "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:30})"
-    username: root
-    password:
-    testWhileIdle: true
-    validationQuery: SELECT 1
-    validationQueryTimeout: 10000
-    driverClassName: com.mysql.jdbc.Driver
-    initialize: false
-    initialSize: 4
-    maxActive: 20
-    minIdle: ${spring.datasource.initialSize}
-    maxIdle: ${spring.datasource.maxActive}
-    maxWait: 10000
-
   http:
     multipart:
       max-file-size: 500MB
@@ -109,3 +86,27 @@ spring:
     default-property-inclusion: non_null
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+
+datasources:
+  warehouse_rw:
+    url: "\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:40000}\
+      "
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:30})"
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    validationQueryTimeout: 10000
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+    initialSize: 4
+    maxActive: 20
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}
+    maxWait: 10000

--- a/import-service/src/test/resources/application-test.yml
+++ b/import-service/src/test/resources/application-test.yml
@@ -1,5 +1,5 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test
     maxActive: 10
     query-timeout: 2

--- a/migrate-olap/build.gradle
+++ b/migrate-olap/build.gradle
@@ -48,21 +48,21 @@ cleanAllTest migrateAllTest
 // (but don't check in your changes!) or set environment variables. If you are using the default
 // CI instances with personal schemas you should set:
 //   ARCHIVE_CLOUD_AWS_CREDENTIALS_SECRETKEY
-//   SPRING_MIGRATE_DATASOURCE_URL_SCHEMA
-//   SPRING_MIGRATE_DATASOURCE_PASSWORD
-//   SPRING_OLAP_DATASOURCE_USERNAME
-//   SPRING_OLAP_DATASOURCE_PASSWORD
-//   SPRING_WAREHOUSE_DATASOURCE_URL_SCHEMA
-//   SPRING_WAREHOUSE_DATASOURCE_PASSWORD
+//   DATASOURCES_MIGRATE_RW_URL_SCHEMA
+//   DATASOURCES_MIGRATE_RW_PASSWORD
+//   DATASOURCES_OLAP_RW_USERNAME
+//   DATASOURCES_OLAP_RW_PASSWORD
+//   DATASOURCES_WAREHOUSE_RW_URL_SCHEMA
+//   DATASOURCES_WAREHOUSE_RW_PASSWORD
 // If you are running from the command-line you can use local bash export to do it in one command, e.g.:
 /*
 (export ARCHIVE_CLOUD_AWS_CREDENTIALS_SECRETKEY=secretkey; \
- export SPRING_MIGRATE_DATASOURCE_URL_SCHEMA=bob_migrate_olap_test; \
- export SPRING_MIGRATE_DATASOURCE_PASSWORD=password; \
- export SPRING_OLAP_DATASOURCE_USERNAME=bob; \
- export SPRING_OLAP_DATASOURCE_PASSWORD=password; \
- export SPRING_WAREHOUSE_DATASOURCE_URL_SCHEMA=bob_warehouse_test; \
- export SPRING_WAREHOUSE_DATASOURCE_PASSWORD=password; \
+ export DATASOURCES_MIGRATE_RW_URL_SCHEMA=bob_migrate_olap_test; \
+ export DATASOURCES_MIGRATE_RW_PASSWORD=password; \
+ export DATASOURCES_OLAP_RW_USERNAME=bob; \
+ export DATASOURCES_OLAP_RW_PASSWORD=password; \
+ export DATASOURCES_WAREHOUSE_RW_URL_SCHEMA=bob_warehouse_test; \
+ export DATASOURCES_WAREHOUSE_RW_PASSWORD=password; \
  gradle rst)
 */
 // If you are using different instances the full set of variables can be found in application-redshift.yml.
@@ -75,18 +75,18 @@ cleanAllTest migrateAllTest
 --archive.cloud.aws.credentials.accessKey=access-key
 --archive.cloud.aws.credentials.secretKey=secret-key
 --migrate.aws.redshift.role=arn:aws:iam::269146879732:role/rdw-redshift
---spring.migrate_datasource.url-server=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
---spring.migrate_datasource.url-schema=bob_migrate_olap_test
---spring.migrate_datasource.username=sbac
---spring.migrate_datasource.password=password
---spring.olap_datasource.url-server=rdw-qa.cibkulpjrgtr.us-west-2.redshift.amazonaws.com:5439
---spring.olap_datasource.url-db=ci
---spring.olap_datasource.username=bob
---spring.olap_datasource.password=password
---spring.warehouse_datasource.url-server=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
---spring.warehouse_datasource.url-schema=bob_warehouse_test
---spring.warehouse_datasource.username=sbac
---spring.warehouse_datasource.password=password
+--datasources.migrate_rw.url-server=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
+--datasources.migrate_rw.url-schema=bob_migrate_olap_test
+--datasources.migrate_rw.username=sbac
+--datasources.migrate_rw.password=password
+--datasources.olap_rw.url-server=rdw-qa.cibkulpjrgtr.us-west-2.redshift.amazonaws.com:5439
+--datasources.olap_rw.url-db=ci
+--datasources.olap_rw.username=bob
+--datasources.olap_rw.password=password
+--datasources.warehouse_rw.url-server=rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
+--datasources.warehouse_rw.url-schema=bob_warehouse_test
+--datasources.warehouse_rw.username=sbac
+--datasources.warehouse_rw.password=password
  */
 
 task RST(type: Test) {

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/repository/DataSourceConfiguration.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/repository/DataSourceConfiguration.java
@@ -28,9 +28,9 @@ public class DataSourceConfiguration {
      * @return DataSource
      */
     @Primary
-    @Bean(name = "migrateDatasource")
-    @ConfigurationProperties(prefix = "spring.migrate_datasource")
-    public DataSource dataSource() {
+    @Bean
+    @ConfigurationProperties(prefix = "datasources.migrate_rw")
+    public DataSource migrateDataSource() {
         return DataSourceBuilder
                 .create()
                 .build();
@@ -43,7 +43,7 @@ public class DataSourceConfiguration {
      * @return BatchConfigurer
      */
     @Bean
-    public BatchConfigurer configurer(@Qualifier("migrateDatasource") final DataSource dataSource) {
+    public BatchConfigurer configurer(@Qualifier("migrateDataSource") final DataSource dataSource) {
         return new DefaultBatchConfigurer(dataSource);
     }
 
@@ -52,8 +52,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "migrateJdbcTemplate")
-    public NamedParameterJdbcTemplate migrateJdbcTemplate(@Qualifier("migrateDatasource") final DataSource dataSource) {
+    @Bean
+    public NamedParameterJdbcTemplate migrateJdbcTemplate(@Qualifier("migrateDataSource") final DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
@@ -62,8 +62,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "warehouseDatasource")
-    @ConfigurationProperties(prefix = "spring.warehouse_datasource")
+    @Bean
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource warehouseDataSource() {
         return DataSourceBuilder
                 .create()
@@ -75,8 +75,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "warehouseJdbcTemplate")
-    public NamedParameterJdbcTemplate warehouseJdbcTemplate(@Qualifier("warehouseDatasource") final DataSource dataSource) {
+    @Bean
+    public NamedParameterJdbcTemplate warehouseJdbcTemplate(@Qualifier("warehouseDataSource") final DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
@@ -85,8 +85,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "olapDatasource")
-    @ConfigurationProperties(prefix = "spring.olap_datasource")
+    @Bean
+    @ConfigurationProperties(prefix = "datasources.olap_rw")
     public DataSource olapDataSource() {
         return DataSourceBuilder
                 .create()
@@ -98,8 +98,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "olapJdbcTemplate")
-    public NamedParameterJdbcTemplate olapJdbcTemplate(@Qualifier("olapDatasource") final DataSource dataSource) {
+    @Bean
+    public NamedParameterJdbcTemplate olapJdbcTemplate(@Qualifier("olapDataSource") final DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 }

--- a/migrate-olap/src/main/resources/application.yml
+++ b/migrate-olap/src/main/resources/application.yml
@@ -63,14 +63,15 @@ spring:
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
 
-  migrate_datasource:
+datasources:
+  migrate_rw:
     url: "\
-      jdbc:mysql://${spring.migrate_datasource.url-server:localhost:3306}/${spring.migrate_datasource.url-schema:migrate_olap}\
-      ?useSSL=${spring.migrate_datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.migrate_datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.migrate_datasource.character-encoding:utf8}\
-      &connectTimeout=${spring.migrate_datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.migrate_datasource.socket-timeout:0}\
+      jdbc:mysql://${datasources.migrate_rw.url-server:localhost:3306}/${datasources.migrate_rw.url-schema:migrate_olap}\
+      ?useSSL=${datasources.migrate_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.migrate_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.migrate_rw.character-encoding:utf8}\
+      &connectTimeout=${datasources.migrate_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.migrate_rw.socket-timeout:0}\
       "
     username: root
     password:
@@ -81,18 +82,18 @@ spring:
     initialize: false
     initialSize: 4
     maxActive: 10
-    minIdle: ${spring.migrate_datasource.initialSize}
-    maxIdle: ${spring.migrate_datasource.maxActive}
+    minIdle: ${datasources.migrate_rw.initialSize}
+    maxIdle: ${datasources.migrate_rw.maxActive}
 
   # http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-options.html
   # https://jdbc.postgresql.org/documentation/head/connect.html
   # NOTE: nothing in these settings controls the schema; it is controlled by the user's search_path
-  olap_datasource:
+  olap_rw:
     url: "\
-      jdbc:redshift://${spring.olap_datasource.url-server:localhost:5432}/${spring.olap_datasource.url-db:dev}\
+      jdbc:redshift://${datasources.olap_rw.url-server:localhost:5432}/${datasources.olap_rw.url-db:dev}\
       ?ApplicationName=rdw-ingest-migrate-olap\
-      &loginTimeout=${spring.olap_datasource.connect-timeout:10}\
-      &socketTimeout=${spring.olap_datasource.socket-timeout:0}\
+      &loginTimeout=${datasources.olap_rw.connect-timeout:10}\
+      &socketTimeout=${datasources.olap_rw.socket-timeout:0}\
       "
     username: root
     password:
@@ -101,14 +102,14 @@ spring:
     validationQueryTimeout: 30000
     driverClassName: com.amazon.redshift.jdbc42.Driver
 
-  warehouse_datasource:
+  warehouse_rw:
     url: "\
-      jdbc:mysql://${spring.warehouse_datasource.url-server:localhost:3306}/${spring.warehouse_datasource.url-schema:warehouse}\
-      ?useSSL=${spring.warehouse_datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.warehouse_datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.warehouse_datasource.character-encoding:utf8}\
-      &connectTimeout=${spring.warehouse_datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.warehouse_datasource.socket-timeout:0}\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:0}\
       "
     username: root
     password:
@@ -119,8 +120,8 @@ spring:
     initialize: false
     initialSize: 4
     maxActive: 10
-    minIdle: ${spring.warehouse_datasource.initialSize}
-    maxIdle: ${spring.warehouse_datasource.maxActive}
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}
 
 logging:
   level:

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
@@ -54,13 +54,13 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM migrate"}, config = @SqlConfig(dataSource = "migrateDatasource"))
     })
     @Test
@@ -88,17 +88,17 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM migrate"}, config = @SqlConfig(dataSource = "migrateDatasource"))
     })
     @Test

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRST.java
@@ -61,7 +61,7 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM migrate"}, config = @SqlConfig(dataSource = "migrateDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM migrate"}, config = @SqlConfig(dataSource = "migrateDataSource"))
     })
     @Test
     public void itShouldUpsertAndDeleteCodesIfBatchHasImportContentWithCodes() throws Exception {
@@ -99,7 +99,7 @@ public class MigrateOlapReportingJobRST extends SpringBatchIT {
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM migrate"}, config = @SqlConfig(dataSource = "migrateDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM migrate"}, config = @SqlConfig(dataSource = "migrateDataSource"))
     })
     @Test
     public void itShouldUpsertAndDeleteEntities() throws Exception {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/DeleteCodesStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/DeleteCodesStepRST.java
@@ -22,10 +22,10 @@ public class DeleteCodesStepRST extends MigrateStepRST {
 
     @SqlGroup({
             //loads all code tables in `staging`; one row in each table with id = -98
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             //loads all code tables in `reporting`;one row in each table with id = -99
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDeleteButNotUpsertCodes() {
@@ -57,8 +57,8 @@ public class DeleteCodesStepRST extends MigrateStepRST {
 
     @SqlGroup({
             //loads all code tables with one row each with id = -99
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDoNothingIfBatchDoesNotHaveImportContentWithCodes() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/DeleteEntitiesStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/DeleteEntitiesStepRST.java
@@ -17,16 +17,16 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class DeleteEntitiesStepRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDeleteButNotInsertEntities() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/DeriveActiveAsmtStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/DeriveActiveAsmtStepRST.java
@@ -20,12 +20,12 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class DeriveActiveAsmtStepRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDeriveActiveAsmt() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadCodesStepsRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadCodesStepsRST.java
@@ -32,10 +32,10 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 @SqlGroup({
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
 })
 public class ExtractAndLoadCodesStepsRST extends MigrateStepRST {
 

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEmbargoRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEmbargoRST.java
@@ -59,24 +59,24 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO district_embargo (district_id, school_year, individual, aggregate) VALUES (-98, 1999, 0, 0), (-99, 1999, 1, 1)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM district_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "DELETE FROM staging_district_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyAllDistrictsWithDefaults() {
@@ -104,27 +104,27 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO state_embargo (school_year, individual, aggregate) VALUES (1999, 1, 1)",
                     "INSERT INTO district_embargo (district_id, school_year, individual, aggregate) VALUES (-1,  1999, null, null), (-98, 1999, 0, 0), (-99, 1999, 1, 1)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM district_embargo",
                     "DELETE from state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "DELETE FROM staging_district_embargo",
                     "DELETE FROM staging_state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyAllDistrictsWhenStateIsEmbargoed() {
@@ -152,27 +152,27 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO state_embargo (school_year, individual, aggregate) VALUES (1999, 0, 0)",
                     "INSERT INTO district_embargo (district_id, school_year, individual, aggregate) VALUES (-1,  1999, null, null), (-98, 1999, 0, 0), (-99, 1999, 1, 1)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM district_embargo",
                     "DELETE FROM state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "DELETE FROM staging_district_embargo",
                     "DELETE FROM staging_state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyAllDistrictsWhenStateIsReleased() {
@@ -198,14 +198,14 @@ public class ExtractAndLoadEmbargoRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO state_embargo (school_year, individual, aggregate) VALUES (1999, 0, 0)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "DELETE FROM staging_state_embargo"
             })
     })

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEntitiesStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/ExtractAndLoadEntitiesStepRST.java
@@ -60,15 +60,15 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopy() {
@@ -150,15 +150,15 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldNotCopyIfNoImports() {
@@ -199,18 +199,18 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD, statements = {"INSERT INTO school (id, district_id, name, natural_id, deleted, import_id, update_import_id, created, updated) " +
-                    "VALUES (-97, -99, 'Sample School -97', 'natural_id-97', 0, -2, -2, '2017-07-18 20:13:34.000000', '2017-07-18 20:13:34.000000')"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+                    "VALUES (-97, -99, 'Sample School -97', 'natural_id-97', 0, -2, -2, '2017-07-18 20:13:34.000000', '2017-07-18 20:13:34.000000')"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM school WHERE id IN (-97)"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM school WHERE id IN (-97)"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyDistrictIfOneSchoolDeleted() {
@@ -240,15 +240,15 @@ public class ExtractAndLoadEntitiesStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldFailWithNoMigrateBatch() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/TruncateStageStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/TruncateStageStepRST.java
@@ -18,15 +18,15 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class TruncateStageStepRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "INSERT INTO staging_state_embargo (aggregate, migrate_id) VALUES (0, -10)",
                     "INSERT INTO staging_district_embargo (district_id, aggregate, migrate_id) VALUES (-99, 0, -99)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDeleteData() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpdateEmbargoRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpdateEmbargoRST.java
@@ -23,8 +23,8 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class UpdateEmbargoRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAndStagingEmbargoSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAndStagingEmbargoSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdateSchoolDistrictEmbargo() {
@@ -55,12 +55,12 @@ public class UpdateEmbargoRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "INSERT INTO staging_state_embargo (aggregate, migrate_id) VALUES (0, -10);",
                     "INSERT INTO state_embargo(aggregate, migrate_id) VALUES(1, -9);"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "olapDataSource"), statements = {
                     "DELETE FROM staging_state_embargo;",
                     "DELETE FROM state_embargo;"
             })
@@ -91,11 +91,11 @@ public class UpdateEmbargoRST extends MigrateStepRST {
     @SqlGroup({
             @Sql(executionPhase = BEFORE_TEST_METHOD, statements = {
                     "INSERT INTO staging_state_embargo (aggregate, migrate_id) VALUES (0, -10);",
-            }, scripts = {"classpath:OlapAndStagingEmbargoSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            }, scripts = {"classpath:OlapAndStagingEmbargoSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
             @Sql(executionPhase = AFTER_TEST_METHOD, statements = {
                     "DELETE FROM staging_state_embargo;",
-            }, scripts = {"classpath:OlapAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            }, scripts = {"classpath:OlapAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDoNothingIfEmbargoFlagIsNotSet() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertAsmtsStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertAsmtsStepRST.java
@@ -20,13 +20,13 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class UpsertAsmtsStepRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -47,10 +47,10 @@ public class UpsertAsmtsStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
 
             @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertAsmtsStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertAsmtsStepRST.java
@@ -51,10 +51,10 @@ public class UpsertAsmtsStepRST extends MigrateStepRST {
             // the same script for staging is done twice intentionally to load duplicate data
             @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -80,15 +80,15 @@ public class UpsertAsmtsStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
     })
     @Test
     public void itShouldInsertButNotDelete() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertCodesStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertCodesStepRST.java
@@ -21,8 +21,8 @@ public class UpsertCodesStepRST extends MigrateStepRST {
 
     @SqlGroup({
             // insert codes into the staging tables
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldDoNothingIfBatchDoesNotHaveCodeImportContent() {
@@ -49,8 +49,8 @@ public class UpsertCodesStepRST extends MigrateStepRST {
 
     @SqlGroup({
             // insert codes into the staging tables
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -81,10 +81,10 @@ public class UpsertCodesStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -123,10 +123,10 @@ public class UpsertCodesStepRST extends MigrateStepRST {
 
     @SqlGroup({
             //loads all code tables with one row each with id = -98
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             //loads all code tables with one row each with id = -99
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapCodesPreload.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsertButNotDeleteCodes() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertFactsRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertFactsRST.java
@@ -20,14 +20,14 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class UpsertFactsRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -88,14 +88,14 @@ public class UpsertFactsRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdate() {
@@ -159,15 +159,15 @@ public class UpsertFactsRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldNotDelete() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertOrganizationStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertOrganizationStepRST.java
@@ -21,10 +21,10 @@ public class UpsertOrganizationStepRST extends MigrateStepRST {
 
     @SqlGroup({
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -44,14 +44,14 @@ public class UpsertOrganizationStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -76,15 +76,15 @@ public class UpsertOrganizationStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsertButNotDelete() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertStudentsStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertStudentsStepRST.java
@@ -20,14 +20,14 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class UpsertStudentsStepRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -48,15 +48,15 @@ public class UpsertStudentsStepRST extends MigrateStepRST {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldInsertButNotDelete() {

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertSubjectsStepRST.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/step/UpsertSubjectsStepRST.java
@@ -20,14 +20,14 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 public class UpsertSubjectsStepRST extends MigrateStepRST {
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
             // the same script for staging is done twice intentionally to load duplicate data
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:OlapEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:OlapAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "olapDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {

--- a/migrate-olap/src/test/resources/application-redshift.yml
+++ b/migrate-olap/src/test/resources/application-redshift.yml
@@ -19,8 +19,8 @@ migrate:
 reporting:
   school-year: 1999
 
-spring:
-  migrate_datasource:
+datasources:
+  migrate_rw:
     url-server: rdw-aurora-ci.cugsexobhx8t.us-west-2.rds.amazonaws.com:3306
     url-schema: migrate_olap_test
     username: sbac

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/DataSourceConfiguration.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/DataSourceConfiguration.java
@@ -28,9 +28,9 @@ public class DataSourceConfiguration {
      * @return DataSource
      */
     @Primary
-    @Bean(name = "reportingDatasource")
-    @ConfigurationProperties(prefix = "spring.reporting_datasource")
-    public DataSource dataSource() {
+    @Bean
+    @ConfigurationProperties(prefix = "datasources.reporting_rw")
+    public DataSource reportingDataSource() {
         return DataSourceBuilder
                 .create()
                 .build();
@@ -43,7 +43,7 @@ public class DataSourceConfiguration {
      * @return BatchConfigurer
      */
     @Bean
-    public BatchConfigurer configurer(@Qualifier("reportingDatasource") final DataSource dataSource) {
+    public BatchConfigurer configurer(@Qualifier("reportingDataSource") final DataSource dataSource) {
         return new DefaultBatchConfigurer(dataSource);
     }
 
@@ -52,8 +52,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "reportingJdbcTemplate")
-    public NamedParameterJdbcTemplate reportingJdbcTemplate(@Qualifier("reportingDatasource") final DataSource dataSource) {
+    @Bean
+    public NamedParameterJdbcTemplate reportingJdbcTemplate(@Qualifier("reportingDataSource") final DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
@@ -63,8 +63,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "migrateJdbcTemplate")
-    public NamedParameterJdbcTemplate migrateJdbcTemplate(@Qualifier("reportingDatasource") final DataSource dataSource) {
+    @Bean
+    public NamedParameterJdbcTemplate migrateJdbcTemplate(@Qualifier("reportingDataSource") final DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 
@@ -73,8 +73,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "warehouseDatasource")
-    @ConfigurationProperties(prefix = "spring.warehouse_datasource")
+    @Bean
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource warehouseDataSource() {
         return DataSourceBuilder
                 .create()
@@ -86,8 +86,8 @@ public class DataSourceConfiguration {
      *
      * @return DataSource
      */
-    @Bean(name = "warehouseJdbcTemplate")
-    public NamedParameterJdbcTemplate warehouseJdbcTemplate(@Qualifier("warehouseDatasource") final DataSource dataSource) {
+    @Bean
+    public NamedParameterJdbcTemplate warehouseJdbcTemplate(@Qualifier("warehouseDataSource") final DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
     }
 

--- a/migrate-reporting/src/main/resources/application.yml
+++ b/migrate-reporting/src/main/resources/application.yml
@@ -25,51 +25,6 @@ reporting:
   school-year: 2019
 
 spring:
-  reporting_datasource:
-    url: "\
-      jdbc:mysql://${spring.reporting_datasource.url-server:localhost:3306}/${spring.reporting_datasource.url-schema:reporting}\
-      ?useSSL=${spring.reporting_datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.reporting_datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.reporting_datasource.character-encoding:utf8}\
-      &rewriteBatchedStatements=${spring.reporting_datasource.rewrite-batched-statements:true}\
-      &connectTimeout=${spring.reporting_datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.reporting_datasource.socket-timeout:130000}\
-      "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.reporting_datasource.query-timeout:120})"
-    username: root
-    password:
-    testWhileIdle: true
-    validationQuery: SELECT 1
-    validationQueryTimeout: 10000
-    driverClassName: com.mysql.jdbc.Driver
-    initialize: false
-    initialSize: 4
-    maxActive: 10
-    minIdle: ${spring.reporting_datasource.initialSize}
-    maxIdle: ${spring.reporting_datasource.maxActive}
-
-  warehouse_datasource:
-    url: "\
-      jdbc:mysql://${spring.warehouse_datasource.url-server:localhost:3306}/${spring.warehouse_datasource.url-schema:warehouse}\
-      ?useSSL=${spring.warehouse_datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.warehouse_datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.warehouse_datasource.character-encoding:utf8}\
-      &connectTimeout=${spring.warehouse_datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.warehouse_datasource.socket-timeout:130000}\
-      "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.warehouse_datasource.query-timeout:120})"
-    username: root
-    password:
-    testWhileIdle: true
-    validationQuery: SELECT 1
-    validationQueryTimeout: 10000
-    driverClassName: com.mysql.jdbc.Driver
-    initialize: false
-    initialSize: 4
-    maxActive: 10
-    minIdle: ${spring.warehouse_datasource.initialSize}
-    maxIdle: ${spring.warehouse_datasource.maxActive}
-
   batch:
     job:
       enabled: false
@@ -78,6 +33,52 @@ spring:
     default-property-inclusion: non_null
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+
+datasources:
+  reporting_rw:
+    url: "\
+      jdbc:mysql://${datasources.reporting_rw.url-server:localhost:3306}/${datasources.reporting_rw.url-schema:reporting}\
+      ?useSSL=${datasources.reporting_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.reporting_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.reporting_rw.character-encoding:utf8}\
+      &rewriteBatchedStatements=${datasources.reporting_rw.rewrite-batched-statements:true}\
+      &connectTimeout=${datasources.reporting_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.reporting_rw.socket-timeout:130000}\
+      "
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.reporting_rw.query-timeout:120})"
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    validationQueryTimeout: 10000
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+    initialSize: 4
+    maxActive: 10
+    minIdle: ${datasources.reporting_rw.initialSize}
+    maxIdle: ${datasources.reporting_rw.maxActive}
+
+  warehouse_rw:
+    url: "\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:130000}\
+      "
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:120})"
+    username: root
+    password:
+    testWhileIdle: true
+    validationQuery: SELECT 1
+    validationQueryTimeout: 10000
+    driverClassName: com.mysql.jdbc.Driver
+    initialize: false
+    initialSize: 4
+    maxActive: 10
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}
 
 logging:
   level:

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/ReportingMigrateJobIT.java
@@ -34,14 +34,14 @@ public class ReportingMigrateJobIT extends SpringBatchIT {
     );
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldUpsertAndDeleteCodesIfBatchHasImportContentWithCodes() throws Exception {
@@ -67,18 +67,18 @@ public class ReportingMigrateJobIT extends SpringBatchIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldUpsertAndDeleteEntities() throws Exception {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepositoryIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcSqlCopyWarehouseToStagingRepositoryIT.java
@@ -37,13 +37,13 @@ public class JdbcSqlCopyWarehouseToStagingRepositoryIT extends RepositoryIT {
 
     @Test
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"),
                     statements = {"INSERT INTO import (id, status, content, contentType, digest) VALUES ( -99, 0, 1, 'type', 'digest')",
                             "INSERT INTO district (id, name, natural_id) VALUES (-22, 'Sample District 1', 'DistrictNaturalId');",
                             "INSERT INTO school (id, district_id, name, natural_id, import_id, update_import_id, created, updated) VALUES " +
                                     "(-27, -22, 'Sample School 1', 'SchoolNaturalId', 1, 1, '2017-07-18 19:45:33.966000', '2017-07-18 19:46:33.966000');"}),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"),
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"),
                     statements = {"DELETE FROM school;",
                             "DELETE FROM district WHERE id = -22;",
                             "DELETE FROM import WHERE id = -99;"})

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcWarehouseImportRepositoryIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/JdbcWarehouseImportRepositoryIT.java
@@ -46,10 +46,10 @@ public class JdbcWarehouseImportRepositoryIT extends RepositoryIT {
                     "  (-1008, 1, 1, 'application/xml', 'digest', '2017-07-18 19:06:33.966000', '2017-07-18 19:46:34.966000')," +
                     "  (-1009, 1, 3, 'application/xml', 'digest', '2017-07-18 19:06:33.966000', '2017-07-18 19:07:02.966000')," +
                     "  (-1010, 1, 1, 'application/xml', 'digest', '2017-07-18 19:05:33.966000', '2017-07-18 19:06:01.966000');"},
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Sql(statements = { "DELETE FROM import" },
             executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Test
     public void itShouldGetMigrateJobState() {
         final Instant boundaryAt = Instant.parse("2017-07-18T19:46:34.966Z");
@@ -88,10 +88,10 @@ public class JdbcWarehouseImportRepositoryIT extends RepositoryIT {
                     "  (-996, 1, 1, 'application/xml', 'digest', '2017-07-18 19:45:33.966000', '2017-07-18 19:45:33.966000')," +
                     "  (-998, 1, 6, 'application/xml', 'digest', '2017-07-18 19:16:33.966000', '2017-07-18 19:16:33.966000')," +
                     "  (-1010, 1, 1, 'application/xml', 'digest', '2017-07-18 19:05:33.966000', '2017-07-18 19:06:01.966000');"},
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Sql(statements = { "DELETE FROM import" },
             executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Test
     public void itShouldGetMigrateJobStateWithEmbargo() {
         final MigrateImportValues jobState = repository.getMigrateImportValues(null, 10);
@@ -103,17 +103,17 @@ public class JdbcWarehouseImportRepositoryIT extends RepositoryIT {
             "INSERT INTO import (id, status, content, contentType, digest, created, updated) VALUES\n" +
                     "  (-996, 1, 1, 'application/xml', 'digest', DATE_ADD(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 1 DAY))," +
                     "  (-997, 1, 2, 'application/xml', 'digest', DATE_ADD(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 1 DAY));"},
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Sql(statements = { "DELETE FROM import" },
             executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Test
     public void itShouldNotGetFutureJobState() {
         final MigrateImportValues jobState = repository.getMigrateImportValues(null, 10);
         assertThat(jobState.getImportCount()).isZero();
     }
 
-    @Sql(config = @SqlConfig(dataSource = "warehouseDatasource"), statements = "DELETE FROM import")
+    @Sql(config = @SqlConfig(dataSource = "warehouseDataSource"), statements = "DELETE FROM import")
     @Test
     public void itShouldGetMigrateJobStateWhenNoImports() {
         final MigrateImportValues migrateImportValues = repository.getMigrateImportValues(null, 10);
@@ -128,10 +128,10 @@ public class JdbcWarehouseImportRepositoryIT extends RepositoryIT {
     @Sql(statements = {"DELETE FROM import",
             "INSERT INTO import (id, status, content, contentType, digest, created, updated) VALUES\n" +
                     "  (-996, 1, 1, 'application/xml', 'digest', '2017-07-18 19:45:33.966123', '2017-07-18 19:45:33.966123');"},
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Sql(statements = { "DELETE FROM import" },
             executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
-            config = @SqlConfig(dataSource = "warehouseDatasource"))
+            config = @SqlConfig(dataSource = "warehouseDataSource"))
     @Test
     public void itShouldPreserveDatabaseTimestampPrecision() {
         // Although the java 8 clock doesn't necessarily have better than millisecond precision

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/TestWarehouseDataSourceConfiguration.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/repository/impl/TestWarehouseDataSourceConfiguration.java
@@ -22,7 +22,7 @@ import javax.sql.DataSource;
 public class TestWarehouseDataSourceConfiguration {
 
     @Bean
-    public PlatformTransactionManager warehouseTxManager(@Qualifier("warehouseDatasource") final DataSource dataSource) {
+    public PlatformTransactionManager warehouseTxManager(@Qualifier("warehouseDataSource") final DataSource dataSource) {
         return new DataSourceTransactionManager(dataSource);
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/DeleteCodesIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/DeleteCodesIT.java
@@ -31,10 +31,10 @@ public class DeleteCodesIT extends SpringBatchStepIT {
 
     @SqlGroup({
             //loads all code tables in `staging`; one row in each table with id = -98
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
             //loads all code tables in `reporting`;one row in each table with id = -99
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldDeleteButNotUpsertCodes() {
@@ -72,8 +72,8 @@ public class DeleteCodesIT extends SpringBatchStepIT {
 
     @SqlGroup({
             //loads all code tables with one row each with id = -99
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldDoNothingIfBatchDoesNotHaveImportContentWithCodes() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/DeleteEntitiesIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/DeleteEntitiesIT.java
@@ -26,14 +26,14 @@ public class DeleteEntitiesIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldDeleteButNotInsertEntities() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/MigrateGroupsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/MigrateGroupsIT.java
@@ -78,12 +78,12 @@ import static org.opentestsystem.rdw.migrate.common.TableTestCountHelper.verifyT
  * </pre>
  */
 @SqlGroup({
-        @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"),
+        @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"),
                 scripts = {"classpath:MigrateGroupsWarehouseSetup.sql"}),
 
-        @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"),
+        @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"),
                 scripts = {"classpath:MigrateGroupsWarehouseTeardown.sql"}),
-        @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDatasource"),
+        @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDataSource"),
                 statements = {"DELETE FROM staging_student_group WHERE id < 0"})
 })
 public class MigrateGroupsIT extends SpringBatchStepIT {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageCodesIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageCodesIT.java
@@ -27,10 +27,10 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 @SqlGroup({
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
 })
 public class StageCodesIT extends SpringBatchStepIT {
 

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageEmbargoIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageEmbargoIT.java
@@ -30,24 +30,24 @@ public class StageEmbargoIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO district_embargo (district_id, school_year, individual, aggregate) VALUES (-98, 1999, 0, 0), (-99, 1999, 1, 1)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM district_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDataSource"), statements = {
                     "DELETE FROM staging_district_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyAllDistrictsWithDefaults() {
@@ -74,26 +74,26 @@ public class StageEmbargoIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO state_embargo (school_year, individual, aggregate) VALUES (1999, 1, 1)",
                     "INSERT INTO district_embargo (district_id, school_year, individual, aggregate) VALUES (-1,  1999, null, null), (-98, 1999, 0, 0), (-99, 1999, 1, 1)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM district_embargo",
                     "DELETE FROM state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDataSource"), statements = {
                     "DELETE FROM staging_district_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyAllDistrictsWhenStateIsEmbargoed() {
@@ -120,26 +120,26 @@ public class StageEmbargoIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "INSERT INTO state_embargo (school_year, individual, aggregate) VALUES (1999, 0, 0)",
                     "INSERT INTO district_embargo (district_id, school_year, individual, aggregate) VALUES (-1,  1999, null, null), (-98, 1999, 0, 0), (-99, 1999, 1, 1)"
             }),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "warehouseDataSource"), statements = {
                     "DELETE FROM district_embargo",
                     "DELETE FROM state_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDatasource"), statements = {
+            @Sql(executionPhase = AFTER_TEST_METHOD, config = @SqlConfig(dataSource = "reportingDataSource"), statements = {
                     "DELETE FROM staging_district_embargo"
             }),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyAllDistrictsWhenStateIsReleased() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageExamIT.java
@@ -26,15 +26,15 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 @SqlGroup({
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
 })
 public class StageExamIT extends SpringBatchStepIT {
 

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageGroupsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageGroupsIT.java
@@ -26,15 +26,15 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 @SqlGroup({
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
 })
 public class StageGroupsIT extends SpringBatchStepIT {
 

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageNormsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageNormsIT.java
@@ -31,8 +31,8 @@ public class StageNormsIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD,
                     statements = {"INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, deleted, import_id, update_import_id, created, updated) VALUES\n" +
                             "(-11, '(SBAC)SBAC-IAB-ASMT TEST-11', -98, 2, 1, 1999, 'SBAC-IAB-FIXED-G4M-OA-MATH-4',     'test IAB',    '9835', 0, -5000, -5000, '2017-05-18 19:05:33.967000', '2017-05-18 20:06:34.966000'),\n" +
@@ -49,20 +49,20 @@ public class StageNormsIT extends SpringBatchStepIT {
                             "  (-89, 25, 2278, 0, 2420),(-89, 50, 2420, 2420, 2566),(-89, 75, 2566, 2566, 9999),\n" +
                             "  (-88, 10, 2307, 1111, 2408),(-88, 30, 2408, 2408, 2464),(-88, 50, 2464, 2464, 2516),(-88, 70, 2516, 2516, 2612),(-88, 90, 2612, 2612, 4444),\n" +
                             "  (-87, 25, 2345, 1500, 2504),(-87, 50, 2504, 2504, 2651),(-87, 75, 2651, 2651, 3500);"},
-                    config = @SqlConfig(dataSource = "warehouseDatasource")),
+                    config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD,
                     statements = {"DELETE FROM staging_percentile_score WHERE percentile_id IN (-89, -88, -87);\n" +
                             "DELETE FROM staging_percentile WHERE id IN (-89, -88, -87);\n" +
                             "DELETE FROM staging_asmt WHERE id IN (-11, -99, -98, -97);"},
-                    config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+                    config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD,
                     statements = {"DELETE FROM percentile_score WHERE percentile_id IN (-89, -88, -87);\n" +
                             "DELETE FROM percentile WHERE id IN (-89, -88, -87);\n" +
                             "DELETE FROM asmt WHERE id IN (-11, -99, -98, -97);"},
-                    config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+                    config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyNorms() {
@@ -94,8 +94,8 @@ public class StageNormsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD,
                     statements = {"INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, deleted, import_id, update_import_id, created, updated) VALUES\n" +
                             "(-11, '(SBAC)SBAC-IAB-ASMT TEST-11', -98, 2, 1, 1999, 'SBAC-IAB-FIXED-G4M-OA-MATH-4',     'test IAB',    '9835', 0, -5000, -5000, '2017-05-18 19:05:33.967000', '2017-05-18 20:06:34.966000'),\n" +
@@ -112,20 +112,20 @@ public class StageNormsIT extends SpringBatchStepIT {
                             "  (-89, 25, 2278, 0, 2420),(-89, 50, 2420, 2420, 2566),(-89, 75, 2566, 2566, 9999),\n" +
                             "  (-88, 10, 2307, 1111, 2408),(-88, 30, 2408, 2408, 2464),(-88, 50, 2464, 2464, 2516),(-88, 70, 2516, 2516, 2612),(-88, 90, 2612, 2612, 4444),\n" +
                             "  (-87, 25, 2345, 1500, 2504),(-87, 50, 2504, 2504, 2651),(-87, 75, 2651, 2651, 3500);"},
-                    config = @SqlConfig(dataSource = "warehouseDatasource")),
+                    config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD,
                     statements = {"DELETE FROM staging_percentile_score WHERE percentile_id IN (-89, -88, -87);\n" +
                             "DELETE FROM staging_percentile WHERE id IN (-89, -88, -87);\n" +
                             "DELETE FROM staging_asmt WHERE id IN (-11, -99, -98, -97);"},
-                    config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+                    config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD,
                     statements = {"DELETE FROM percentile_score WHERE percentile_id IN (-89, -88, -87);\n" +
                             "DELETE FROM percentile WHERE id IN (-89, -88, -87);\n" +
                             "DELETE FROM asmt WHERE id IN (-11, -99, -98, -97);"},
-                    config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+                    config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyNewAndUpdatedNorms() {
@@ -159,8 +159,8 @@ public class StageNormsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD,
                     statements = {"INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, deleted, import_id, update_import_id, created, updated) VALUES\n" +
                             "(-11, '(SBAC)SBAC-IAB-ASMT TEST-11', -98, 2, 1, 1999, 'SBAC-IAB-FIXED-G4M-OA-MATH-4',     'test IAB',    '9835', 0, -5000, -5000, '2017-05-18 19:05:33.967000', '2017-05-18 20:06:34.966000'),\n" +
@@ -177,20 +177,20 @@ public class StageNormsIT extends SpringBatchStepIT {
                             "  (-89, 25, 2278, 0, 2420),(-89, 50, 2420, 2420, 2566),(-89, 75, 2566, 2566, 9999),\n" +
                             "  (-88, 10, 2307, 1111, 2408),(-88, 30, 2408, 2408, 2464),(-88, 50, 2464, 2464, 2516),(-88, 70, 2516, 2516, 2612),(-88, 90, 2612, 2612, 4444),\n" +
                             "  (-87, 25, 2345, 1500, 2504),(-87, 50, 2504, 2504, 2651),(-87, 75, 2651, 2651, 3500);"},
-                    config = @SqlConfig(dataSource = "warehouseDatasource")),
+                    config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD,
                     statements = {"DELETE FROM staging_percentile_score WHERE percentile_id IN (-89, -88, -87);\n" +
                             "DELETE FROM staging_percentile WHERE id IN (-89, -88, -87);\n" +
                             "DELETE FROM staging_asmt WHERE id IN (-11, -99, -98, -97);"},
-                    config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+                    config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
             @Sql(executionPhase = AFTER_TEST_METHOD,
                     statements = {"DELETE FROM percentile_score WHERE percentile_id IN (-89, -88, -87);\n" +
                             "DELETE FROM percentile WHERE id IN (-89, -88, -87);\n" +
                             "DELETE FROM asmt WHERE id IN (-11, -99, -98, -97);"},
-                    config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+                    config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldNotCopyNewAndUpdatedChildRecordsOnDelete() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageOrganizationsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageOrganizationsIT.java
@@ -31,17 +31,17 @@ public class StageOrganizationsIT extends SpringBatchStepIT {
 
     @SqlGroup({
             // Set up import id's
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             // Codes migrate from warehouse.
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             // Entities migrate from warehouse.
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             // Teardown
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyOrganizations() {
@@ -74,18 +74,18 @@ public class StageOrganizationsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD, statements = {"INSERT INTO school (id, district_id, name, natural_id, deleted, import_id, update_import_id, created, updated) " +
-                    "VALUES (-97, -99, 'Sample School -97', 'natural_id-97', 0, -2, -2, '2017-07-18 20:13:34.000000', '2017-07-18 20:13:34.000000')"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+                    "VALUES (-97, -99, 'Sample School -97', 'natural_id-97', 0, -2, -2, '2017-07-18 20:13:34.000000', '2017-07-18 20:13:34.000000')"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM school WHERE id IN (-97)"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, statements = {"DELETE FROM school WHERE id IN (-97)"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
     })
     @Test
     public void itShouldCopyDistrictIfOneSchoolDeleted() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StagePackageIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StagePackageIT.java
@@ -27,15 +27,15 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTableWhere;
 
 @SqlGroup({
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
 })
 public class StagePackageIT extends SpringBatchStepIT {
 

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageSubjectsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/StageSubjectsIT.java
@@ -24,15 +24,15 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 @SqlGroup({
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseImportSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseCodesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
 
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource")),
-        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDatasource"))
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseCodesTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource")),
+        @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:WarehouseImportTeardown.sql"}, config = @SqlConfig(dataSource = "warehouseDataSource"))
 })
 public class StageSubjectsIT extends SpringBatchStepIT {
 

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpdateEmbargoIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpdateEmbargoIT.java
@@ -26,8 +26,8 @@ public class UpdateEmbargoIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEmbargoSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEmbargoSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEmbargoTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdate() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertAsmtsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertAsmtsIT.java
@@ -27,12 +27,12 @@ public class UpsertAsmtsIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -65,13 +65,13 @@ public class UpsertAsmtsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -108,14 +108,14 @@ public class UpsertAsmtsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsertButNotDelete() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertCodesIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertCodesIT.java
@@ -30,8 +30,8 @@ public class UpsertCodesIT extends SpringBatchStepIT {
 
     @SqlGroup({
             // insert codes into the staging tables
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldDoNothingIfBatchDoesNotHaveCodeImportContent() {
@@ -57,8 +57,8 @@ public class UpsertCodesIT extends SpringBatchStepIT {
 
     @SqlGroup({
             // insert codes into the staging tables
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -90,10 +90,10 @@ public class UpsertCodesIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -132,10 +132,10 @@ public class UpsertCodesIT extends SpringBatchStepIT {
 
     @SqlGroup({
             //loads all code tables with one row each with id = -98
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingCodesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
             //loads all code tables with one row each with id = -99
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingCodesPreload.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsertButNotDeleteCodes() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertExamsIT.java
@@ -26,13 +26,13 @@ public class UpsertExamsIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -60,13 +60,13 @@ public class UpsertExamsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdate() {
@@ -97,14 +97,14 @@ public class UpsertExamsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldNotDelete() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertNormsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertNormsIT.java
@@ -28,16 +28,16 @@ public class UpsertNormsIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingPercentilesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingPercentilesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
             @Sql(executionPhase = BEFORE_TEST_METHOD,
                     statements = {"INSERT INTO asmt (id, natural_id, grade_id, grade_code, type_id, subject_id, school_year, name, label, version, update_import_id, cut_point_1, cut_point_2, cut_point_3, min_score, max_score, updated, migrate_id) VALUES\n" +
                             "   (-11, '(SBAC)SBAC-IAB-ASMT TEST-11', -98, '98', 2, 1, 1999, 'SBAC-IAB-FIXED-G4M-OA-MATH-4',     'test',          '9835', -1, 2442, 2502, 2582, 2201, 2701, '2017-07-18 20:14:34.000000', -1),\n" +
                             "   (-98, 'SBAC)SBAC-ICA-ASMT TEST',     -98, '98', 1, 1, 1999, 'SBAC-ICA-FIXED-G5E-COMBINED-2017', 'Grade 5 ELA',   '9835', -1, 2442, 2502, 2582, 2201, 2701, '2017-07-18 20:14:34.000000', -1),\n" +
                             "   (-97, 'SBAC)SBAC-ICA-ASMT TEST-2',   -98, '98', 1, 2, 1999, 'SBAC-ICA-FIXED-G5E-COMNED-2017-2', 'Grade 5 ELA-2', '9835', -1, 2442, 2502, 2582, 2201, 2701, '2017-07-18 20:14:34.000000', -1);"},
-                    config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingPercentilesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+                    config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingPercentilesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -67,11 +67,11 @@ public class UpsertNormsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingPercentilesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingPercentilesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingPercentilesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingPercentilesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingPercentilesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingPercentilesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertOrganizationIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertOrganizationIT.java
@@ -26,8 +26,8 @@ public class UpsertOrganizationIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsert() {
@@ -47,13 +47,13 @@ public class UpsertOrganizationIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -78,14 +78,14 @@ public class UpsertOrganizationIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsertButNotDelete() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertStudentsAndGroupsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertStudentsAndGroupsIT.java
@@ -26,13 +26,13 @@ public class UpsertStudentsAndGroupsIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {
@@ -58,14 +58,14 @@ public class UpsertStudentsAndGroupsIT extends SpringBatchStepIT {
     }
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesForDeleteSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldInsertButNotDelete() {

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertSubjectsIT.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/step/UpsertSubjectsIT.java
@@ -26,12 +26,12 @@ public class UpsertSubjectsIT extends SpringBatchStepIT {
     private JdbcTemplate reportingJdbcTemplate;
 
     @SqlGroup({
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingAllCodesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:ReportingSubjectSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = {"classpath:StagingEntitiesSetup.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
 
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource")),
-            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDatasource"))
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingEntitiesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource")),
+            @Sql(executionPhase = AFTER_TEST_METHOD, scripts = {"classpath:ReportingAndStagingCodesTeardown.sql"}, config = @SqlConfig(dataSource = "reportingDataSource"))
     })
     @Test
     public void itShouldUpdateAndInsert() {

--- a/migrate-reporting/src/test/resources/application-test.yml
+++ b/migrate-reporting/src/test/resources/application-test.yml
@@ -1,9 +1,8 @@
 reporting:
   school-year: 1999
 
-spring:
-  reporting_datasource:
-    url-schema: reporting_test
-  warehouse_datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test
-
+  reporting_rw:
+    url-schema: reporting_test

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/configuration/DataSourceConfiguration.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/configuration/DataSourceConfiguration.java
@@ -22,14 +22,14 @@ import javax.sql.DataSource;
 public class DataSourceConfiguration {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource")
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource dataSource() {
         return DataSourceBuilder
                 .create()
                 .build();
     }
 
-    @Bean(name = "queryJdbcTemplate")
+    @Bean
     public NamedParameterJdbcTemplate queryJdbcTemplate() {
         return new NamedParameterJdbcTemplate(dataSource());
     }

--- a/package-processor/src/main/resources/application.yml
+++ b/package-processor/src/main/resources/application.yml
@@ -46,21 +46,27 @@ spring:
           destination: SUBJECT
           group: default
 
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+
   profiles:
     include: ingest-common
 
-  datasource:
+datasources:
+  warehouse_rw:
     url: "\
-      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse}\
-      ?useSSL=${spring.datasource.use-ssl:false}\
-      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
-      &characterEncoding=${spring.datasource.character-encoding:utf8}\
-      &rewriteBatchedStatements=${spring.datasource.rewrite-batched-statements:true}\
-      &noAccessToProcedureBodies=${spring.datasource.no-access-to-procedure-bodies:true}\
-      &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:130000}\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &rewriteBatchedStatements=${datasources.warehouse_rw.rewrite-batched-statements:true}\
+      &noAccessToProcedureBodies=${datasources.warehouse_rw.no-access-to-procedure-bodies:true}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:130000}\
       "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:120})"
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:120})"
     username: root
     password:
     testWhileIdle: true
@@ -70,10 +76,5 @@ spring:
     initialize: false
     initialSize: 4
     maxActive: 10
-    minIdle: ${spring.datasource.initialSize}
-    maxIdle: ${spring.datasource.maxActive}
-
-  jackson:
-    default-property-inclusion: non_null
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}

--- a/package-processor/src/test/resources/application-test.yml
+++ b/package-processor/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/DataSourceConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/repository/DataSourceConfiguration.java
@@ -12,7 +12,7 @@ import javax.sql.DataSource;
 public class DataSourceConfiguration {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource")
+    @ConfigurationProperties(prefix = "datasources.warehouse_rw")
     public DataSource dataSource() {
         return DataSourceBuilder
                 .create()

--- a/task-service/src/main/resources/application.yml
+++ b/task-service/src/main/resources/application.yml
@@ -23,16 +23,22 @@ cloud:
       instance-profile: false
 
 spring:
-  datasource:
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+
+datasources:
+  warehouse_rw:
     url: "\
-      jdbc:mysql://${spring.datasource.url-server:localhost:3306}/${spring.datasource.url-schema:warehouse}\
-      ?useSSL=${spring.datasource.use-ssl:false}\
-      &characterEncoding=${spring.datasource.character-encoding:utf8}\
-      &useLegacyDatetimeCode=${spring.datasource.use-legacy-datetime-code:false}\
-      &connectTimeout=${spring.datasource.connect-timeout:10000}\
-      &socketTimeout=${spring.datasource.socket-timeout:40000}\
+      jdbc:mysql://${datasources.warehouse_rw.url-server:localhost:3306}/${datasources.warehouse_rw.url-schema:warehouse}\
+      ?useSSL=${datasources.warehouse_rw.use-ssl:false}\
+      &characterEncoding=${datasources.warehouse_rw.character-encoding:utf8}\
+      &useLegacyDatetimeCode=${datasources.warehouse_rw.use-legacy-datetime-code:false}\
+      &connectTimeout=${datasources.warehouse_rw.connect-timeout:10000}\
+      &socketTimeout=${datasources.warehouse_rw.socket-timeout:40000}\
       "
-    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${spring.datasource.query-timeout:30})"
+    jdbcInterceptors: "QueryTimeoutInterceptor(queryTimeout=${datasources.warehouse_rw.query-timeout:30})"
     username: root
     password:
     testWhileIdle: true
@@ -42,13 +48,8 @@ spring:
     initialize: false
     initialSize: 4
     maxActive: 10
-    minIdle: ${spring.datasource.initialSize}
-    maxIdle: ${spring.datasource.maxActive}
-
-  jackson:
-    default-property-inclusion: non_null
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
+    minIdle: ${datasources.warehouse_rw.initialSize}
+    maxIdle: ${datasources.warehouse_rw.maxActive}
 
 task:
 # by default, all tasks are disabled for local dev environment; uncomment and set secrets/hosts to test

--- a/task-service/src/test/resources/application-test.yml
+++ b/task-service/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
-spring:
-  datasource:
+datasources:
+  warehouse_rw:
     url-schema: warehouse_test


### PR DESCRIPTION
Two sets of changes:
* change top-level for datasource properties from `spring` to `datasources`; make the datasource property names consistent with RDW_Reporting, e.g. `warehouse_rw`
* clean up data source beans a bit: remove unnecessary bean names, make names consistent