### PR TITLE
RP-721: integrate import service OAuth with Okta.

### DIFF
--- a/import-service/build.gradle
+++ b/import-service/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     // auth
     compile 'org.springframework.boot:spring-boot-starter-security'
     compile 'org.springframework.security.oauth:spring-security-oauth2'
+    compile group: 'com.okta.jwt', name: 'okta-jwt-verifier', version: '0.4.0'
+    compile group: 'com.okta.jwt', name: 'okta-jwt-verifier-impl', version: '0.4.0'
 
     // this is for retrying connection to config server
     compile 'org.springframework.boot:spring-boot-starter-aop'

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaJwtHelper.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaJwtHelper.java
@@ -1,0 +1,37 @@
+package org.opentestsystem.rdw.ingest.impsvc.auth;
+
+import com.okta.jwt.AccessTokenVerifier;
+import com.okta.jwt.JwtVerifiers;
+
+import java.time.Duration;
+
+/**
+ * Helper class to create the JWT verifier, which is used to decode the JWT token.
+ */
+public class OktaJwtHelper {
+
+    private String issuer;
+    private String audience;
+    private Long connectionTimeout = 1000L;
+
+    public void setIssuer(final String issuer) {
+        this.issuer = issuer;
+    }
+
+    public void setAudience(final String audience) {
+        this.audience = audience;
+    }
+
+    public void setConnectionTimeout(final Long connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public AccessTokenVerifier getJwtVerifier() {
+        return JwtVerifiers.accessTokenVerifierBuilder()
+                .setIssuer(this.issuer)
+                .setAudience(this.audience)
+                .setConnectionTimeout(Duration.ofMillis(this.connectionTimeout))
+                .setReadTimeout(Duration.ofMillis(connectionTimeout))
+                .build();
+    }
+}

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServices.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServices.java
@@ -100,24 +100,24 @@ class OktaTokenServices implements ResourceServerTokenServices {
         Map<String,Object> sanitized = new HashMap<>(claims);
 
         // The EXPIRES_IN seconds can be computed from EXP
-        if (claims.containsKey(EXP) && !claims.containsKey(EXPIRES_IN)) {
+        if (sanitized.containsKey(EXP) && !sanitized.containsKey(EXPIRES_IN)) {
             try {
                 long now = System.currentTimeMillis() / 1000L;
-                long exp = ((Number)claims.get(EXP)).longValue();
+                long exp = ((Number)sanitized.get(EXP)).longValue();
                 sanitized.put(EXPIRES_IN, (int)(exp - now));
             } catch (Exception e) {
-                logger.info("Cannot compute expires-in value from exp: " + claims.get(EXP));
+                logger.info("Cannot compute expires-in value from exp: " + sanitized.get(EXP));
             }
         }
 
         // Tenancy chain may be in a list, but must be joined into a string.
-        final Object tenancyChain = claims.get(SBAC_TENANCY_CHAIN);
+        final Object tenancyChain = sanitized.get(SBAC_TENANCY_CHAIN);
         if (tenancyChain instanceof Collection) {
             String tenancyChainString = StringUtils.join(((Collection) tenancyChain), ",");
             sanitized.put(SBAC_TENANCY_CHAIN, tenancyChainString);
         }
 
-        if (!claims.containsKey(GRANT_TYPE)) {
+        if (!sanitized.containsKey(GRANT_TYPE)) {
             sanitized.put(GRANT_TYPE, "password");
         }
 

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServices.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServices.java
@@ -1,0 +1,127 @@
+package org.opentestsystem.rdw.ingest.impsvc.auth;
+
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.okta.jwt.AccessTokenVerifier;
+import com.okta.jwt.JwtVerificationException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.springframework.security.oauth2.common.OAuth2AccessToken.EXPIRES_IN;
+import static org.springframework.security.oauth2.common.util.OAuth2Utils.GRANT_TYPE;
+
+/**
+ * An implementation of {@link ResourceServerTokenServices} backed by Okta. It expects the access token to be
+ * a JWT containing all the necessary OAuth information in its claims.
+ *
+ * @see SecurityConfigurer
+ * @see SbacTokenConverter
+ */
+class OktaTokenServices implements ResourceServerTokenServices {
+    private static final Logger logger = LoggerFactory.getLogger(OktaTokenServices.class);
+
+    // Expiration claim, used to calculate EXPIRES_IN used by the SbacTokenConverter.
+    private static final String EXP = "exp";
+    private static final String SBAC_TENANCY_CHAIN = "sbacTenancyChain";
+
+    private OktaJwtHelper jwtHelper;
+
+    private final AccessTokenConverter tokenConverter;
+    private final LoadingCache<String, OAuth2Authentication> cache;
+
+    OktaTokenServices(final AccessTokenConverter tokenConverter) {
+        this.tokenConverter = tokenConverter;
+        this.cache = new ExpiringAuthenticationCache(key -> tokenConverter.extractAuthentication(getTokenInfo(key)));
+        this.jwtHelper = new OktaJwtHelper();
+    }
+
+    public void setJwtHelper(final OktaJwtHelper jwtHelper) {
+        this.jwtHelper = jwtHelper;
+    }
+
+    @SuppressWarnings("unused")
+    public void setTokenInfoUrl(final String tokenInfoUrl) {
+        jwtHelper.setIssuer(tokenInfoUrl);
+    }
+
+    @SuppressWarnings("unused")
+    public void setAudience(final String audience) {
+        jwtHelper.setAudience(audience);
+    }
+
+    @SuppressWarnings("unused")
+    public void setConnectionTimeout(final Long connectionTimeout) {
+        jwtHelper.setConnectionTimeout(connectionTimeout);
+    }
+
+    @Override
+    public OAuth2Authentication loadAuthentication(final String accessToken) throws AuthenticationException, InvalidTokenException {
+        try {
+            return cache.get(accessToken);
+        } catch (final ExecutionException | UncheckedExecutionException e) {
+            // propagate the cause if we can, otherwise wrap in generic auth exception
+            throw e.getCause() instanceof RuntimeException ? (RuntimeException) e.getCause()
+                    : new AuthenticationServiceException(e.getMessage());
+        }
+    }
+
+    @Override
+    public OAuth2AccessToken readAccessToken(final String accessToken) {
+        return tokenConverter.extractAccessToken(accessToken, getTokenInfo(accessToken));
+    }
+
+    private Map<String, Object> getTokenInfo(final String token) {
+
+        try {
+            final AccessTokenVerifier jwtVerifier = jwtHelper.getJwtVerifier();
+            final Map<String, Object> claims = jwtVerifier.decode(token).getClaims();
+            return sanitize(claims);
+        } catch (JwtVerificationException e) {
+            logger.debug("getTokenInfo exception: {}", e.getMessage());
+            throw new InvalidTokenException(token + ": " + e.getMessage());
+        }
+    }
+
+    // Adjusts contents of the JWT claims so they synch with what the token convert expects.
+    private Map<String, Object> sanitize(final Map<String, Object> claims) {
+        Map<String,Object> sanitized = new HashMap<>(claims);
+
+        // The EXPIRES_IN seconds can be computed from EXP
+        if (claims.containsKey(EXP) && !claims.containsKey(EXPIRES_IN)) {
+            try {
+                long now = System.currentTimeMillis() / 1000L;
+                long exp = ((Number)claims.get(EXP)).longValue();
+                sanitized.put(EXPIRES_IN, (int)(exp - now));
+            } catch (Exception e) {
+                logger.info("Cannot compute expires-in value from exp: " + claims.get(EXP));
+            }
+        }
+
+        // Tenancy chain may be in a list, but must be joined into a string.
+        final Object tenancyChain = claims.get(SBAC_TENANCY_CHAIN);
+        if (tenancyChain instanceof Collection) {
+            String tenancyChainString = StringUtils.join(((Collection) tenancyChain), ",");
+            sanitized.put(SBAC_TENANCY_CHAIN, tenancyChainString);
+        }
+
+        if (!claims.containsKey(GRANT_TYPE)) {
+            sanitized.put(GRANT_TYPE, "password");
+        }
+
+        return sanitized;
+    }
+}
+

--- a/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/SecurityConfiguration.java
+++ b/import-service/src/main/java/org/opentestsystem/rdw/ingest/impsvc/auth/SecurityConfiguration.java
@@ -1,14 +1,16 @@
 package org.opentestsystem.rdw.ingest.impsvc.auth;
 
-import org.opentestsystem.rdw.security.client.permissionservice.PermissionWebServiceClient;
-import org.opentestsystem.rdw.security.service.ComponentPermissionService;
-import org.opentestsystem.rdw.security.service.PermissionService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.web.client.RestTemplate;
+
+import org.opentestsystem.rdw.security.client.permissionservice.PermissionWebServiceClient;
+import org.opentestsystem.rdw.security.service.ComponentPermissionService;
+import org.opentestsystem.rdw.security.service.PermissionService;
 
 /**
  * Default security configuration uses the real ForgeRockTokenServices and Authority/Permission services.
@@ -17,10 +19,18 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @ConditionalOnMissingBean(StubSecurityConfiguration.class)
 class SecurityConfiguration {
+    private static final String OKTA_PROVIDER = "okta";
 
     @Bean
     @ConfigurationProperties(prefix = "security.oauth2")
-    public ForgeRockTokenServices forgeRockTokenServices(final SbacTokenConverter tokenConverter) {
+    public ResourceServerTokenServices tokenServices(
+            final SbacTokenConverter tokenConverter,
+            @Value("${security.oauth2.provider:}") final String provider) {
+
+        // For transition period, support both OpenAM and Okta, depending on configured provider.
+        if (OKTA_PROVIDER.equalsIgnoreCase(provider)) {
+            return new OktaTokenServices(tokenConverter);
+        }
         return new ForgeRockTokenServices(tokenConverter);
     }
 

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServicesTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServicesTest.java
@@ -21,6 +21,8 @@ import static org.opentestsystem.rdw.ingest.impsvc.auth.SbacTokenConverterTest.t
 import static org.springframework.security.oauth2.common.OAuth2AccessToken.EXPIRES_IN;
 
 public class OktaTokenServicesTest {
+    private static final String AccessToken = "abc123";
+
     private OktaJwtHelper jwtHelper;
     private AccessTokenVerifier jwtVerifier;
     private Jwt jwt;
@@ -35,7 +37,8 @@ public class OktaTokenServicesTest {
         jwt = mock(Jwt.class);
 
         when(jwtHelper.getJwtVerifier()).thenReturn(jwtVerifier);
-        when(jwtVerifier.decode(anyString())).thenReturn(jwt);
+        when(jwtVerifier.decode(AccessToken)).thenReturn(jwt);
+        when(jwt.getClaims()).thenReturn(oktaPasswordGrantTokenMap(AccessToken));
 
         services = new OktaTokenServices(testConverter());
         services.setJwtHelper(jwtHelper);
@@ -43,41 +46,31 @@ public class OktaTokenServicesTest {
 
     @Test
     public void itShouldLoadAuthentication() {
-        final String accessToken = "abc123";
-
-        when(jwt.getClaims()).thenReturn(oktaPasswordGrantTokenMap(accessToken));
-
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
     }
 
     @Test
     public void itShouldCacheAuthentication() throws Exception {
-        final String accessToken = "abc123";
-
-        when(jwt.getClaims()).thenReturn(oktaPasswordGrantTokenMap(accessToken));
-
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
 
         verify(jwtVerifier, times(1)).decode(anyString());
     }
 
     @Test
     public void itShouldInvalidateBasedOnExpiresInValue() throws Exception {
-        final String accessToken = "abc123";
-
-        final Map<String, Object> map = oktaPasswordGrantTokenMap(accessToken);
+        final Map<String, Object> map = oktaPasswordGrantTokenMap(AccessToken);
         map.put(EXPIRES_IN, 1);
         when(jwt.getClaims()).thenReturn(map);
 
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
 
         verify(jwtVerifier, times(1)).decode(anyString());
 
         sleep(1200);
-        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(AccessToken));
 
         verify(jwtVerifier, times(2)).decode(anyString());
     }
@@ -100,7 +93,7 @@ public class OktaTokenServicesTest {
 
     @Test(expected = InvalidTokenException.class)
     public void itShouldPropagateCheckedException() throws Exception {
-        when(jwtVerifier.decode(anyString())).thenThrow(JwtVerificationException.class);
-        services.loadAuthentication("abc123");
+        when(jwtVerifier.decode(AccessToken)).thenThrow(JwtVerificationException.class);
+        services.loadAuthentication(AccessToken);
     }
 }

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServicesTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/impsvc/auth/OktaTokenServicesTest.java
@@ -1,0 +1,106 @@
+package org.opentestsystem.rdw.ingest.impsvc.auth;
+
+import com.okta.jwt.AccessTokenVerifier;
+import com.okta.jwt.Jwt;
+import com.okta.jwt.JwtVerificationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+
+import java.util.Map;
+
+import static java.lang.Thread.sleep;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.ingest.impsvc.auth.SbacTokenConverterTest.assertPasswordGrantAuth;
+import static org.opentestsystem.rdw.ingest.impsvc.auth.SbacTokenConverterTest.oktaPasswordGrantTokenMap;
+import static org.opentestsystem.rdw.ingest.impsvc.auth.SbacTokenConverterTest.testConverter;
+import static org.springframework.security.oauth2.common.OAuth2AccessToken.EXPIRES_IN;
+
+public class OktaTokenServicesTest {
+    private OktaJwtHelper jwtHelper;
+    private AccessTokenVerifier jwtVerifier;
+    private Jwt jwt;
+
+    // Class under test
+    private OktaTokenServices services;
+
+    @Before
+    public void createServices() throws Exception {
+        jwtHelper = mock(OktaJwtHelper.class);
+        jwtVerifier = mock(AccessTokenVerifier.class);
+        jwt = mock(Jwt.class);
+
+        when(jwtHelper.getJwtVerifier()).thenReturn(jwtVerifier);
+        when(jwtVerifier.decode(anyString())).thenReturn(jwt);
+
+        services = new OktaTokenServices(testConverter());
+        services.setJwtHelper(jwtHelper);
+    }
+
+    @Test
+    public void itShouldLoadAuthentication() {
+        final String accessToken = "abc123";
+
+        when(jwt.getClaims()).thenReturn(oktaPasswordGrantTokenMap(accessToken));
+
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+    }
+
+    @Test
+    public void itShouldCacheAuthentication() throws Exception {
+        final String accessToken = "abc123";
+
+        when(jwt.getClaims()).thenReturn(oktaPasswordGrantTokenMap(accessToken));
+
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+
+        verify(jwtVerifier, times(1)).decode(anyString());
+    }
+
+    @Test
+    public void itShouldInvalidateBasedOnExpiresInValue() throws Exception {
+        final String accessToken = "abc123";
+
+        final Map<String, Object> map = oktaPasswordGrantTokenMap(accessToken);
+        map.put(EXPIRES_IN, 1);
+        when(jwt.getClaims()).thenReturn(map);
+
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+
+        verify(jwtVerifier, times(1)).decode(anyString());
+
+        sleep(1200);
+        assertPasswordGrantAuth(services.loadAuthentication(accessToken));
+
+        verify(jwtVerifier, times(2)).decode(anyString());
+    }
+
+    @Test
+    public void itShouldUseConfiguredProperites() {
+        final String url = "http://myserver/tokenInfo";
+        final String audience = "api://test";
+        final Long timeout = 1000L;
+
+        services.setTokenInfoUrl(url);
+        verify(jwtHelper).setIssuer(url);
+
+        services.setAudience(audience);
+        verify(jwtHelper).setAudience(audience);
+
+        services.setConnectionTimeout(timeout);
+        verify(jwtHelper).setConnectionTimeout(timeout);
+    }
+
+    @Test(expected = InvalidTokenException.class)
+    public void itShouldPropagateCheckedException() throws Exception {
+        when(jwtVerifier.decode(anyString())).thenThrow(JwtVerificationException.class);
+        services.loadAuthentication("abc123");
+    }
+}

--- a/import-service/src/test/java/org/opentestsystem/rdw/ingest/impsvc/auth/SbacTokenConverterTest.java
+++ b/import-service/src/test/java/org/opentestsystem/rdw/ingest/impsvc/auth/SbacTokenConverterTest.java
@@ -93,6 +93,18 @@ public class SbacTokenConverterTest {
         return map;
     }
 
+    // typical set of Okta claims from getting token info for a password grant token
+    static Map<String, Object> oktaPasswordGrantTokenMap(final String access_token) {
+        final Map<String, Object> map = newHashMap();
+        map.put("sbacUUID", "57e3ed3de4b0e3b75702f3a0");
+        map.put("mail", "dwtest@example.com");
+        map.put("sbacTenancyChain", Collections.singletonList("|CA|ASMTDATALOAD|STATE|98765|CA98765|||CA|CALIFORNIA|||||||||"));
+        map.put("token_type", "Bearer");
+        map.put("exp", (int)((System.currentTimeMillis() / 1000) + 34479));
+        map.put(ACCESS_TOKEN, access_token);
+        return map;
+    }
+
     // asserts values from map
     static void assertPasswordGrantAuth(final OAuth2Authentication oauth2) {
         final Authentication authentication = oauth2.getUserAuthentication();


### PR DESCRIPTION
Enables validating Okta access tokens based on configuration, while still supporting OpenAM during transition period. Per Jeff Khoury, integration to ART will still use OpenAM for the forseeable future.