### PR TITLE
allow for "NS" and "0" in overall score to mean unscored; add alias f…

### DIFF
--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessor.java
@@ -57,7 +57,9 @@ class DefaultStudentExamProcessor implements StudentExamProcessor {
     private static final String PerformanceLevelMeasureLabel = "PerformanceLevel";
     private static final String OverallScore = "Overall";
     private static final String StudentRelativeResidualScoreLabel = "StudentRelativeResidualScore";
+    private static final String BenchmarkLabel = "Benchmark";               // alias for StudentRelativeResidualScore
     private static final String StandardMetRelativeResidualScoreLabel = "StandardMetRelativeResidualScore";
+    private static final String ProficiencyDeltaLabel = "ProficiencyDelta"; // alias for StandardMetRelativeResidualScore
     private static final List<String> scoreLabelsToValidate = ImmutableList.of(StudentRelativeResidualScoreLabel, StandardMetRelativeResidualScoreLabel);
     private static final String ResetStatus = "reset";
 
@@ -230,9 +232,9 @@ class DefaultStudentExamProcessor implements StudentExamProcessor {
             } else if (targetCodeToId.containsKey(scoreOf)) {
                 final ExamTarget.Builder builder = targetBuilders
                         .computeIfAbsent(scoreOf, k -> ExamTarget.builder().targetId(targetCodeToId.get(k)));
-                if (StudentRelativeResidualScoreLabel.equals(label)) {
+                if (StudentRelativeResidualScoreLabel.equals(label) || BenchmarkLabel.equals(label)) {
                     builder.studentRelativeResidualScore(parserHelper.validate(scoreOf + " " + label, score.getValue(), toDoubleOrNull));
-                } else if (StandardMetRelativeResidualScoreLabel.equals(label)) {
+                } else if (StandardMetRelativeResidualScoreLabel.equals(label) || ProficiencyDeltaLabel.equals(label)) {
                     builder.standardMetRelativeResidualScore(parserHelper.validate(scoreOf + " " + label, score.getValue(), toDoubleOrNull));
                 }
             } else if (scoreLabelsToValidate.contains(label)) {
@@ -258,7 +260,10 @@ class DefaultStudentExamProcessor implements StudentExamProcessor {
     private static Function<String, Double> scoreChecker(final AssessmentScore assessmentScore) {
         return value -> {
             if (!hasText(value)) return null;
+            if ("NS".equalsIgnoreCase(value)) return null;
+
             final Double score = Double.parseDouble(value);
+            if (score == 0) return null;
 
             // this shouldn't happen (except in ill behaved tests) but ...
             if (assessmentScore == null) {

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessorTest.java
@@ -201,6 +201,30 @@ public class DefaultStudentExamProcessorTest {
     }
 
     @Test
+    public void itShouldInterpretNSAsNullScore() {
+        overallScaleScore.setValue("NS");
+        overallScaleScore.setStandardError(null);
+        perfLevel.setValue(null);
+
+        final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        assertThat(exam.getScaleScore()).isNull();
+        assertThat(exam.getScaleScoreStdErr()).isNull();
+    }
+
+    @Test
+    public void itShouldInterpretZeroAsNullScore() {
+        overallScaleScore.setValue("0");
+        overallScaleScore.setStandardError(null);
+        perfLevel.setValue(null);
+
+        final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        assertThat(exam.getScaleScore()).isNull();
+        assertThat(exam.getScaleScoreStdErr()).isNull();
+    }
+
+    @Test
     public void itShouldParseExamWithClaims() {
         final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1)
                 .scores(asmtScores()).build();


### PR DESCRIPTION
…or residual score labels

These were two bitty requests from Smarter Balanced in anticipation of receiving summative results from ETS.