### PR TITLE
add check that assessment names are not duplicated across subjects

### DIFF
--- a/validator/src/main/java/org/opentestsystem/rdw/ingest/validator/service/AssessmentChecker.java
+++ b/validator/src/main/java/org/opentestsystem/rdw/ingest/validator/service/AssessmentChecker.java
@@ -3,7 +3,6 @@ package org.opentestsystem.rdw.ingest.validator.service;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.opentestsystem.rdw.common.model.AssessmentType;
 import org.opentestsystem.rdw.common.model.assessment.Assessment;
 import org.opentestsystem.rdw.common.model.assessment.Scoring;
@@ -12,7 +11,9 @@ import org.opentestsystem.rdw.common.model.subject.SubjectAssessmentType;
 
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Helper to partition logic for checking assessments.
@@ -31,34 +32,47 @@ class AssessmentChecker {
                                  final List<Subject> subjects) {
 
         // if the assessments came from multiple files there could be duplicate ids (which is bad)
-        for (final String id : assessments.stream()
+        assessments.stream()
             .collect(groupingBy(Assessment::getId, counting()))
-            .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey).collect(Collectors.toList())) {
-            messageSink.error("duplicate assessment id {0}", id);
-        }
+            .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey)
+            .forEach(id ->
+                messageSink.error("duplicate assessment id {0}", id)
+            );
 
         // duplicate labels within a single year may be confusing to users
-        for (final String key : assessments.stream()
+        assessments.stream()
             .collect(groupingBy(a -> String.join("/", a.getLabel(), ""+a.getSchoolYear()), counting()))
-            .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey).collect(Collectors.toList())) {
-            messageSink.warning("duplicate assessment label/year {0} may be confusing for users", key);
-        }
+            .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey)
+            .forEach(key ->
+                messageSink.warning("duplicate assessment label/year {0} may be confusing for users", key)
+            );
+
+        // duplicate names across subjects are probably wrong and have adverse affects in the system
+        // (this was the instructional resource problem when Math and ELA had assessments with the same name)
+        assessments.stream()
+            .collect(groupingBy(Assessment::getName, mapping(Assessment::getSubject, toSet())))
+            .entrySet().stream().filter(entry -> entry.getValue().size() > 1)
+            .forEach(entry ->
+                messageSink.error("duplicate assessment name {0} across subjects {1}", entry.getKey(), entry.getValue().toString())
+            );
 
         // there should be a single summative per subject per grade per school year
-        for (final String key : assessments.stream()
-                .filter(a -> AssessmentType.SUMMATIVE.equals(a.getType()))
-                .collect(groupingBy(a -> String.join("-", a.getSubject(), a.getGrade(), ""+a.getSchoolYear()), counting()))
-                .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey).collect(Collectors.toList())) {
-            messageSink.error("multiple summatives found for {0}", key);
-        }
+        assessments.stream()
+            .filter(a -> AssessmentType.SUMMATIVE.equals(a.getType()))
+            .collect(groupingBy(a -> String.join("-", a.getSubject(), a.getGrade(), ""+a.getSchoolYear()), counting()))
+            .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey)
+            .forEach(key ->
+                messageSink.error("multiple summatives found for {0}", key)
+            );
 
         // there should be a single ICA per subject per grade per school year
-        for (final String key : assessments.stream()
-                .filter(a -> AssessmentType.ICA.equals(a.getType()))
-                .collect(groupingBy(a -> String.join("-", a.getSubject(), a.getGrade(), ""+a.getSchoolYear()), counting()))
-                .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey).collect(Collectors.toList())) {
-            messageSink.error("multiple ICAs found for {0}", key);
-        }
+        assessments.stream()
+            .filter(a -> AssessmentType.ICA.equals(a.getType()))
+            .collect(groupingBy(a -> String.join("-", a.getSubject(), a.getGrade(), ""+a.getSchoolYear()), counting()))
+            .entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey)
+            .forEach(key ->
+                messageSink.error("multiple ICAs found for {0}", key)
+            );
 
         // to facilitate looking them up case insensitively
         final Map<String, Subject> subjectMap = subjects.stream().collect(toMap(s -> s.getCode().toUpperCase(), s -> s));

--- a/validator/src/test/java/org/opentestsystem/rdw/ingest/validator/service/AssessmentCheckerTest.java
+++ b/validator/src/test/java/org/opentestsystem/rdw/ingest/validator/service/AssessmentCheckerTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.opentestsystem.rdw.common.model.assessment.Assessment;
 import org.opentestsystem.rdw.common.model.assessment.AssessmentSerializationService;
-import org.opentestsystem.rdw.common.model.assessment.TabulatorService;
 import org.opentestsystem.rdw.common.model.subject.Subject;
 import org.opentestsystem.rdw.common.model.subject.SubjectSerializationService;
 import org.opentestsystem.rdw.ingest.validator.ApplicationConfiguration;
@@ -53,6 +52,14 @@ public class AssessmentCheckerTest {
                 "Warning: duplicate assessment label/year GEO Grade 8/2018 may be confusing for users",
                 "Error: multiple summatives found for GEO-08-2018",
                 "Error: multiple ICAs found for GEO-08-2018"
+        );
+    }
+
+    @Test
+    public void itShouldCheckForDuplicateNamesAcrossSubjects() {
+        checkAssessmentResource("assessments.dup-name.csv", null);
+        assertThat(messageCollector.getMessages()).contains(
+                "Error: duplicate assessment name GEO-ASMT across subjects [GEO, HIST]"
         );
     }
 

--- a/validator/src/test/resources/assessments.dup-name.csv
+++ b/validator/src/test/resources/assessments.dup-name.csv
@@ -1,0 +1,4 @@
+AssessmentId,AssessmentName,AssessmentSubject,AssessmentGrade,AssessmentType,AssessmentSubtype,AssessmentLabel,AssessmentVersion,AcademicYear,ScaledLow1,ScaledHigh1,ScaledLow2,ScaledHigh2,ScaledLow3,ScaledHigh3,ScaledLow4,ScaledHigh4
+GEO-GRADE-07-2018,GEO-ASMT,GEO,07,summative,SUM,GEO Grade 7, 112,2018,1150,1480,1481,1526,1527,1575,1576,1900
+GEO-GRADE-08-2018,GEO-ASMT,GEO,08,summative,SUM,GEO Grade 8, 112,2018,1150,1485,1486,1533,1534,1589,1590,1900
+HIST-GRADE-08-2018,GEO-ASMT,HIST,08,summative,SUM,HIST Grade 8, 112,2018,1150,1485,1486,1533,1534,1589,1590,1900


### PR DESCRIPTION
This adds a validation that the assessment name, e.g. "SBAC-IAB-G8E-Perf-Fubar", is not duplicate across subjects. It is allowed and expected to be duplicated within a subject since the name indicates a year-over-year continuity for IABs. 