### PR TITLE
attempted fix for java.lang.IllegalStateException

### DIFF
--- a/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
+++ b/migrate-olap/src/main/java/org/opentestsystem/rdw/ingest/migrate/olap/MigrateOlapReportingJobRunner.java
@@ -1,5 +1,11 @@
 package org.opentestsystem.rdw.ingest.migrate.olap;
 
+import org.opentestsystem.rdw.migrate.common.MigrateJobRunner;
+import org.opentestsystem.rdw.migrate.common.TenantAwareMigrateJobRunner;
+import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
+import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
+import org.opentestsystem.rdw.multitenant.TenantIdResolver;
+import org.opentestsystem.rdw.multitenant.TenantProperties;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +18,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import org.opentestsystem.rdw.migrate.common.MigrateJobRunner;
-import org.opentestsystem.rdw.migrate.common.TenantAwareMigrateJobRunner;
-import org.opentestsystem.rdw.migrate.common.repository.MigrateRepository;
-import org.opentestsystem.rdw.migrate.common.repository.WarehouseImportRepository;
-import org.opentestsystem.rdw.multitenant.TenantIdResolver;
-import org.opentestsystem.rdw.multitenant.TenantProperties;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Scheduled execution of the {@link MigrateOlapReportingConfiguration#jobBuilderFactory}'s job.
@@ -54,6 +54,7 @@ class MigrateOlapReportingJobRunner extends TenantAwareMigrateJobRunner {
     @Scheduled(cron = "${migrate.olap-batch.run-cron}", zone = "GMT")
     @EventListener(classes = EnvironmentChangeEvent.class)
     @Override
+    @Transactional
     public void run() {
         super.run();
     }


### PR DESCRIPTION
attempted fix for java.lang.IllegalStateException: No value for key [..TenantDynamicRoutingDataSource...] bound to thread

- unable to test this locally, but I don't think it can make things any worse
- plan to deploy and evaluate, if it is worse I will quickly back it out