### PR TITLE
Pinned common lib to latest version, fixed tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ idea {
 project.ext.apps = subprojects.findAll { !'lib'.equalsIgnoreCase(it.findProperty('moduleType') as String) }
 
 // Set version dependencies. This allows the cli to force version, e.g. `-Pcommon=2.4.0-SNAPSHOT`
-String rdwCommonVersion = project.hasProperty('common') ? project.property('common') : '2.4.0-20'
+String rdwCommonVersion = project.hasProperty('common') ? project.property('common') : '2.4.0-23'
 String rdwSchemaVersion = project.hasProperty('schema') ? project.property('schema') : '2.4.0-20'
 String dockerPrefix = 'smarterbalanced'
 

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
@@ -163,26 +163,6 @@ public class DefaultTDSReportProcessorIT {
         assertThat(countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(beforeStudentEthnicityCount);
     }
 
-
-    @Test
-    public void itShouldReturnErrorsMissingOpportunityElements() {
-        final int beforeStudentCount = countRowsInTable(jdbcTemplate, "student");
-        final int beforeStudentEthnicityCount = countRowsInTable(jdbcTemplate, "student_ethnicity");
-        try {
-            final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/NULL-fields.xml"));
-            processor.process(tdsReport, importId);
-            fail("it should fail");
-        } catch (final ImportException ex) {
-            assertThat(ex.getMessage()).isEqualTo("{\"messages\":[" +
-                    "{\"elementName\":\"IDEAIndicator\",\"error\":\"invalid value [null]\"}," +
-                    "{\"elementName\":\"EconomicDisadvantageStatus\",\"error\":\"invalid value [null]\"}" +
-                    //note that it does not error on Completeness and Administration conditions since they have hardcoded defaults
-                    "]}");
-        }
-        assertThat(countRowsInTable(jdbcTemplate, "student")).isEqualTo(beforeStudentCount);
-        assertThat(countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(beforeStudentEthnicityCount);
-    }
-
     @Test
     public void itShouldHandleLargeItemResponses() {
         // this sample has an item response >64k; before the fix it would throw a data violation exception

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorWithOptionalDataIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorWithOptionalDataIT.java
@@ -9,7 +9,6 @@ import org.opentestsystem.rdw.ingest.common.test.CachingTest;
 import org.opentestsystem.rdw.ingest.processor.ExamProcessorApplication;
 import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -19,6 +18,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.rmi.UnmarshalException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.jdbc.JdbcTestUtils.countRowsInTable;
@@ -47,17 +48,9 @@ public class DefaultTDSReportProcessorWithOptionalDataIT {
         TenantContextHolder.setTenantId("CA");
     }
 
-    @Test
+    @Test(expected = RuntimeException.class)
     public void test() {
-
-        final int beforeStudentCount = countRowsInTable(jdbcTemplate, "student");
-        final int beforeIabExamCount = countRowsInTableWhere(jdbcTemplate, "exam", "type_id = 2 and completeness_id is null and administration_condition_id is null and session_id is null");
-
+        // Change to TRT validation in 9/2020 means the NULL fields TRT will no longer be ingested
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/NULL-fields.xml"));
-        processor.process(tdsReport, importId);
-
-        assertThat(countRowsInTable(jdbcTemplate, "student")).isEqualTo(beforeStudentCount + 1);
-        assertThat(countRowsInTableWhere(jdbcTemplate, "exam", "type_id = 2 and completeness_id is null and administration_condition_id is null and session_id is null"))
-                .isEqualTo(beforeIabExamCount + 1);
     }
 }

--- a/exam-processor/src/test/resources/Custom_Subject_ICA.xml
+++ b/exam-processor/src/test/resources/Custom_Subject_ICA.xml
@@ -73,7 +73,7 @@
                reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T18:25:13.487"
                assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-12" itemCount="36"
                pauseCount="0"
-               completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T18:25:13.487" administrationCondition="" startDate="2016-10-12T18:14:21.101" oppId="5000015" opportunity="1"
+               completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T18:25:13.487" administrationCondition="SD" startDate="2016-10-12T18:14:21.101" oppId="5000015" opportunity="1"
                gracePeriodRestarts="0">
     <Segment id="(SBAC)SBAC-ICA-FIXED-G4M-COMBINED-MATH-4-Winter-2016-2017" position="1" formId="Math ICA G4 2017 ENG COMBINED" formKey="200-18787" algorithm="fixedform" algorithmVersion="0"/>
     <Segment id="(SBAC)SBAC-ICA-FIXED-G4M-Perf-AnimalJumping-COMBINED-MATH-4-Winter-2016-2017" position="2" formId="Math ICA Perf G4 AnimalJumping 2017 ENG COMBINED" formKey="200-18848" algorithm="fixedform" algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/ICA-score-test.xml
+++ b/exam-processor/src/test/resources/ICA-score-test.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="5b63d7f5-e783-411a-9a15-f1753542f523" taId="jtreuting@fairwaytech.com" taName="Jeff Treuting" sessionId="Tre-7" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T18:25:13.487"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-12" itemCount="36" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T18:25:13.487" administrationCondition="" startDate="2016-10-12T18:14:21.101" oppId="5000015" opportunity="1" gracePeriodRestarts="0">
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T18:25:13.487" administrationCondition="SD" startDate="2016-10-12T18:14:21.101" oppId="5000015" opportunity="1" gracePeriodRestarts="0">
         <Segment id="(SBAC)SBAC-ICA-FIXED-G4M-COMBINED-MATH-4-Winter-2016-2017" position="1" formId="Math ICA G4 2017 ENG COMBINED" formKey="200-18787" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G4M-Perf-AnimalJumping-COMBINED-MATH-4-Winter-2016-2017" position="2" formId="Math ICA Perf G4 AnimalJumping 2017 ENG COMBINED" formKey="200-18848" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/SBAC-IAB-FIXED-G4M-G-MATH-4.xml
+++ b/exam-processor/src/test/resources/SBAC-IAB-FIXED-G4M-G-MATH-4.xml
@@ -76,7 +76,7 @@
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                  itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete"
-                 statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100150"
+                 statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100150"
                  windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/SBAC-IAB-FIXED-G6E-LangVocab-ELA-6.xml
+++ b/exam-processor/src/test/resources/SBAC-IAB-FIXED-G6E-LangVocab-ELA-6.xml
@@ -74,7 +74,7 @@
     <Opportunity database="session" key="4f523c9c-38dd-4631-86d4-ea395f4394e7" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="Lab-32" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-13T02:35:56.863"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" itemCount="15" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:35:56.863" administrationCondition="" startDate="2016-10-13T02:34:58.036" oppId="100156" windowOpportunity="1" opportunity="1"
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:35:56.863" administrationCondition="SD" startDate="2016-10-13T02:34:58.036" oppId="100156" windowOpportunity="1" opportunity="1"
                  gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G6E-LangVocab-ELA-6-Winter-2016-2017" position="1" formId="IAB-G6E-LangVocab-2017 ENG" formKey="200-18624" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/SBAC-IAB-FIXED-G6E-ReadLit-ELA-6.xml
+++ b/exam-processor/src/test/resources/SBAC-IAB-FIXED-G6E-ReadLit-ELA-6.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="5ba80509-8638-4d39-8cd4-a2bad9b936a5" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="Lab-32" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-13T02:24:58.828"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" itemCount="15" pauseCount="0"
-                 completeStatus="Complete" status="scored" completeness="Complete" statusDate="2016-10-13T02:24:58.828" administrationCondition="" startDate="2016-10-13T02:23:56.791" oppId="100153" windowOpportunity="1" opportunity="1"
+                 completeStatus="Complete" status="scored" completeness="Complete" statusDate="2016-10-13T02:24:58.828" administrationCondition="SD" startDate="2016-10-13T02:23:56.791" oppId="100153" windowOpportunity="1" opportunity="1"
                  gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G6E-ReadLit-ELA-6-Winter-2016-2017" position="1" formId="IAB-G6E-ReadLit-2017 ENG" formKey="200-18566" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/SBAC-IAB-FIXED-G6M-EE.xml
+++ b/exam-processor/src/test/resources/SBAC-IAB-FIXED-G6M-EE.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="0fa3310d-d9b3-42f1-a5a5-c6b88ca0993c" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="Lab-31" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T23:59:17.693"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" itemCount="16" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T23:59:17.693" administrationCondition="" startDate="2016-10-12T23:56:54.173" oppId="100150" windowOpportunity="1" opportunity="1"
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T23:59:17.693" administrationCondition="SD" startDate="2016-10-12T23:56:54.173" oppId="100150" windowOpportunity="1" opportunity="1"
                  gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G6M-EE-NoCalc-MATH-6-Winter-2016-2017" position="1" formId="IAB-G6M-EE-NoCalc-2017 ENG" formKey="200-18691" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-IAB-FIXED-G6M-EE-Calc-MATH-6-Winter-2016-2017" position="2" formId="IAB-G6M-EE-Calc-2017 ENG" formKey="200-18688" algorithm="fixedform" algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/SBAC-ICA-FIXED-G4M-COMBINED-2017.xml
+++ b/exam-processor/src/test/resources/SBAC-ICA-FIXED-G4M-COMBINED-2017.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="5b63d7f5-e783-411a-9a15-f1753542f523" taId="jtreuting@fairwaytech.com" taName="Jeff Treuting" sessionId="Tre-7" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T18:25:13.487"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-12" itemCount="36" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T18:25:13.487" administrationCondition="" startDate="2016-10-12T18:14:21.101" oppId="5000015" opportunity="1" gracePeriodRestarts="0">
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T18:25:13.487" administrationCondition="SD" startDate="2016-10-12T18:14:21.101" oppId="5000015" opportunity="1" gracePeriodRestarts="0">
         <Segment id="(SBAC)SBAC-ICA-FIXED-G4M-COMBINED-MATH-4-Winter-2016-2017" position="1" formId="Math ICA G4 2017 ENG COMBINED" formKey="200-18787" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G4M-Perf-AnimalJumping-COMBINED-MATH-4-Winter-2016-2017" position="2" formId="Math ICA Perf G4 AnimalJumping 2017 ENG COMBINED" formKey="200-18848" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/SBAC-ICA-FIXED-G6E-COMBINED-2017.xml
+++ b/exam-processor/src/test/resources/SBAC-ICA-FIXED-G6E-COMBINED-2017.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="cd3f30b2-b631-4801-9472-3beaad0f1fb9" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="Lab-32" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-13T02:32:24.972"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-13" itemCount="48" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:32:24.972" administrationCondition="" startDate="2016-10-13T02:25:49.066" oppId="5000021" opportunity="1" gracePeriodRestarts="0">
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:32:24.972" administrationCondition="SD" startDate="2016-10-13T02:25:49.066" oppId="5000021" opportunity="1" gracePeriodRestarts="0">
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-COMBINED-ELA-6-Winter-2016-2017" position="1" formId="ELA ICA G6 2017 ENG COMBINED" formKey="200-18836" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-Perf-ImportofNutriA-COMBINED-ELA-6-Winter-2016-2017" position="2" formId="ELA ICA Perf G6a 2017 ENG COMBINED" formKey="200-18878" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-Perf-ImportofNutriB-COMBINED-ELA-6-Winter-2016-2017" position="3" formId="ELA ICA Perf G6b 2017 ENG COMBINED" formKey="200-18880" algorithm="fixedform" algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/SBAC-ICA-FIXED-G6M-COMBINED-2017.xml
+++ b/exam-processor/src/test/resources/SBAC-ICA-FIXED-G6M-COMBINED-2017.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="5c697ed7-b3f8-49e1-be21-7e7d80eefa81" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="Lab-31" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-13T00:05:20.194"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-12" itemCount="36" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T00:05:20.194" administrationCondition="" startDate="2016-10-12T23:59:58.037" oppId="5000017" opportunity="1" gracePeriodRestarts="0">
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T00:05:20.194" administrationCondition="SD" startDate="2016-10-12T23:59:58.037" oppId="5000017" opportunity="1" gracePeriodRestarts="0">
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6M-NoCalc-COMBINED-MATH-6-Winter-2016-2017" position="1" formId="Math ICA G6 No Calc 2017 ENG COMBINED" formKey="200-18794" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6M-Calc-COMBINED-MATH-6-Winter-2016-2017" position="2" formId="Math ICA G6 Calc 2017 ENG COMBINED" formKey="200-18799" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6M-Perf-CellPhonePlan-COMBINED-MATH-6-Winter-2016-2017" position="3" formId="Math ICA Perf G6 CellPhonePlan 2017 ENG COMBINED" formKey="200-18854" algorithm="fixedform" algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.2018_AIR_empty_examinee.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.2018_AIR_empty_examinee.xml
@@ -5,7 +5,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.2018_AIR_format.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.2018_AIR_format.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.basic.errors.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.basic.errors.xml
@@ -45,7 +45,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.emptyDataElements.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.emptyDataElements.xml
@@ -45,7 +45,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.largeitem.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.largeitem.xml
@@ -72,7 +72,7 @@
                reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete"
-               statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100149"
+               statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100149"
                windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
     <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
     <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.longdata.basic.error.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.longdata.basic.error.xml
@@ -51,7 +51,7 @@
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                  itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete"
-                 statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100149"
+                 statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100149"
                  windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.noElement.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.noElement.xml
@@ -17,7 +17,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.noStudentElement.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.noStudentElement.xml
@@ -38,7 +38,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.iab.sample.xml
+++ b/exam-processor/src/test/resources/TDSReport.iab.sample.xml
@@ -74,7 +74,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.ica.exam.errors.xml
+++ b/exam-processor/src/test/resources/TDSReport.ica.exam.errors.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="cd3f30b2-b631-4801-9472-3beaad0f1fb9" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted=""
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-13" itemCount="48" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:32:24.972" administrationCondition="" startDate="2016-10-13T02:25:49.066" oppId="5000018" opportunity="1" gracePeriodRestarts="0">
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:32:24.972" administrationCondition="SD" startDate="2016-10-13T02:25:49.066" oppId="5000018" opportunity="1" gracePeriodRestarts="0">
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-COMBINED-ELA-6-Winter-2016-2017" position="1" formId="ELA ICA G6 2017 ENG COMBINED" formKey="200-18836" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-Perf-ImportofNutriA-COMBINED-ELA-6-Winter-2016-2017" position="2" formId="ELA ICA Perf G6a 2017 ENG COMBINED" formKey="200-18878" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-Perf-ImportofNutriB-COMBINED-ELA-6-Winter-2016-2017" position="3" formId="ELA ICA Perf G6b 2017 ENG COMBINED" formKey="200-18880" algorithm="fixedform" algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.ica.sample.xml
+++ b/exam-processor/src/test/resources/TDSReport.ica.sample.xml
@@ -72,7 +72,7 @@
     <Opportunity database="session" key="cd3f30b2-b631-4801-9472-3beaad0f1fb9" taId="uat_lab20@mailinator.com" taName="UAT Lab20" sessionId="Lab-32" windowId="ANNUAL" server="ip-172-19-0-179" qaLevel="" clientName="SBAC"
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-13T02:32:24.972"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36" effectiveDate="2016-10-13" itemCount="48" pauseCount="0"
-                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:32:24.972" administrationCondition="" startDate="2016-10-13T02:25:49.066" oppId="5000018" opportunity="1" gracePeriodRestarts="0">
+                 completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-13T02:32:24.972" administrationCondition="SD" startDate="2016-10-13T02:25:49.066" oppId="5000018" opportunity="1" gracePeriodRestarts="0">
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-COMBINED-ELA-6-Winter-2016-2017" position="1" formId="ELA ICA G6 2017 ENG COMBINED" formKey="200-18836" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-Perf-ImportofNutriA-COMBINED-ELA-6-Winter-2016-2017" position="2" formId="ELA ICA Perf G6a 2017 ENG COMBINED" formKey="200-18878" algorithm="fixedform" algorithmVersion="0"/>
         <Segment id="(SBAC)SBAC-ICA-FIXED-G6E-Perf-ImportofNutriB-COMBINED-ELA-6-Winter-2016-2017" position="3" formId="ELA ICA Perf G6b 2017 ENG COMBINED" formKey="200-18880" algorithm="fixedform" algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/TDSReport.no-examinee.xml
+++ b/exam-processor/src/test/resources/TDSReport.no-examinee.xml
@@ -4,7 +4,7 @@
     <Opportunity database="session" key="41345bd8-0b4b-43d3-8de5-0c281582e12d" taId="uat_lab15@mailinator.com" taName="UAT Lab15" sessionId="Lab-30" windowId="ANNUAL"
                  server="ip-172-19-0-179" qaLevel="" clientName="SBAC" reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
-                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition=""
+                 itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete" statusDate="2016-10-12T22:00:49.658" administrationCondition="SD"
                  startDate="2016-10-12T21:52:34.065" oppId="100149" windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform"
                  algorithmVersion="0"/>

--- a/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4-delete.xml
+++ b/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4-delete.xml
@@ -76,7 +76,7 @@
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                  itemCount="11" pauseCount="0" completeStatus="Complete" status="reset" completeness="Complete"
-                 statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100150"
+                 statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100150"
                  windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4-new-oppId-and-date.xml
+++ b/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4-new-oppId-and-date.xml
@@ -76,7 +76,7 @@
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-12-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                  itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete"
-                 statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100155"
+                 statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100155"
                  windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4.update.student.xml
+++ b/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4.update.student.xml
@@ -76,7 +76,7 @@
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                  itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete"
-                 statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100150"
+                 statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100150"
                  windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>

--- a/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4.xml
+++ b/exam-processor/src/test/resources/inferSchool/SBAC-IAB-FIXED-G4M-G-MATH-4.xml
@@ -76,7 +76,7 @@
                  reportingVersion="0" abnormalStarts="0" ftCount="0" dateCompleted="2016-10-12T22:00:49.658"
                  assessmentParticipantSessionPlatformUserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"
                  itemCount="11" pauseCount="0" completeStatus="Complete" status="completed" completeness="Complete"
-                 statusDate="2016-10-12T22:00:49.658" administrationCondition="" startDate="2016-10-12T21:52:34.065" oppId="100150"
+                 statusDate="2016-10-12T22:00:49.658" administrationCondition="SD" startDate="2016-10-12T21:52:34.065" oppId="100150"
                  windowOpportunity="1" opportunity="1" gracePeriodRestarts="0" effectiveDate="2016-08-29">
         <Segment id="(SBAC)SBAC-IAB-FIXED-G4M-G-MATH-4-Winter-2016-2017" position="1" formId="IAB-G4M-G-2017 ENG" formKey="200-18740" algorithm="fixedform" algorithmVersion="0"/>
         <Accommodation code="ENU" type="Language" value="English" segment="0"/>


### PR DESCRIPTION
A number of tests were broken by a tightening of the schema for TRT XMLs, which was done as a hotfix in Tier 3 support and merged into development. Most of the fixes were just updating the sample TRTs used as test inputs to be compliant with the new schema. In a few cases, the tests themselves had to be updated to conform with the new behavior.