### PR TITLE
make the Tenant instances stored in Tenant Properties a Map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=1.2.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-134"
+String rdwCommonVersion = project.hasProperty("common") ? project.property("common") : "1.4.0-137"
 String rdwSchemaVersion = project.hasProperty("schema") ? project.property("schema") : "1.4.0-418"
 String dockerPrefix = "smarterbalanced"
 

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/config/TenantConfiguration.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/config/TenantConfiguration.java
@@ -25,7 +25,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();

--- a/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/configuration/TenantConfiguration.java
+++ b/group-processor/src/main/java/org/opentestsystem/rdw/ingest/group/configuration/TenantConfiguration.java
@@ -23,7 +23,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/multitenant/TenantConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/multitenant/TenantConfiguration.java
@@ -18,7 +18,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverterTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/auth/SbacTokenConverterTest.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.ingest.auth;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.opentestsystem.rdw.multitenant.TenantProperties;
 import org.opentestsystem.rdw.security.repository.OrganizationRepository;
 import org.opentestsystem.rdw.utils.TenancyChain;
@@ -15,6 +14,7 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -75,7 +75,7 @@ public class SbacTokenConverterTest {
         tenant.setKey("CA");
         tenant.setName("CA");
         final TenantProperties tenantProperties = new TenantProperties();
-        tenantProperties.setTenants(newArrayList(tenant));
+        tenantProperties.setTenants(Collections.singletonMap(tenant.getKey(), tenant));
 
         return new SbacTokenConverter(authorityService, tenantProperties);
     }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/TestAppConfig.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/web/TestAppConfig.java
@@ -1,5 +1,7 @@
 package org.opentestsystem.rdw.ingest.web;
 
+import org.opentestsystem.rdw.ingest.repository.DataSourceConfiguration;
+import org.opentestsystem.rdw.multitenant.TenantProperties;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -7,10 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-import org.opentestsystem.rdw.ingest.repository.DataSourceConfiguration;
-import org.opentestsystem.rdw.multitenant.TenantProperties;
-
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.Collections;
 
 /**
  * This configures an application context that has just enough to test controllers.
@@ -37,7 +36,7 @@ class TestAppConfig {
         tenant.setKey("CA");
         tenant.setName("CA");
         final TenantProperties tenantProperties = new TenantProperties();
-        tenantProperties.setTenants(newArrayList(tenant));
+        tenantProperties.setTenants(Collections.singletonMap(tenant.getKey(), tenant));
         return tenantProperties;
     }
 }

--- a/import-service/src/test/resources/application-test.yml
+++ b/import-service/src/test/resources/application-test.yml
@@ -4,8 +4,9 @@ datasources:
     maxActive: 10
     query-timeout: 2
 
-tenant-properties:
+tenantProperties:
   tenants:
-    - id: CA
+    CA:
+      id: CA
       key: CA
       name: California

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/TenantConfiguration.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/TenantConfiguration.java
@@ -23,7 +23,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/TenantConfiguration.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/TenantConfiguration.java
@@ -23,7 +23,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();

--- a/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/configuration/TenantConfiguration.java
+++ b/package-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/configuration/TenantConfiguration.java
@@ -25,7 +25,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();

--- a/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/TenantConfiguration.java
+++ b/task-service/src/main/java/org/opentestsystem/rdw/ingest/tasking/TenantConfiguration.java
@@ -23,7 +23,7 @@ public class TenantConfiguration {
     }
 
     @Bean
-    @ConfigurationProperties("tenant-properties")
+    @ConfigurationProperties("tenantProperties")
     @RefreshScope
     public TenantProperties tenantProperties() {
         return new TenantProperties();


### PR DESCRIPTION
- Map<TenantKey,Tenant> instead of a List<Tenant>
- simplifies modification of tenant data in git, ties it directly to other tenant configuration
- depends on changes in common