### PR TITLE
RP-466, make migrate job runners more tenant-aware

### DIFF
--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateEndpoint.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateEndpoint.java
@@ -30,12 +30,12 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 public class MigrateEndpoint extends AbstractEndpoint<String> {
     private static final Logger logger = LoggerFactory.getLogger(MigrateEndpoint.class);
 
-    private final MigrateLifecycle jobRunner;
+    private final TenantAwareMigrateLifecycle jobRunner;
     private final MigrateRepository repository;
     private final TenantProperties tenantProperties;
 
     @Autowired
-    public MigrateEndpoint(final MigrateLifecycle jobRunner,
+    public MigrateEndpoint(final TenantAwareMigrateLifecycle jobRunner,
                            final MigrateRepository repository,
                            final TenantProperties tenantProperties) {
         super("migrate", true, true);
@@ -80,24 +80,27 @@ public class MigrateEndpoint extends AbstractEndpoint<String> {
     /**
      * Trigger migration.
      *
-     * @param tenantId tenant id
+     * @param tenantId optional tenant id
      * @return message indicating action taken (or not)
      */
     public String migrate(final String tenantId) {
         final String message;
-        if (!checkAndSetTenant(tenantId)) {
-            message = "Ignoring /migrate request for unknown tenant id " + tenantId;
-        } else if (!jobRunner.isEnabled()) {
-            message = "Ignoring /migrate request since migrate is disabled for tenant " + tenantId;
-        } else if (!jobRunner.isRunning()) {
+        if (!jobRunner.isRunning()) {
             message = "Ignoring /migrate request since migrate is not running";
+        } else if (tenantId != null) {
+            if (!checkAndSetTenant(tenantId)) {
+                message = "Ignoring /migrate request for unknown tenant id " + tenantId;
+            } else if (!jobRunner.isEnabled()) {
+                message = "Ignoring /migrate request since migrate is disabled for tenant " + tenantId;
+            } else {
+                message = "Migrate triggered by /migrate request for tenant " + tenantId;
+                Executors.newSingleThreadExecutor().execute(() -> jobRunner.run(tenantId));
+            }
         } else {
-            message = "Migrate triggered by /migrate request for tenant " + tenantId;
-            Executors.newSingleThreadExecutor().execute(() -> {
-                TenantContextHolder.setTenantId(tenantId);
-                jobRunner.run();
-            });
+            message = "Migrate triggered by /migrate request for all tenants";
+            Executors.newSingleThreadExecutor().execute(jobRunner::run);
         }
+
         logger.info(message);
         return message;
     }

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunner.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunner.java
@@ -30,7 +30,7 @@ import org.opentestsystem.rdw.multitenant.TenantIdResolver;
  * </p>
  */
 public abstract class MigrateJobRunner implements MigrateLifecycle {
-    protected static final Logger logger = LoggerFactory.getLogger(MigrateJobRunner.class);
+    static final Logger logger = LoggerFactory.getLogger(MigrateJobRunner.class);
 
     private final MigrateRepository migrateRepository;
     private final WarehouseImportRepository importRepository;
@@ -41,6 +41,14 @@ public abstract class MigrateJobRunner implements MigrateLifecycle {
     private final TenantIdResolver tenantIdResolver;
     private final Map<String, Boolean> tenantDisabled = new ConcurrentHashMap<>();
 
+    /**
+     * @param migrateRepository migrate repository
+     * @param importRepository used to query for next job params
+     * @param tenantIdResolver used when enabling migrate for a tenant
+     * @param jobLauncher job launch
+     * @param job job
+     * @param batchSize controls amount of work done in a single migrate jobs
+     */
     public MigrateJobRunner(final MigrateRepository migrateRepository,
                             final WarehouseImportRepository importRepository,
                             final TenantIdResolver tenantIdResolver,

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateMvcEndpoint.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/MigrateMvcEndpoint.java
@@ -32,7 +32,7 @@ public class MigrateMvcEndpoint extends EndpointMvcAdapter {
 
     @PostMapping()
     @ResponseBody
-    public Object migrate(@RequestParam final String tenantId) {
+    public Object migrate(@RequestParam(required = false) final String tenantId) {
         if (!getDelegate().isEnabled()) {
             // Shouldn't happen - MVC endpoint shouldn't be registered when delegate's disabled
             return getDisabledResponse();

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/TenantAwareMigrateJobRunner.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/TenantAwareMigrateJobRunner.java
@@ -1,0 +1,46 @@
+package org.opentestsystem.rdw.migrate.common;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.launch.JobLauncher;
+
+import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
+import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
+import org.opentestsystem.rdw.multitenant.Tenant;
+import org.opentestsystem.rdw.multitenant.TenantContextHolder;
+import org.opentestsystem.rdw.multitenant.TenantIdResolver;
+import org.opentestsystem.rdw.multitenant.TenantProperties;
+
+public class TenantAwareMigrateJobRunner extends MigrateJobRunner implements TenantAwareMigrateLifecycle {
+
+    private final TenantProperties tenantProperties;
+
+    public TenantAwareMigrateJobRunner(final MigrateRepository migrateRepository,
+                                       final WarehouseImportRepository importRepository,
+                                       final TenantIdResolver tenantIdResolver,
+                                       final JobLauncher jobLauncher,
+                                       final Job job,
+                                       final int batchSize,
+                                       final TenantProperties tenantProperties) {
+        super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize);
+        this.tenantProperties = tenantProperties;
+        if (tenantProperties.getTenants().isEmpty()) {
+            logger.warn("No tenants found, no migration jobs will be run (this is probably a configuration error)");
+        }
+    }
+
+    @Override
+    public void run() {
+        // run the migration for every known tenant
+        for (final Tenant tenant : tenantProperties.getTenants().values()) {
+            run(tenant.getId());
+        }
+    }
+
+
+    @Override
+    public void run(final String tenantId) {
+        TenantContextHolder.setTenantId(tenantId);
+        super.run();
+        TenantContextHolder.clear();
+    }
+}

--- a/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/TenantAwareMigrateLifecycle.java
+++ b/migrate-common/src/main/java/org/opentestsystem/rdw/migrate/common/TenantAwareMigrateLifecycle.java
@@ -1,0 +1,14 @@
+package org.opentestsystem.rdw.migrate.common;
+
+/**
+ * A tenant-aware runnable migrate component
+ */
+public interface TenantAwareMigrateLifecycle extends MigrateLifecycle {
+
+    /**
+     * take action for a specific tenant
+     *
+     * @param tenantId tenant id
+     */
+    void run(String tenantId);
+}

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateEndpointTest.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateEndpointTest.java
@@ -16,13 +16,13 @@ import static org.mockito.Mockito.when;
 
 public class MigrateEndpointTest {
 
-    private MigrateLifecycle jobRunner;
+    private TenantAwareMigrateLifecycle jobRunner;
     private MigrateRepository repository;
     private MigrateEndpoint endpoint;
 
     @Before
     public void createEndpoint() {
-        jobRunner = mock(MigrateLifecycle.class);
+        jobRunner = mock(TenantAwareMigrateLifecycle.class);
         repository = mock(MigrateRepository.class);
 
         final Tenant tenant = Tenant.builder().id("CA").key("CA").name("California").build();
@@ -68,32 +68,44 @@ public class MigrateEndpointTest {
     }
 
     @Test
+    public void itShouldNotMigrateIfPaused() {
+        when(jobRunner.isRunning()).thenReturn(false);
+        assertThat(endpoint.migrate(null)).isEqualTo("Ignoring /migrate request since migrate is not running");
+    }
+
+    @Test
     public void itShouldNotMigrateForUnknownTenant() {
+        when(jobRunner.isRunning()).thenReturn(true);
         assertThat(endpoint.migrate("MI")).isEqualTo("Ignoring /migrate request for unknown tenant id MI");
     }
 
     @Test
     public void itShouldNotMigrateIfDisabled() {
+        when(jobRunner.isRunning()).thenReturn(true);
         when(jobRunner.isEnabled()).thenReturn(false);
         assertThat(endpoint.migrate("CA")).isEqualTo("Ignoring /migrate request since migrate is disabled for tenant CA");
     }
 
     @Test
-    public void itShouldNotMigrateIfPaused() {
-        when(jobRunner.isEnabled()).thenReturn(true);
-        when(jobRunner.isRunning()).thenReturn(false);
-        assertThat(endpoint.migrate("CA")).isEqualTo("Ignoring /migrate request since migrate is not running");
-    }
-
-    @Test
     public void itShouldMigrate() throws InterruptedException {
-        when(jobRunner.isEnabled()).thenReturn(true);
         when(jobRunner.isRunning()).thenReturn(true);
-        assertThat(endpoint.migrate("CA")).isEqualTo("Migrate triggered by /migrate request for tenant CA");
+        when(jobRunner.isEnabled()).thenReturn(true);
+        assertThat(endpoint.migrate(null)).isEqualTo("Migrate triggered by /migrate request for all tenants");
         // yeah, this sucks; not sure what else to do that doesn't involve
         // modifying MigrateEndpoint to allow a test hook ...
         Thread.sleep(200);
         verify(jobRunner).run();
+    }
+
+    @Test
+    public void itShouldMigrateTenant() throws InterruptedException {
+        when(jobRunner.isRunning()).thenReturn(true);
+        when(jobRunner.isEnabled()).thenReturn(true);
+        assertThat(endpoint.migrate("CA")).isEqualTo("Migrate triggered by /migrate request for tenant CA");
+        // yeah, this sucks; not sure what else to do that doesn't involve
+        // modifying MigrateEndpoint to allow a test hook ...
+        Thread.sleep(200);
+        verify(jobRunner).run("CA");
     }
 
     @Test

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunnerTest.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/MigrateJobRunnerTest.java
@@ -1,11 +1,8 @@
 package org.opentestsystem.rdw.migrate.common;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
-import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
-import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
-import org.opentestsystem.rdw.multitenant.TenantIdResolver;
-
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobParameters;
@@ -13,6 +10,11 @@ import org.springframework.batch.core.launch.JobLauncher;
 
 import java.time.Instant;
 import java.util.Optional;
+import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
+import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
+import org.opentestsystem.rdw.multitenant.Tenant;
+import org.opentestsystem.rdw.multitenant.TenantIdResolver;
+import org.opentestsystem.rdw.multitenant.TenantProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +36,7 @@ public class MigrateJobRunnerTest {
     private TenantIdResolver tenantIdResolver;
     private JobLauncher jobLauncher;
     private Job job;
+    private TenantProperties tenantProperties;
     private MigrateJobRunner reportingJobRunner;
 
 
@@ -56,17 +59,22 @@ public class MigrateJobRunnerTest {
         jobLauncher = mock(JobLauncher.class);
         job = mock(Job.class);
 
-        reportingJobRunner = new TestJobRunner(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize);
+        // for most of the tests we want a single tenant ('cause that's how they were written initially)
+        tenantProperties = new TenantProperties();
+        tenantProperties.setTenants(ImmutableMap.of("CA", Tenant.builder().id("CA").key("CA").build()));
+
+        reportingJobRunner = new TestJobRunner(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize, tenantProperties);
     }
 
-    private static class TestJobRunner extends MigrateJobRunner {
+    private static class TestJobRunner extends TenantAwareMigrateJobRunner {
         TestJobRunner(final MigrateRepository migrateRepository,
                       final WarehouseImportRepository importRepository,
                       final TenantIdResolver tenantIdResolver,
                       final JobLauncher jobLauncher,
                       final Job job,
-                      final int batchSize) {
-            super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize);
+                      final int batchSize,
+                      final TenantProperties tenantProperties) {
+            super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize, tenantProperties);
         }
     }
 
@@ -146,5 +154,20 @@ public class MigrateJobRunnerTest {
 
         // direct calls to enable or isEnabled will fail however
         reportingJobRunner.isEnabled();
+    }
+
+    @Test
+    public void itShouldRunForAllTenants() throws JobExecutionException {
+        tenantProperties.setTenants(ImmutableMap.of(
+                "CA", Tenant.builder().id("CA").key("CA").build(),
+                "NV", Tenant.builder().id("NV").key("NV").build()));
+
+        when(importRepository.getMigrateImportValues(null, batchSize))
+                .thenReturn(MigrateImportValues.builder().firstAt(firstAt).lastAt(lastAt).migrateCodes(true).importCount(batchSize-1).build())
+                .thenReturn(MigrateImportValues.builder().firstAt(lastAt).lastAt(nextLastAt).migrateCodes(true).importCount(batchSize-1).build());
+
+        reportingJobRunner.run();
+        verify(importRepository, times(2)).getMigrateImportValues(null, batchSize);
+        verify(jobLauncher, times(2)).run(same(job), any(JobParameters.class));
     }
 }

--- a/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/SimpleMigrateLifecycle.java
+++ b/migrate-common/src/test/java/org/opentestsystem/rdw/migrate/common/SimpleMigrateLifecycle.java
@@ -6,12 +6,16 @@ package org.opentestsystem.rdw.migrate.common;
  * tests in migrate-olap and migrate-reporting but i can't. So this can be used
  * to fulfill the autowire requirement in tests.
  */
-public class SimpleMigrateLifecycle implements MigrateLifecycle {
+public class SimpleMigrateLifecycle implements TenantAwareMigrateLifecycle {
     private boolean running = true;
     private boolean enabled = true;
 
     @Override
     public void run() {
+    }
+
+    @Override
+    public void run(final String tenantId) {
     }
 
     @Override

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
@@ -12,10 +12,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import org.opentestsystem.rdw.migrate.common.MigrateJobRunner;
+import org.opentestsystem.rdw.migrate.common.TenantAwareMigrateJobRunner;
 import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
 import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
-import org.opentestsystem.rdw.multitenant.Tenant;
-import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.multitenant.TenantIdResolver;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
 
@@ -28,9 +27,7 @@ import org.opentestsystem.rdw.multitenant.TenantProperties;
 @EnableAsync
 @Component
 @Import({MigrateOlapReportingConfiguration.class})
-class MigrateOlapReportingJobRunner extends MigrateJobRunner {
-
-    private final TenantProperties tenantProperties;
+class MigrateOlapReportingJobRunner extends TenantAwareMigrateJobRunner {
 
     @Autowired
     public MigrateOlapReportingJobRunner(final MigrateRepository migrateRepository,
@@ -40,22 +37,13 @@ class MigrateOlapReportingJobRunner extends MigrateJobRunner {
                                          final Job job,
                                          @Value("${migrate.olap-batch.size}") final int batchSize,
                                          final TenantProperties tenantProperties) {
-        super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize);
-        this.tenantProperties = tenantProperties;
-        if (tenantProperties.getTenants().isEmpty()) {
-            logger.warn("No tenants found, no migration jobs will be run (this is probably a configuration error)");
-        }
+        super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize, tenantProperties);
     }
 
     @Async
     @Scheduled(cron = "${migrate.olap-batch.run-cron}", zone = "GMT")
     @Override
     public void run() {
-        // run the migration for every known tenant
-        for (final Tenant tenant : tenantProperties.getTenants().values()) {
-            TenantContextHolder.setTenantId(tenant.getId());
-            super.run();
-        }
-        TenantContextHolder.clear();
+        super.run();
     }
 }

--- a/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/TestAppConfig.java
+++ b/migrate-olap/src/test/java/org/opentestsystem/rdw/ingest/migrate/olap/TestAppConfig.java
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import org.opentestsystem.rdw.ingest.migrate.olap.repository.DataSourceConfiguration;
-import org.opentestsystem.rdw.migrate.common.MigrateLifecycle;
 import org.opentestsystem.rdw.migrate.common.SimpleMigrateLifecycle;
+import org.opentestsystem.rdw.migrate.common.TenantAwareMigrateLifecycle;
 import org.opentestsystem.rdw.multitenant.Tenant;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
@@ -36,7 +36,7 @@ class TestAppConfig {
      * This is needed because of MigrateEndpoint being in the application context.
      */
     @Bean
-    public MigrateLifecycle simpleMigrateLifecycle() {
+    public TenantAwareMigrateLifecycle simpleMigrateLifecycle() {
         return new SimpleMigrateLifecycle();
     }
 

--- a/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
+++ b/migrate-reporting/src/main/java/org/opentestsystem/rdw/ingest/migrate/reporting/MigrateReportingJobRunner.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.rdw.ingest.migrate.reporting;
 
-
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,10 +11,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import org.opentestsystem.rdw.migrate.common.MigrateJobRunner;
+import org.opentestsystem.rdw.migrate.common.TenantAwareMigrateJobRunner;
 import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
 import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
-import org.opentestsystem.rdw.multitenant.Tenant;
-import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.multitenant.TenantIdResolver;
 import org.opentestsystem.rdw.multitenant.TenantProperties;
 
@@ -28,9 +26,7 @@ import org.opentestsystem.rdw.multitenant.TenantProperties;
 @EnableAsync
 @Component
 @Import({MigrateReportingConfiguration.class})
-class MigrateReportingJobRunner extends MigrateJobRunner {
-
-    private final TenantProperties tenantProperties;
+class MigrateReportingJobRunner extends TenantAwareMigrateJobRunner {
 
     @Autowired
     public MigrateReportingJobRunner(final MigrateRepository migrateRepository,
@@ -40,21 +36,12 @@ class MigrateReportingJobRunner extends MigrateJobRunner {
                                      final Job job,
                                      @Value("${migrate.batch.size}") final int batchSize,
                                      final TenantProperties tenantProperties) {
-        super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize);
-        this.tenantProperties = tenantProperties;
-        if (tenantProperties.getTenants().isEmpty()) {
-            logger.warn("No tenants found, no migration jobs will be run (this is probably a configuration error)");
-        }
+        super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize, tenantProperties);
     }
 
     @Scheduled(fixedDelayString = "${migrate.batch.delay}")
     @Override
     public void run() {
-        // run the migration for every known tenant
-        for (final Tenant tenant : tenantProperties.getTenants().values()) {
-            TenantContextHolder.setTenantId(tenant.getId());
-            super.run();
-        }
-        TenantContextHolder.clear();
+        super.run();
     }
 }

--- a/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/TestAppConfig.java
+++ b/migrate-reporting/src/test/java/org/opentestsystem/rdw/ingest/migrate/reporting/TestAppConfig.java
@@ -4,6 +4,7 @@ import org.opentestsystem.rdw.ingest.migrate.reporting.repository.DataSourceConf
 import org.opentestsystem.rdw.ingest.migrate.reporting.step.StagingToReportingStepsConfig;
 import org.opentestsystem.rdw.migrate.common.MigrateLifecycle;
 import org.opentestsystem.rdw.migrate.common.SimpleMigrateLifecycle;
+import org.opentestsystem.rdw.migrate.common.TenantAwareMigrateLifecycle;
 import org.opentestsystem.rdw.migrate.common.config.MigrateStagingToReportingSqlConfiguration;
 import org.opentestsystem.rdw.migrate.common.config.MigrateWarehouseToStagingSqlConfiguration;
 import org.opentestsystem.rdw.utils.YamlPropertiesConfigurator;
@@ -41,7 +42,7 @@ class TestAppConfig {
      * This is needed because of MigrateEndpoint being in the application context.
      */
     @Bean
-    public MigrateLifecycle simpleMigrateLifecycle() {
+    public TenantAwareMigrateLifecycle simpleMigrateLifecycle() {
         return new SimpleMigrateLifecycle();
     }
 }


### PR DESCRIPTION
Before this fix, POSTing to the /migrate end-point would trigger migration for all tenants. This makes it so you can trigger for just one. 