### PR TITLE
RP-508: Creating a Sandbox/Tenant must migrate and initialize cached values

### DIFF
--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
@@ -4,7 +4,9 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -40,8 +42,9 @@ class MigrateOlapReportingJobRunner extends TenantAwareMigrateJobRunner {
         super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize, tenantProperties);
     }
 
-    @Async
+    @Async("serialExecutor")
     @Scheduled(cron = "${migrate.olap-batch.run-cron}", zone = "GMT")
+    @EventListener(classes = EnvironmentChangeEvent.class)
     @Override
     public void run() {
         super.run();

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
@@ -42,7 +42,15 @@ class MigrateOlapReportingJobRunner extends TenantAwareMigrateJobRunner {
         super(migrateRepository, importRepository, tenantIdResolver, jobLauncher, job, batchSize, tenantProperties);
     }
 
-    @Async("serialExecutor")
+    /**
+     * Runs the migrate job. Each call will be serialized so that one must finish before the next starts. This
+     * is true whether the job is invoked by the scheduler, an EnvironmentChangeEvent, or via the MVC
+     * endpoint.
+     *
+     * NOTE: this method should never be modified in such a way that it could throw an exception, because this
+     * could interfere with Spring's event listener handling.
+     */
+    @Async("singleThreadExecutor")
     @Scheduled(cron = "${migrate.olap-batch.run-cron}", zone = "GMT")
     @EventListener(classes = EnvironmentChangeEvent.class)
     @Override

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/SpringAsyncConfiguration.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/SpringAsyncConfiguration.java
@@ -1,0 +1,60 @@
+package org.opentestsystem.rdw.ingest.migrate.olap;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+
+/**
+ * Configuration defining custom Executors to use with Spring's @Async annotation.
+ */
+@Configuration
+@EnableAsync
+public class SpringAsyncConfiguration {
+
+    /**
+     * SerialExecutor based on the implementation described in the {@link Executor} API docs.
+     *
+     * @return an Executor that will enforce that one job finishes before the next can begin
+     */
+    @Bean(name = "serialExecutor")
+    public Executor serialExecutor() {
+        return new SerialExecutor(new SimpleAsyncTaskExecutor());
+    }
+
+    // Serial Executor adapted from java.util.Executor java docs.
+    private static class SerialExecutor implements Executor {
+        final Queue<Runnable> tasks = new ArrayDeque<>();
+        final Executor executor;
+        Runnable active;
+
+        SerialExecutor(Executor executor) {
+            this.executor = executor;
+        }
+
+        public synchronized void execute(final Runnable r) {
+            tasks.offer(() -> {
+                try {
+                    r.run();
+                } finally {
+                    scheduleNext();
+                }
+            });
+
+            if (active == null) {
+                scheduleNext();
+            }
+        }
+
+        private synchronized void scheduleNext() {
+            if ((active = tasks.poll()) != null) {
+                executor.execute(active);
+            }
+        }
+    }
+}

--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/SpringAsyncConfiguration.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/SpringAsyncConfiguration.java
@@ -3,12 +3,10 @@ package org.opentestsystem.rdw.ingest.migrate.olap;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 /**
  * Configuration defining custom Executors to use with Spring's @Async annotation.
@@ -18,43 +16,12 @@ import java.util.concurrent.Executor;
 public class SpringAsyncConfiguration {
 
     /**
-     * SerialExecutor based on the implementation described in the {@link Executor} API docs.
+     * Returns a single thread executor, which will ensure only one job is processed at a time.
      *
      * @return an Executor that will enforce that one job finishes before the next can begin
      */
-    @Bean(name = "serialExecutor")
-    public Executor serialExecutor() {
-        return new SerialExecutor(new SimpleAsyncTaskExecutor());
-    }
-
-    // Serial Executor adapted from java.util.Executor java docs.
-    private static class SerialExecutor implements Executor {
-        final Queue<Runnable> tasks = new ArrayDeque<>();
-        final Executor executor;
-        Runnable active;
-
-        SerialExecutor(Executor executor) {
-            this.executor = executor;
-        }
-
-        public synchronized void execute(final Runnable r) {
-            tasks.offer(() -> {
-                try {
-                    r.run();
-                } finally {
-                    scheduleNext();
-                }
-            });
-
-            if (active == null) {
-                scheduleNext();
-            }
-        }
-
-        private synchronized void scheduleNext() {
-            if ((active = tasks.poll()) != null) {
-                executor.execute(active);
-            }
-        }
+    @Bean(name = "singleThreadExecutor")
+    public Executor singleThreadExecutor() {
+        return Executors.newSingleThreadExecutor();
     }
 }


### PR DESCRIPTION
Adds event listener to OLAP migration job and serializes calls to this method (scheduled, event triggered, or otherwise called via proxy) so that one must complete before another starts. 