### PR TITLE
Hotfix/2.3.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 ## Change Log
 
 #### 2.3.1 - 2020-09-24
-* SRS-199: Fix problem with TRT not picking up the overridden ingest validation value 
-
-#### 2.2.0 -
-
+* SRS-199: TRT ingest validation problem 
+  * Fix problem with TRT not picking up the overridden ingest validation value 
+  * modify the logic to combine exam and student validation errors
 #### 2.1.0 - 2019-09-18
 
 No real code changes but some "nearby" fixes for this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Change Log
 
 #### 2.3.1 - 2020-09-24
+
 * SRS-199: TRT ingest validation problem 
   * Fix problem with TRT not picking up the overridden ingest validation value 
   * modify the logic to combine exam and student validation errors
+
 #### 2.1.0 - 2019-09-18
 
 No real code changes but some "nearby" fixes for this release:

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/ExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/ExamineeProcessor.java
@@ -5,6 +5,7 @@ import org.opentestsystem.rdw.common.model.trt.Examinee;
 import org.opentestsystem.rdw.ingest.common.model.District;
 import org.opentestsystem.rdw.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.model.School;
+import org.opentestsystem.rdw.ingest.processor.model.Exam;
 import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.processor.model.Student;
 import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
@@ -19,11 +20,12 @@ public interface ExamineeProcessor {
      * Parses {@link Student} and group membership
      *
      * @param examinee   the {@link Examinee} to be parsed
-     * @param schoolYear the school year
+     * @param exam       the exam containing school year
      * @param schoolId   the id of the school
+     * @param errorCollector the {@link DataElementErrorCollector} to store any parsing/validation error
      * @throws ImportException
      */
-    Student parseStudent(Examinee examinee, int schoolYear, int schoolId) throws ImportException;
+    Student parseStudent(Examinee examinee, Exam exam, int schoolId, DataElementErrorCollector errorCollector) throws ImportException;
 
     /**
      * Parses {@link StudentExamAttributes}.

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/StudentExamProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/StudentExamProcessor.java
@@ -6,6 +6,7 @@ import org.opentestsystem.rdw.common.model.trt.Test;
 import org.opentestsystem.rdw.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.processor.model.Assessment;
 import org.opentestsystem.rdw.ingest.processor.model.Exam;
+import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 
 /**
  * An interface responsible for parsing and validating an exam related data
@@ -18,7 +19,9 @@ public interface StudentExamProcessor {
      * @param report     the {@link Test}
      * @param schoolId   the school id
      * @param assessment the {@link Assessment} that defines the given test
+     * @param errorCollector the {@link DataElementErrorCollector} to store any parsing/validation error
      * @throws ImportException in case of the parsing or validation error
      */
-    Exam parseExam(TDSReport report, int schoolId, Assessment assessment) throws ImportException;
+    Exam parseExam(TDSReport report, int schoolId, Assessment assessment, DataElementErrorCollector errorCollector
+) throws ImportException;
 }

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
@@ -1,8 +1,10 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
+import org.opentestsystem.rdw.ingest.processor.model.Exam;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Year;
 import java.util.List;
 import java.util.Set;
 import org.opentestsystem.rdw.common.model.ImportStatus;
@@ -13,7 +15,6 @@ import org.opentestsystem.rdw.ingest.common.repository.LanguageRepository;
 import org.opentestsystem.rdw.utils.DataElementError;
 import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.processor.config.DataElementsConfiguration;
-import org.opentestsystem.rdw.ingest.processor.model.ConfigurableDataElement;
 import org.opentestsystem.rdw.ingest.processor.model.Student;
 import org.opentestsystem.rdw.ingest.processor.model.StudentExamAttributes;
 import org.opentestsystem.rdw.ingest.processor.model.StudentGroup;
@@ -103,11 +104,12 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
     }
 
     @Override
-    public Student parseStudent(final Examinee examinee, final int schoolYear, final int schoolId) throws ImportException {
-        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
-        final ExamParserHelper parserHelper = new ExamParserHelper(errorCollector, optionalDataElements.getOptionalDataElements());
+    public Student parseStudent(final Examinee examinee, final Exam exam, final int schoolId, DataElementErrorCollector examErrorCollector) throws ImportException {
+        final ExamParserHelper parserHelper = new ExamParserHelper(examErrorCollector, optionalDataElements.getOptionalDataElements());
+        DataElementErrorCollector studentExamErrorCollector = parserHelper.getElementErrorCollector();
         if (examinee.getIsDemo()) {
-            errorCollector.add(new DataElementError("isDemo", "true", "demo students are not supported"));
+            studentExamErrorCollector
+                    .add(new DataElementError("isDemo", "true", "demo students are not supported"));
         }
 
         final Student.Builder studentBuilder = Student.builder()
@@ -123,11 +125,11 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
                 .lepExitAt(parserHelper.validate(LEPExitDate, getBestAttributeValue(examinee, LEPExitDate), toLocalDate))
                 // each individual ethnicity value is validated by the ethnicity service,
                 // but a validation of at least one ethnicity being required is done here
-                .ethnicityIds(parserHelper.isNotEmpty(Ethnicity, ethnicityService.getEthnicity(examinee, errorCollector)))
-                .groups(parseGroups(examinee, schoolYear, schoolId, parserHelper));
+                .ethnicityIds(parserHelper.isNotEmpty(Ethnicity, ethnicityService.getEthnicity(examinee, studentExamErrorCollector)))
+                .groups(parseGroups(examinee, exam, schoolId, parserHelper));
 
-        if (errorCollector.isEmpty()) return studentBuilder.build();
-        throw new ImportException(ImportStatus.BAD_DATA, errorCollector.toJson());
+        if (studentExamErrorCollector.isEmpty()) return studentBuilder.build();
+        throw new ImportException(ImportStatus.BAD_DATA, studentExamErrorCollector.toJson());
     }
 
     @Override
@@ -153,10 +155,15 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         return errorCollector.isEmpty() ? builder.build() : null;
     }
 
-    private List<StudentGroup> parseGroups(final Examinee examinee, final int schoolYear, final int schoolId, final ExamParserHelper parserHelper) {
+    private List<StudentGroup> parseGroups(final Examinee examinee, final Exam exam, final int schoolId, final ExamParserHelper parserHelper) {
         // deal with student groups: create groups if they don't already exist then add student to them
         final List<StudentGroup> groups = newArrayList();
         final Set<String> groupNames = getBestGroupNames(examinee);
+        // if the exam object is not null meaning that the validation for exam
+        // passed.if the exam is null that means there are exam validation
+        // failures, to be able to continue with the validation for StudentGroupName
+        // set a dummy year, an exception will be thrown on the parent method
+        int schoolYear = exam != null ? exam.getSchoolYear() : Year.now().getValue();
         if (!groupNames.isEmpty()) {
             for (final String groupName : groupNames) {
                 groups.add(StudentGroup.builder()

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessor.java
@@ -106,7 +106,7 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
     @Override
     public Student parseStudent(final Examinee examinee, final Exam exam, final int schoolId, DataElementErrorCollector examErrorCollector) throws ImportException {
         final ExamParserHelper parserHelper = new ExamParserHelper(examErrorCollector, optionalDataElements.getOptionalDataElements());
-        DataElementErrorCollector studentExamErrorCollector = parserHelper.getElementErrorCollector();
+        final DataElementErrorCollector studentExamErrorCollector = parserHelper.getElementErrorCollector();
         if (examinee.getIsDemo()) {
             studentExamErrorCollector
                     .add(new DataElementError("isDemo", "true", "demo students are not supported"));
@@ -163,7 +163,7 @@ class DefaultExamineeProcessor implements ExamineeProcessor {
         // passed.if the exam is null that means there are exam validation
         // failures, to be able to continue with the validation for StudentGroupName
         // set a dummy year, an exception will be thrown on the parent method
-        int schoolYear = exam != null ? exam.getSchoolYear() : Year.now().getValue();
+        final int schoolYear = exam != null ? exam.getSchoolYear() : Year.now().getValue();
         if (!groupNames.isEmpty()) {
             for (final String groupName : groupNames) {
                 groups.add(StudentGroup.builder()

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessor.java
@@ -86,18 +86,17 @@ class DefaultStudentExamProcessor implements StudentExamProcessor {
     }
 
     @Override
-    public Exam parseExam(final TDSReport report, final int schoolId, final Assessment assessment) throws ImportException {
-        final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+    public Exam parseExam(final TDSReport report, final int schoolId, final Assessment assessment,DataElementErrorCollector examErrorCollector ) throws ImportException {
 
-        final ExamParserHelper parserHelper = new ExamParserHelper(errorCollector, optionalDataElements.getOptionalDataElements());
+        final ExamParserHelper parserHelper = new ExamParserHelper(examErrorCollector, optionalDataElements.getOptionalDataElements());
 
         final Test test = report.getTest();
         final Opportunity opportunity = report.getOpportunity();
 
-        final Exam.Builder builder = parseScoreData(opportunity, assessment, parserHelper, errorCollector)
+        final Exam.Builder builder = parseScoreData(opportunity, assessment, parserHelper, examErrorCollector)
                 .typeId(assessment.getTypeId())
-                .examItems(parserHelper.isNotEmpty(ExamItems, examItemProcessor.parseExamItems(opportunity.getItem(), assessment, errorCollector)))
-                .studentExamAttributes(examineeProcessor.parseStudentExamAttributes(report.getExaminee(), schoolId, errorCollector))
+                .examItems(parserHelper.isNotEmpty(ExamItems, examItemProcessor.parseExamItems(opportunity.getItem(), assessment, examErrorCollector)))
+                .studentExamAttributes(examineeProcessor.parseStudentExamAttributes(report.getExaminee(), schoolId, examErrorCollector))
                 .schoolYear(parserHelper.validate("Test AcademicYear", test.getAcademicYear(), toYear))
                 .assessmentId(assessment.getId())
                 .asmtVersion(parserHelper.validate("Test AssessmentVersion", test.getAssessmentVersion(), 30, false))
@@ -131,9 +130,8 @@ class DefaultStudentExamProcessor implements StudentExamProcessor {
                 .testDeliveryServer(opportunity.getServer())
                 .testDeliveryDb(opportunity.getDatabase())
                 .windowOpportunityCount(opportunity.getWindowOpportunity());
-
-        if (errorCollector.isEmpty()) return builder.build();
-        else throw new ImportException(ImportStatus.BAD_DATA, errorCollector.toJson());
+        //modified on 10/2020 to include all error responses
+        return examErrorCollector.isEmpty() ? builder.build() : null;
     }
 
     private Iterable<Integer> parseAccommodations(final List<Accommodation> accommodations) {

--- a/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
+++ b/exam-processor/src/main/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessor.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
+import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -51,9 +52,13 @@ class DefaultTDSReportProcessor implements TDSReportProcessor {
 
             final Assessment assessment = assessmentService.findOneForNaturalId(report.getTest().getName());
             if (assessment == null) throw new IllegalArgumentException("Assessment may not be null");
-
-            final Exam exam = studentExamProcessor.parseExam(report, schoolId, assessment);
-            final Student student = examineeProcessor.parseStudent(examinee, exam.getSchoolYear(), schoolId);
+            // modified the logic to combine exam and student validation errors .the student
+            // validation happens after all the exam attributes has been checked and validated
+            // previously ,the new behavior is to check all the trt attributes and return errors
+            // in one single response.
+            final DataElementErrorCollector errorCollector = new DataElementErrorCollector();
+            final Exam exam = studentExamProcessor.parseExam(report, schoolId, assessment, errorCollector);
+            final Student student = examineeProcessor.parseStudent(examinee, exam, schoolId, errorCollector);
 
             writer.upsert(student, exam, importId);
 

--- a/exam-processor/src/main/resources/scripts/pipelines/exam/post-process.groovy
+++ b/exam-processor/src/main/resources/scripts/pipelines/exam/post-process.groovy
@@ -1,3 +1,5 @@
+import org.opentestsystem.rdw.utils.DataElementErrorCollector
+
 //
 // System validation script for ingested TRTs.
 //
@@ -37,8 +39,10 @@ if (!assessment.gradeCode.equalsIgnoreCase(formattedGrade))
 //
 // Use existing processing services for additional validation
 //
-def exam = studentExamProcessor.parseExam(report, schoolId, assessment)
-examineeProcessor.parseStudent(report.examinee, exam.schoolYear, schoolId)
+// added to combine exam and student validation error
+def errorCollector = new DataElementErrorCollector();
+def exam = studentExamProcessor.parseExam(report, schoolId, assessment,errorCollector)
+examineeProcessor.parseStudent(report.examinee, exam, schoolId,errorCollector)
 
 // Check if any errors have been added to the error collector. If so throw a combined error.
 // Otherwise returns true (valid). (This should be the last line of any system validation script.)

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorValidationTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/ExamProcessorValidationTest.java
@@ -209,7 +209,7 @@ public class ExamProcessorValidationTest {
 
         when(schoolRepository.findIdByNaturalId(any())).thenReturn(1);
         when(assessmentRepository.findOneByNaturalId(any())).thenReturn(assessment);
-        when(studentExamProcessor.parseExam(any(), anyInt(), any())).thenReturn(exam);
+        when(studentExamProcessor.parseExam(any(), anyInt(), any(), any())).thenReturn(exam);
 
         processor.process(message);
         verifyZeroInteractions(archiveService); // No archival on error
@@ -231,7 +231,7 @@ public class ExamProcessorValidationTest {
 
         when(schoolRepository.findIdByNaturalId(any())).thenReturn(1);
         when(assessmentRepository.findOneByNaturalId(any())).thenReturn(assessment);
-        when(studentExamProcessor.parseExam(any(), anyInt(), any())).thenReturn(exam);
+        when(studentExamProcessor.parseExam(any(), anyInt(), any(), any())).thenReturn(exam);
 
         processor.process(message);
         verifyZeroInteractions(archiveService); // No archival on error
@@ -262,7 +262,7 @@ public class ExamProcessorValidationTest {
 
         when(schoolRepository.findIdByNaturalId(any())).thenReturn(1);
         when(assessmentRepository.findOneByNaturalId(any())).thenReturn(assessment);
-        when(studentExamProcessor.parseExam(any(), anyInt(), any())).thenReturn(exam);
+        when(studentExamProcessor.parseExam(any(), anyInt(), any(), any())).thenReturn(exam);
     }
 
     private byte [] loadBytesFromResourceFile(final String name) throws Exception {

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorIT.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.ingest.processor.model.Exam;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -41,15 +43,25 @@ public class DefaultExamineeProcessorIT {
     @Autowired
     private ExamineeProcessor processor;
 
+    private DataElementErrorCollector errorCollector;
+
+    private Exam exam;
+
     @BeforeClass
     public static void setTenantContext() {
         TenantContextHolder.setTenantId("CA");
     }
 
+    @Before
+    public void setUp(){
+        errorCollector = new DataElementErrorCollector();
+        exam = Exam.builder().schoolYear(2016).build();
+    }
+
     @Test
     public void itShouldParseStudent() {
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.sample.xml"));
-        final Student student = processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+        final Student student = processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         assertThat(student).isNotNull();
         assertThat(student.getAliasName()).isEqualTo("AliasName116");
     }
@@ -71,7 +83,7 @@ public class DefaultExamineeProcessorIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.basic.errors.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"isDemo\",\"value\":\"true\",\"error\":\"demo students are not supported\"}," +
@@ -100,7 +112,7 @@ public class DefaultExamineeProcessorIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.emptyDataElements.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             // this test for both mandatory and configured RequiredAndMandatoryd based on the latest TRT specification at the time this is written
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -120,7 +132,7 @@ public class DefaultExamineeProcessorIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.noElement.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             // this test for both mandatory and configured RequiredAndMandatoryd based on the latest TRT specification at the time this is written
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -140,7 +152,7 @@ public class DefaultExamineeProcessorIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.longdata.basic.error.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"FirstName\",\"value\":\"VeryLongFirstName12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890\",\"error\":\"string is too long, max length is 60\"}," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorOptionalDataElementsIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorOptionalDataElementsIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,6 +9,7 @@ import org.opentestsystem.rdw.common.model.trt.TDSReport;
 import org.opentestsystem.rdw.common.model.trt.XmlUtils;
 import org.opentestsystem.rdw.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.test.CachingTest;
+import org.opentestsystem.rdw.ingest.processor.model.Exam;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.processor.ExamProcessorApplication;
@@ -37,9 +39,19 @@ public class DefaultExamineeProcessorOptionalDataElementsIT {
     @Autowired
     private ExamineeProcessor processor;
 
+    private DataElementErrorCollector errorCollector;
+
+    private Exam exam;
+
     @BeforeClass
     public static void setTenantContext() {
         TenantContextHolder.setTenantId("CA");
+    }
+
+    @Before
+    public void setUp(){
+        errorCollector = new DataElementErrorCollector();
+        exam = Exam.builder().schoolYear(2016).build();
     }
 
     @Test(expected = ImportException.class)
@@ -47,7 +59,7 @@ public class DefaultExamineeProcessorOptionalDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.basic.errors.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"isDemo\",\"value\":\"true\",\"error\":\"demo students are not supported\"}," +
@@ -74,7 +86,7 @@ public class DefaultExamineeProcessorOptionalDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.emptyDataElements.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             // this test for both mandatory and configured required based on the latest TRT specification at the time this is written
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -90,7 +102,7 @@ public class DefaultExamineeProcessorOptionalDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.noElement.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             // this test for both mandatory and configured required based on the latest TRT specification at the time this is written
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -106,7 +118,7 @@ public class DefaultExamineeProcessorOptionalDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.longdata.basic.error.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"FirstName\",\"value\":\"VeryLongFirstName12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890\",\"error\":\"string is too long, max length is 60\"}," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorRequiredDataElementsIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultExamineeProcessorRequiredDataElementsIT.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,6 +9,7 @@ import org.opentestsystem.rdw.common.model.trt.TDSReport;
 import org.opentestsystem.rdw.common.model.trt.XmlUtils;
 import org.opentestsystem.rdw.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.test.CachingTest;
+import org.opentestsystem.rdw.ingest.processor.model.Exam;
 import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 import org.opentestsystem.rdw.ingest.processor.ExamProcessorApplication;
@@ -37,9 +39,19 @@ public class DefaultExamineeProcessorRequiredDataElementsIT {
     @Autowired
     private ExamineeProcessor processor;
 
+    private DataElementErrorCollector errorCollector;
+
+    private Exam exam;
+
     @BeforeClass
     public static void setTenantContext() {
         TenantContextHolder.setTenantId("CA");
+    }
+
+    @Before
+    public void setUp(){
+        errorCollector = new DataElementErrorCollector();
+        exam = Exam.builder().schoolYear(2016).build();
     }
 
     @Test(expected = ImportException.class)
@@ -47,7 +59,7 @@ public class DefaultExamineeProcessorRequiredDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.basic.errors.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"isDemo\",\"value\":\"true\",\"error\":\"demo students are not supported\"}," +
@@ -79,7 +91,7 @@ public class DefaultExamineeProcessorRequiredDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.emptyDataElements.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             // this test for both mandatory and configured required based on the latest TRT specification at the time this is written
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -105,7 +117,7 @@ public class DefaultExamineeProcessorRequiredDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.noElement.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             // this test for both mandatory and configured required based on the latest TRT specification at the time this is written
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -131,7 +143,7 @@ public class DefaultExamineeProcessorRequiredDataElementsIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.iab.longdata.basic.error.xml"));
         try {
-            processor.parseStudent(tdsReport.getExaminee(), 2016, -99);
+            processor.parseStudent(tdsReport.getExaminee(), exam, -99, errorCollector);
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"FirstName\",\"value\":\"VeryLongFirstName12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890\",\"error\":\"string is too long, max length is 60\"}," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultStudentExamProcessorTest.java
@@ -25,6 +25,7 @@ import org.opentestsystem.rdw.ingest.processor.service.ExamItemProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.ExamineeProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.StudentExamProcessor;
 import org.opentestsystem.rdw.multitenant.validation.ExamProcessorValidationPropertiesTenant;
+import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -47,6 +48,7 @@ public class DefaultStudentExamProcessorTest {
 
     private TDSReport tdsReport;
     private Opportunity opportunity;
+    private DataElementErrorCollector errorCollector;
 
     private StudentExamProcessor examProcessor;
     private final List<ExamItem> examItems = newArrayList(mock(ExamItem.class));
@@ -86,6 +88,8 @@ public class DefaultStudentExamProcessorTest {
         examProcessor = new DefaultStudentExamProcessor(examItemProcessor, adminConditionRepository, completenessRepository, accommodationRepository, examineeProcessor, requiredDataElementsConfiguration);
 
         tdsReport = new TDSReport();
+        errorCollector = new DataElementErrorCollector();
+
         final org.opentestsystem.rdw.common.model.trt.Test test = new org.opentestsystem.rdw.common.model.trt.Test();
         test.setAcademicYear(2017);
         test.setAssessmentVersion("asmtVersion");
@@ -151,7 +155,7 @@ public class DefaultStudentExamProcessorTest {
     @Test
     public void itShouldParseExamWithNoClaims() {
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getStudentExamAttributes()).isEqualTo(studentExamAttributes);
         assertThat(exam.getAccommodationIds()).containsExactly(33);
         assertThat(exam.getAsmtVersion()).isEqualTo("asmtVersion");
@@ -205,7 +209,7 @@ public class DefaultStudentExamProcessorTest {
         overallThetaScore.setStandardError(null);
 
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getScaleScore()).isNull();
         assertThat(exam.getScaleScoreStdErr()).isNull();
         assertThat(exam.getThetaScore()).isNull();
@@ -220,7 +224,7 @@ public class DefaultStudentExamProcessorTest {
         perfLevel.setValue(null);
 
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getScaleScore()).isNull();
         assertThat(exam.getScaleScoreStdErr()).isNull();
     }
@@ -232,7 +236,7 @@ public class DefaultStudentExamProcessorTest {
         perfLevel.setValue(null);
 
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getScaleScore()).isNull();
         assertThat(exam.getScaleScoreStdErr()).isNull();
     }
@@ -241,7 +245,7 @@ public class DefaultStudentExamProcessorTest {
     public void itShouldParseExamWithClaims() {
         final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1)
                 .scores(asmtScores()).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getExamScores().size()).isEqualTo(1);
         final ExamScore examScore = exam.getExamScores().get(0);
         assertThat(examScore.getSubjectScoreId()).isEqualTo(27);
@@ -262,7 +266,7 @@ public class DefaultStudentExamProcessorTest {
 
         final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1)
                 .scores(asmtScores()).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getExamScores().size()).isEqualTo(1);
         final ExamScore examScore = exam.getExamScores().get(0);
         assertThat(examScore.getScaleScore()).isNull();
@@ -278,7 +282,7 @@ public class DefaultStudentExamProcessorTest {
         opportunity.getScore().add(createScore("3|G-SRT|A", "StandardMetRelativeResidualScore", "0.5", null));
 
         final Assessment assessment = Assessment.builder().id(99).typeId(1).targetCodeToId(ImmutableMap.of("3|G-SRT|A", 42)).subjectId(1).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getExamTargets()).hasSize(1);
         final ExamTarget target = exam.getExamTargets().get(0);
         assertThat(target.getTargetId()).isEqualTo(42);
@@ -286,75 +290,77 @@ public class DefaultStudentExamProcessorTest {
         assertThat(target.getStandardMetRelativeResidualScore()).isEqualTo(0.5);
     }
 
-    @Test(expected = ImportException.class)
+    @Test
     public void itShouldNotIgnoreUnknownTargetScore() {
         opportunity.getScore().add(createScore("3|G-SRT|A", "StudentRelativeResidualScore", "0.2", ""));
         opportunity.getScore().add(createScore("3|G-SRT|A", "StandardMetRelativeResidualScore", "0.5", ""));
 
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(2).build();
-        examProcessor.parseExam(tdsReport, 4, assessment);
+        examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
+        assertThat(errorCollector.toJson()).isEqualTo("{\"messages\":[" +
+                "{\"elementName\":\"scoreOf [3|G-SRT|A] for label [StudentRelativeResidualScore]\",\"value\":\"0.2\",\"error\":\"unrecognizable score for the asmt\"}," +
+                "{\"elementName\":\"scoreOf [3|G-SRT|A] for label [StandardMetRelativeResidualScore]\",\"value\":\"0.5\",\"error\":\"unrecognizable score for the asmt\"}" +
+                "]}"
+        );
     }
 
     @Test
     public void itShouldDeleteAResetOpportunity() {
         opportunity.setStatus("reset");
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
 
         assertThat(exam.isDeleted()).isTrue();
     }
 
     @Test
     public void itShouldReturnErrors() {
-        try {
-            tdsReport.getTest().setAssessmentVersion("0123456789012345678901234567891");
-            tdsReport.getTest().setAcademicYear(Year.MAX_VALUE + 1);
-            tdsReport.getTest().setMode(null);
-            tdsReport.getTest().setHandScoreProject(null);
-            tdsReport.getTest().setContract(null);
 
-            opportunity.setOppId("0123456789012345678901234567890123456789012345678901234567891");
-            opportunity.setSessionId("longSessionId01234567890123456789012345678901234567890123456789012345678910123456789012345678901234567890123456789012345678901234567891");
-            opportunity.setCompleteness("");
-            opportunity.setAdministrationCondition("");
-            opportunity.setTestReason(null);
-            opportunity.setEffectiveDate(null);
-            opportunity.setStartDate(null);
-            opportunity.setDateForceCompleted(null);
-            opportunity.setStatus(null);
-            opportunity.setWindowId(null);
-            opportunity.setTaId(null);
-            opportunity.setClientName(null);
-            opportunity.setTaName(null);
-            opportunity.setAssessmentParticipantSessionPlatformUserAgent(null);
-            opportunity.setServer(null);
-            opportunity.setDatabase(null);
-            opportunity.setWindowOpportunity(null);
+        tdsReport.getTest().setAssessmentVersion("0123456789012345678901234567891");
+        tdsReport.getTest().setAcademicYear(Year.MAX_VALUE + 1);
+        tdsReport.getTest().setMode(null);
+        tdsReport.getTest().setHandScoreProject(null);
+        tdsReport.getTest().setContract(null);
 
-            for (final Score score : opportunity.getScore()) {
-                score.setStandardError("-1");
-                score.setValue("-2000.00");
-            }
+        opportunity.setOppId("0123456789012345678901234567890123456789012345678901234567891");
+        opportunity.setSessionId("longSessionId01234567890123456789012345678901234567890123456789012345678910123456789012345678901234567890123456789012345678901234567891");
+        opportunity.setCompleteness("");
+        opportunity.setAdministrationCondition("");
+        opportunity.setTestReason(null);
+        opportunity.setEffectiveDate(null);
+        opportunity.setStartDate(null);
+        opportunity.setDateForceCompleted(null);
+        opportunity.setStatus(null);
+        opportunity.setWindowId(null);
+        opportunity.setTaId(null);
+        opportunity.setClientName(null);
+        opportunity.setTaName(null);
+        opportunity.setAssessmentParticipantSessionPlatformUserAgent(null);
+        opportunity.setServer(null);
+        opportunity.setDatabase(null);
+        opportunity.setWindowOpportunity(null);
 
-            final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1).scores(asmtScores()).build();
-            examProcessor.parseExam(tdsReport, 4, assessment);
-            fail("It should have thrown an exception");
-        } catch (final ImportException e) {
-            assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
-                    "{\"elementName\":\"Overall ScaleScore\",\"value\":\"-2000.00\",\"error\":\"invalid value, must be 0.0 - 3000.0\"}," +
-                    "{\"elementName\":\"Overall ScaleScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
-                    "{\"elementName\":\"Overall ThetaScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
-                    "{\"elementName\":\"Overall PerformanceLevel\",\"value\":\"-2000.00\",\"error\":\"For input string: \\\"-2000.00\\\"\"}," +
-                    "{\"elementName\":\"Claim1 ScaleScore\",\"value\":\"-2000.00\",\"error\":\"invalid value, must be 0.0 - 3000.0\"}," +
-                    "{\"elementName\":\"Claim1 ScaleScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
-                    "{\"elementName\":\"Claim1 ThetaScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
-                    "{\"elementName\":\"Claim1 PerformanceLevel\",\"value\":\"-2000.00\",\"error\":\"For input string: \\\"-2000.00\\\"\"}," +
-                    "{\"elementName\":\"Test AcademicYear\",\"value\":\"1000000000\",\"error\":\"invalid year\"}," +
-                    "{\"elementName\":\"Test AssessmentVersion\",\"value\":\"0123456789012345678901234567891\",\"error\":\"string is too long, max length is 30\"}," +
-                    "{\"elementName\":\"OppId\",\"value\":\"0123456789012345678901234567890123456789012345678901234567891\",\"error\":\"string is too long, max length is 60\"}," +
-                    "{\"elementName\":\"SessionId\",\"value\":\"longSessionId01234567890123456789012345678901234567890123456789012345678910123456789012345678901234567890123456789012345678901234567891\",\"error\":\"string is too long, max length is 128\"}" +
-                    "]}");
+        for (final Score score : opportunity.getScore()) {
+            score.setStandardError("-1");
+            score.setValue("-2000.00");
         }
+
+        final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1).scores(asmtScores()).build();
+        examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
+        assertThat(errorCollector.toJson()).isEqualTo("{\"messages\":[" +
+                "{\"elementName\":\"Overall ScaleScore\",\"value\":\"-2000.00\",\"error\":\"invalid value, must be 0.0 - 3000.0\"}," +
+                "{\"elementName\":\"Overall ScaleScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
+                "{\"elementName\":\"Overall ThetaScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
+                "{\"elementName\":\"Overall PerformanceLevel\",\"value\":\"-2000.00\",\"error\":\"For input string: \\\"-2000.00\\\"\"}," +
+                "{\"elementName\":\"Claim1 ScaleScore\",\"value\":\"-2000.00\",\"error\":\"invalid value, must be 0.0 - 3000.0\"}," +
+                "{\"elementName\":\"Claim1 ScaleScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
+                "{\"elementName\":\"Claim1 ThetaScore StandardError\",\"value\":\"-1\",\"error\":\"invalid value, must be a positive number\"}," +
+                "{\"elementName\":\"Claim1 PerformanceLevel\",\"value\":\"-2000.00\",\"error\":\"For input string: \\\"-2000.00\\\"\"}," +
+                "{\"elementName\":\"Test AcademicYear\",\"value\":\"1000000000\",\"error\":\"invalid year\"}," +
+                "{\"elementName\":\"Test AssessmentVersion\",\"value\":\"0123456789012345678901234567891\",\"error\":\"string is too long, max length is 30\"}," +
+                "{\"elementName\":\"OppId\",\"value\":\"0123456789012345678901234567890123456789012345678901234567891\",\"error\":\"string is too long, max length is 60\"}," +
+                "{\"elementName\":\"SessionId\",\"value\":\"longSessionId01234567890123456789012345678901234567890123456789012345678910123456789012345678901234567890123456789012345678901234567891\",\"error\":\"string is too long, max length is 128\"}" +
+                "]}");
     }
 
     @Test
@@ -367,16 +373,13 @@ public class DefaultStudentExamProcessorTest {
         opportunity = new Opportunity();
         tdsReport.setOpportunity(opportunity);
 
-        try {
-            final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1).scores(asmtScores()).build();
-            examProcessor.parseExam(tdsReport, 4, assessment);
-            fail("It should have thrown an exception");
-        } catch (final ImportException e) {
-            assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
-                    "{\"elementName\":\"OppId\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"DateCompleted\",\"error\":\"invalid value\"}" +
-                    "]}");
-        }
+        final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1).scores(asmtScores()).build();
+        examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
+
+        assertThat(errorCollector.toJson()).isEqualTo("{\"messages\":[" +
+                "{\"elementName\":\"OppId\",\"error\":\"value may not be blank\"}," +
+                "{\"elementName\":\"DateCompleted\",\"error\":\"invalid value\"}" +
+                "]}");
     }
 
     @Test
@@ -406,20 +409,17 @@ public class DefaultStudentExamProcessorTest {
         opportunity = new Opportunity();
         tdsReport.setOpportunity(opportunity);
 
-        try {
-            final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1).scores(asmtScores()).build();
-            examProcessor.parseExam(tdsReport, 4, assessment);
-            fail("It should have thrown an exception");
-        } catch (final ImportException e) {
-            assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
-                    "{\"elementName\":\"ExamItems\",\"value\":\"none\",\"error\":\"must provide at least one value for ExamItems\"}," +
-                    "{\"elementName\":\"OppId\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"SessionId\",\"error\":\"value may not be blank\"}," +
-                    "{\"elementName\":\"Completeness\",\"error\":\"invalid value\"}," +
-                    "{\"elementName\":\"AdministrationCondition\",\"error\":\"invalid value\"}," +
-                    "{\"elementName\":\"DateCompleted\",\"error\":\"invalid value\"}" +
-                    "]}");
-        }
+
+        final Assessment assessment = Assessment.builder().id(99).typeId(2).subjectId(1).scores(asmtScores()).build();
+        examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
+        assertThat(errorCollector.toJson()).isEqualTo("{\"messages\":[" +
+                "{\"elementName\":\"ExamItems\",\"value\":\"none\",\"error\":\"must provide at least one value for ExamItems\"}," +
+                "{\"elementName\":\"OppId\",\"error\":\"value may not be blank\"}," +
+                "{\"elementName\":\"SessionId\",\"error\":\"value may not be blank\"}," +
+                "{\"elementName\":\"Completeness\",\"error\":\"invalid value\"}," +
+                "{\"elementName\":\"AdministrationCondition\",\"error\":\"invalid value\"}," +
+                "{\"elementName\":\"DateCompleted\",\"error\":\"invalid value\"}" +
+                "]}");
     }
 
     @Test
@@ -427,7 +427,7 @@ public class DefaultStudentExamProcessorTest {
         setUpWithNoOptionalDataElements();
         final Assessment assessment = Assessment.builder().id(99).typeId(3).subjectId(1).build();
         tdsReport.getOpportunity().setAdministrationCondition("");
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getAdministrationConditionId()).isEqualTo(1);
     }
 
@@ -436,7 +436,7 @@ public class DefaultStudentExamProcessorTest {
         setUpWithNoOptionalDataElements();
         final Assessment assessment = Assessment.builder().id(99).typeId(1).subjectId(1).build();
         tdsReport.getOpportunity().setAdministrationCondition("");
-        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment);
+        final Exam exam = examProcessor.parseExam(tdsReport, 4, assessment, errorCollector);
         assertThat(exam.getAdministrationConditionId()).isEqualTo(2);
     }
 

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
@@ -168,7 +168,6 @@ public class DefaultTDSReportProcessorIT {
             processor.process(tdsReport, importId);
             fail("it should fail");
         } catch (final ImportException ex) {
-            System.out.println(ex.getMessage());
             assertThat(ex.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"IDEAIndicator\",\"error\":\"invalid value [null]\"}," +
                     "{\"elementName\":\"EconomicDisadvantageStatus\",\"error\":\"invalid value [null]\"}," +

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.trt.TDSReport;
@@ -8,6 +9,7 @@ import org.opentestsystem.rdw.common.model.ImportException;
 import org.opentestsystem.rdw.ingest.common.test.CachingTest;
 import org.opentestsystem.rdw.ingest.processor.ExamProcessorApplication;
 import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
+import org.opentestsystem.rdw.multitenant.TenantContextHolder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -166,11 +168,15 @@ public class DefaultTDSReportProcessorIT {
             processor.process(tdsReport, importId);
             fail("it should fail");
         } catch (final ImportException ex) {
+            System.out.println(ex.getMessage());
             assertThat(ex.getMessage()).isEqualTo("{\"messages\":[" +
                     "{\"elementName\":\"IDEAIndicator\",\"error\":\"invalid value [null]\"}," +
-                    "{\"elementName\":\"EconomicDisadvantageStatus\",\"error\":\"invalid value [null]\"}" +
-                    //note that it does not error on Completeness and Administration conditions since they have hardcoded defaults
-                    "]}");
+                    "{\"elementName\":\"EconomicDisadvantageStatus\",\"error\":\"invalid value [null]\"}," +
+                    "{\"elementName\":\"FirstName\",\"error\":\"value may not be blank\"}," +
+                    "{\"elementName\":\"LastOrSurname\",\"error\":\"value may not be blank\"}," +
+                    "{\"elementName\":\"Sex\",\"error\":\"value may not be blank\"}]}");
+            //note that it does not error on Completeness and Administration conditions since they have hardcoded defaults
+
         }
         assertThat(countRowsInTable(jdbcTemplate, "student")).isEqualTo(beforeStudentCount);
         assertThat(countRowsInTable(jdbcTemplate, "student_ethnicity")).isEqualTo(beforeStudentEthnicityCount);

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/DefaultTDSReportProcessorTest.java
@@ -4,6 +4,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.text.ParseException;
+
+import org.mockito.ArgumentCaptor;
 import org.opentestsystem.rdw.common.model.trt.Examinee;
 import org.opentestsystem.rdw.common.model.trt.Opportunity;
 import org.opentestsystem.rdw.common.model.trt.TDSReport;
@@ -16,11 +18,14 @@ import org.opentestsystem.rdw.ingest.processor.service.ExamineeProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.StudentExamProcessor;
 import org.opentestsystem.rdw.ingest.processor.service.StudentExamWriter;
 import org.opentestsystem.rdw.ingest.processor.service.TDSReportProcessor;
+import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+
 
 public class DefaultTDSReportProcessorTest {
 
@@ -67,10 +72,11 @@ public class DefaultTDSReportProcessorTest {
         final Assessment assessment = mock(Assessment.class);
         when(assessment.getSubjectId()).thenReturn(1);
         when(assessmentService.findOneForNaturalId(test.getName())).thenReturn(assessment);
-        when(studentExamProcessor.parseExam(tdsReport, 99, assessment)).thenReturn(exam);
 
+        ArgumentCaptor<DataElementErrorCollector> argumentCaptor= ArgumentCaptor.forClass(DataElementErrorCollector.class);
+        when(studentExamProcessor.parseExam(eq(tdsReport), eq(99), eq(assessment), argumentCaptor.capture())).thenReturn(exam);
         final Student student = mock(Student.class);
-        when(examineeProcessor.parseStudent(examinee, 2016, 99)).thenReturn(student);
+        when(examineeProcessor.parseStudent(eq(examinee), eq(exam), eq(99),argumentCaptor.capture())).thenReturn(student);
 
         processor.process(tdsReport, importId);
         verify(writer, times((1))).upsert(student, exam, importId);

--- a/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/StudentExamProcessorIT.java
+++ b/exam-processor/src/test/java/org/opentestsystem/rdw/ingest/processor/service/impl/StudentExamProcessorIT.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.ingest.processor.service.impl;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.common.model.trt.TDSReport;
@@ -9,6 +10,7 @@ import org.opentestsystem.rdw.ingest.common.test.CachingTest;
 import org.opentestsystem.rdw.ingest.processor.ExamProcessorApplication;
 import org.opentestsystem.rdw.ingest.processor.repository.AssessmentRepository;
 import org.opentestsystem.rdw.ingest.processor.service.StudentExamProcessor;
+import org.opentestsystem.rdw.utils.DataElementErrorCollector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -37,6 +39,13 @@ public class StudentExamProcessorIT {
     @Autowired
     private AssessmentRepository assessmentRepository;
 
+    private DataElementErrorCollector errorCollector;
+
+    @Before
+    public void setUp() {
+        errorCollector = new DataElementErrorCollector();
+    }
+
     @Test
     @Sql(statements = {insertImportSql,
             "INSERT INTO asmt (id, natural_id, grade_id, type_id, subject_id, school_year, name, label, version, import_id, update_import_id) VALUES " +
@@ -50,7 +59,7 @@ public class StudentExamProcessorIT {
 
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.ica.exam.errors.xml"));
         try {
-            processor.parseExam(tdsReport, 1, assessmentRepository.findOneByNaturalId("exam natural id"));
+            processor.parseExam(tdsReport, 1, assessmentRepository.findOneByNaturalId("exam natural id"), errorCollector);
 
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +
@@ -84,7 +93,7 @@ public class StudentExamProcessorIT {
         //note: it reused the ica sample for the test, but since the exam is inserted as IAB, it report errors that are IAB specific
         final TDSReport tdsReport = XmlUtils.tdsReportFromXml(this.getClass().getResourceAsStream("/TDSReport.ica.exam.errors.xml"));
         try {
-            processor.parseExam(tdsReport, 1, assessmentRepository.findOneByNaturalId("exam natural id"));
+            processor.parseExam(tdsReport, 1, assessmentRepository.findOneByNaturalId("exam natural id"), errorCollector);
 
         } catch (final ImportException e) {
             assertThat(e.getMessage()).isEqualTo("{\"messages\":[" +


### PR DESCRIPTION
this fix is to combine the validation error response for exam and student trt attribute. what's happening now is that we do the exam validation first, and ignore the student attribute validation if there is an exam validation failure. smarter balanced wants to combine the validation so that the user will know the exact attribute that failed the validation instead of the partial error response.