### PR TITLE
adds school year to app test yml as a safe fallback

### DIFF
--- a/migrate-olap/src/test/resources/application-test.yml
+++ b/migrate-olap/src/test/resources/application-test.yml
@@ -1,0 +1,2 @@
+reporting:
+  school-year: 2019


### PR DESCRIPTION
this feels like a safe thing to do to me - thoughts?

issue here is `application-redshift.yml` has a school year. but not all RST are `@ActiveProfile("redshift")` so they don't get the school year that they used to get from the `application.yml`